### PR TITLE
Add vmo service account name to it's deployments

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -28,6 +28,7 @@ const VMOKind = "VerrazzanoMonitoringInstance"
 const VMOPlural = "verrazzanomonitoringinstances"
 const VMOFullname = VMOPlural + "." + VMOGroup
 
+const ServiceAccountName = "verrazzano-monitoring-operator"
 const RoleBindingForVMOInstance = "verrazzano-monitoring-operator"
 const ClusterRoleForVMOInstances = "vmi-cluster-role"
 

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -245,6 +245,7 @@ func createDeploymentElementByPvcIndex(vmo *vmcontrollerv1.VerrazzanoMonitoringI
 					Containers: []corev1.Container{
 						resources.CreateContainerElement(vmoStorage, vmoResources, componentDetails),
 					},
+					ServiceAccountName:            constants.ServiceAccountName,
 					TerminationGracePeriodSeconds: resources.New64Val(1),
 				},
 			},


### PR DESCRIPTION
Add the service account verrazzano-monitoring-operator to each deployment generated by this operator.  This is required to inherit the imagePullSecrets that may be associated with the service account.