### PR TITLE
Add service account name to statefulsets

### DIFF
--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -256,6 +256,7 @@ func createStatefulSetElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, 
 					Containers: []corev1.Container{
 						resources.CreateContainerElement(nil, vmoResources, componentDetails),
 					},
+					ServiceAccountName:            constants.ServiceAccountName,
 					TerminationGracePeriodSeconds: resources.New64Val(1),
 				},
 			},


### PR DESCRIPTION
Add service account name to statefulsets created by the operator.  This is required for supporting images that require an imagePullSecret.