### PR TITLE
Elasticsearch Master should use PVs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,7 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*OperatorConfig, error
 	}
 	var config OperatorConfig
 	err := yaml.Unmarshal([]byte(configString), &config)
-	glog.V(6).Infof("Unmarshalled configmap is:\n %s", configMap.String())
+	// glog.V(6).Infof("Unmarshalled configmap is:\n %s", configMap.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshall ConfigMap %s: %v", configMap.String(), err)
 	}

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -192,11 +192,12 @@ func CreateZoneAntiAffinityElement(vmoName string, component string) *corev1.Aff
 	}
 }
 
-// GetElasticsearchInitContainerChown return an Elasticsearch Init container which changes owernsip of
-// the ES directory permissions needed to to access PV volume data.  Also set the max map count.
-func GetElasticsearchInitContainerChown() *corev1.Container {
+// GetElasticsearchMasterInitContainer return an Elasticsearch Init container for the mater.  This changes owernship of
+// the ES directory permissions needed to access PV volume data.  Also set the max map count.
+func GetElasticsearchMasterInitContainer() *corev1.Container {
 	elasticsearchInitContainer := CreateContainerElement(nil, nil, config.ElasticsearchInit)
-	elasticsearchInitContainer.Command = []string{"sh", "-c", "chown -R 1000:1000 /usr/share/elasticsearch/data"}
+	elasticsearchInitContainer.Command =
+		[]string{"sh", "-c", "chown -R 1000:1000 /usr/share/elasticsearch/data; sysctl -w vm.max_map_count=262144"}
 	elasticsearchInitContainer.Ports = nil
 	return &elasticsearchInitContainer
 }

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -192,6 +192,15 @@ func CreateZoneAntiAffinityElement(vmoName string, component string) *corev1.Aff
 	}
 }
 
+// GetElasticsearchInitContainerChown return an Elasticsearch Init container which changes owernsip of
+// the ES directory permissions needed to to access PV volume data.  Also set the max map count.
+func GetElasticsearchInitContainerChown() *corev1.Container {
+	elasticsearchInitContainer := CreateContainerElement(nil, nil, config.ElasticsearchInit)
+	elasticsearchInitContainer.Command = []string{"sh", "-c", "chown -R 1000:1000 /usr/share/elasticsearch/data"}
+	elasticsearchInitContainer.Ports = nil
+	return &elasticsearchInitContainer
+}
+
 // GetElasticsearchInitContainer returns an Elasticsearch Init container object
 func GetElasticsearchInitContainer() *corev1.Container {
 	elasticsearchInitContainer := CreateContainerElement(nil, nil, config.ElasticsearchInit)

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -145,7 +145,7 @@ fi`,
 
 	// Add init container
 	statefulSet.Spec.Template.Spec.InitContainers = append(statefulSet.Spec.Template.Spec.InitContainers,
-		*resources.GetElasticsearchInitContainerChown())
+		*resources.GetElasticsearchMasterInitContainer())
 
 	// Add the pv volume mount to the init container
 	statefulSet.Spec.Template.Spec.InitContainers[0].VolumeMounts =

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -5,16 +5,16 @@ package statefulsets
 
 import (
 	"fmt"
-	"strings"
-
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"strings"
 )
 
 // New creates StatefulSet objects for a VMO resource
@@ -74,15 +74,11 @@ func createElasticsearchMasterStatefulSet(vmo *vmcontrollerv1.VerrazzanoMonitori
 		corev1.EnvVar{Name: "cluster.initial_master_nodes", Value: strings.Join(initialMasterNodes, ",")},
 	)
 
-	// Add init containers
-	statefulSet.Spec.Template.Spec.InitContainers = append(statefulSet.Spec.Template.Spec.InitContainers, *resources.GetElasticsearchInitContainer())
-
 	basicAuthParams := ""
 	readinessProbeCondition = `
         echo 'Cluster is not yet ready'
         exit 1
 `
-
 	// Customized Readiness and Liveness probes
 	statefulSet.Spec.Template.Spec.Containers[0].ReadinessProbe =
 		&corev1.Probe{
@@ -136,6 +132,43 @@ fi`,
 			TimeoutSeconds:      5,
 			FailureThreshold:    5,
 		}
+
+	const esMasterVolName = "elasticsearch-master"
+	const esMasterData = "/usr/share/elasticsearch/data"
+
+	// Add the pv volume mount to the main container
+	statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts =
+		append(statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      esMasterVolName,
+			MountPath: esMasterData,
+		})
+
+	// Add init container
+	statefulSet.Spec.Template.Spec.InitContainers = append(statefulSet.Spec.Template.Spec.InitContainers,
+		*resources.GetElasticsearchInitContainerChown())
+
+	// Add the pv volume mount to the init container
+	statefulSet.Spec.Template.Spec.InitContainers[0].VolumeMounts =
+		[]corev1.VolumeMount{{
+			Name:      esMasterVolName,
+			MountPath: esMasterData,
+		}}
+
+	// Add the pvc templates, this will result in a PV + PVC being created automatically for each
+	// pod in the stateful set.
+	statefulSet.Spec.VolumeClaimTemplates =
+		[]corev1.PersistentVolumeClaim{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      esMasterVolName,
+				Namespace: vmo.Namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(vmo.Spec.Elasticsearch.Storage.Size)},
+				},
+			},
+		}}
 
 	return statefulSet
 }

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -33,6 +33,9 @@ func TestVMOWithReplicas(t *testing.T) {
 				MasterNode: vmcontrollerv1.ElasticsearchNode{
 					Replicas: 5,
 				},
+				Storage: vmcontrollerv1.Storage{
+					Size: "50Gi",
+				},
 			},
 		},
 	}

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -484,7 +484,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	specDiffs := diff.CompareIgnoreTargetEmpties(originalVMO, vmo)
 	if specDiffs != "" {
 		glog.V(6).Infof("Acquired lock in namespace: %s", vmo.Namespace)
-		glog.V(4).Infof("VMO %s : Spec differences %s", vmo.Name, specDiffs)
+		glog.V(6).Infof("VMO %s : Spec differences %s", vmo.Name, specDiffs)
 		glog.V(4).Infof("Updating VMO")
 		_, err = c.vmoclientset.VerrazzanoV1().VerrazzanoMonitoringInstances(vmo.Namespace).Update(context.TODO(), vmo, metav1.UpdateOptions{})
 		if err != nil {

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -63,7 +63,7 @@ func CreateDeployments(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMon
 			} else {
 				specDiffs := diff.CompareIgnoreTargetEmpties(existingDeployment, curDeployment)
 				if specDiffs != "" {
-					glog.V(4).Infof("Deployment %s : Spec differences %s", curDeployment.Name, specDiffs)
+					glog.V(6).Infof("Deployment %s : Spec differences %s", curDeployment.Name, specDiffs)
 					_, err = controller.kubeclientset.AppsV1().Deployments(vmo.Namespace).Update(context.TODO(), curDeployment, metav1.UpdateOptions{})
 				}
 			}
@@ -117,7 +117,7 @@ func updateNextDeployment(controller *Controller, vmo *vmcontrollerv1.Verrazzano
 		// Deployment spec differences, so call Update() and return
 		specDiffs := diff.CompareIgnoreTargetEmpties(existingDeployment, curDeployment)
 		if specDiffs != "" {
-			glog.V(4).Infof("Deployment %s : Spec differences %s", curDeployment.Name, specDiffs)
+			glog.V(6).Infof("Deployment %s : Spec differences %s", curDeployment.Name, specDiffs)
 			_, err = controller.kubeclientset.AppsV1().Deployments(vmo.Namespace).Update(context.TODO(), curDeployment, metav1.UpdateOptions{})
 			if err != nil {
 				return false, err

--- a/pkg/vmo/statefulset.go
+++ b/pkg/vmo/statefulset.go
@@ -6,12 +6,15 @@ package vmo
 import (
 	"context"
 	"errors"
-
+	"fmt"
 	"github.com/golang/glog"
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/statefulsets"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/diff"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -19,6 +22,7 @@ import (
 
 // CreateStatefulSets creates/updates/deletes VMO statefulset k8s resources
 func CreateStatefulSets(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) error {
+	const finalizer = "verrazzano.io/sts"
 	statefulSetList, err := statefulsets.New(vmo)
 	if err != nil {
 		glog.Errorf("Failed to create StatefulSet specs for vmo: %s", err)
@@ -42,11 +46,16 @@ func CreateStatefulSets(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMo
 		if existingStatefulSet != nil {
 			specDiffs := diff.CompareIgnoreTargetEmpties(existingStatefulSet, curStatefulSet)
 			if specDiffs != "" {
-				glog.V(4).Infof("Statefulset %s : Spec differences %s", curStatefulSet.Name, specDiffs)
-				_, err = controller.kubeclientset.AppsV1().StatefulSets(vmo.Namespace).Update(context.TODO(), curStatefulSet, metav1.UpdateOptions{})
+				glog.V(6).Infof("Statefulset %s : Spec differences %s", curStatefulSet.Name, specDiffs)
+				_, _ = controller.kubeclientset.AppsV1().StatefulSets(vmo.Namespace).Update(context.TODO(), curStatefulSet, metav1.UpdateOptions{})
 			}
 		} else {
-			_, err = controller.kubeclientset.AppsV1().StatefulSets(vmo.Namespace).Create(context.TODO(), curStatefulSet, metav1.CreateOptions{})
+			// Create StatefulSet. Also add finalizer so that we can detect when this StatefulSet is being deleted and cleanup PVCs
+			// curStatefulSet.ObjectMeta.Finalizers = append(curStatefulSet.ObjectMeta.Finalizers, finalizer)
+			_, err := controller.kubeclientset.AppsV1().StatefulSets(vmo.Namespace).Create(context.TODO(), curStatefulSet, metav1.CreateOptions{})
+			if err != nil {
+				return err
+			}
 		}
 		if err != nil {
 			return err
@@ -55,13 +64,20 @@ func CreateStatefulSets(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMo
 	}
 
 	// Delete StatefulSets that shouldn't exist
-	glog.V(4).Infof("Deleting unwanted Statefulsets for vmo '%s' in namespace '%s'", vmo.Name, vmo.Namespace)
 	selector := labels.SelectorFromSet(map[string]string{constants.VMOLabel: vmo.Name})
 	existingStatefulSetsList, err := controller.statefulSetLister.StatefulSets(vmo.Namespace).List(selector)
 	if err != nil {
 		return err
 	}
 	for _, statefulSet := range existingStatefulSetsList {
+		latestSts, _ := controller.kubeclientset.AppsV1().StatefulSets(vmo.Namespace).Get(context.TODO(), statefulSet.Name, metav1.GetOptions{})
+		if latestSts == nil {
+			break
+		}
+		err = updateOwnerForPVCs(controller, latestSts, vmo.Name, vmo.Namespace)
+		if err != nil {
+			return err
+		}
 		if !contains(statefulSetNames, statefulSet.Name) {
 			glog.V(6).Infof("Deleting StatefulSet %s", statefulSet.Name)
 			err := controller.kubeclientset.AppsV1().StatefulSets(vmo.Namespace).Delete(context.TODO(), statefulSet.Name, metav1.DeleteOptions{})
@@ -73,5 +89,47 @@ func CreateStatefulSets(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMo
 	}
 
 	glog.V(4).Infof("Successfully applied StatefulSets for vmo '%s'", vmo.Name)
+	return nil
+}
+
+// Update the each PVC owner reference to be the StatefulSet (STS).
+// PVCs are created automatically by Kubernetes when the STS is created,
+// because the STS has a volumeClaimTemplate.  However, the PVCs are not deleted
+// when the STS is deleted. Set the PVC owner reference to be the STS
+// so that when the STS is deleted, the PVC will automatically get deleted.
+// Because PVC is dynamic, when it is deleted, the bound PV will also get deleted.
+func updateOwnerForPVCs(controller *Controller, statefulSet *appsv1.StatefulSet, vmoName string, vmoNamespace string) error {
+
+	// Get for PVCs for this STS using the specID label. Each PVC metadata.label
+	// has the same specID label as the STS template.metadata.label,
+	// For example: " app: hello-world-binding-es-master"
+	idLabel := resources.GetSpecID(vmoName, config.ElasticsearchMaster.Name)
+	selector := labels.SelectorFromSet(idLabel)
+	existingPvcList, err := controller.pvcLister.PersistentVolumeClaims(vmoNamespace).List(selector)
+	if err != nil {
+		return err
+	}
+	for _, pvc := range existingPvcList {
+		if len(pvc.OwnerReferences) != 0 {
+			continue
+		}
+		pvc.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "apps/v1",
+			Kind:       "StatefulSet",
+			Name:       statefulSet.Name,
+			UID:        statefulSet.UID,
+		}}
+		glog.V(4).Infof("Setting owner reference for PVC %s", pvc.Name)
+		_, err := controller.kubeclientset.CoreV1().PersistentVolumeClaims(vmoNamespace).Update(context.TODO(), pvc, metav1.UpdateOptions{})
+		if err != nil {
+			glog.Errorf("Failed to update the owner reference in  PVC %s, for the reason (%v)", pvc.Name, err)
+			return err
+		}
+	}
+	replicas := int(*statefulSet.Spec.Replicas)
+	numPVCs := len(existingPvcList)
+	if numPVCs != replicas {
+		return errors.New(fmt.Sprintf("PVC owner reference set in %v of %v PVCs", numPVCs, replicas))
+	}
 	return nil
 }


### PR DESCRIPTION
When provisioning an Elasticsearch master, I want to use the minimum size (50g) persistent storage, so that the cluster UUID is saved on persistent storage and doesn't change when the ES pod restarts.  This will prevent the ES data nodes from getting out of sync with the masters (because the UID doesn't change) if all the masters go down at the same time.

Provisioning: 
The ES master uses a Kubernetes stateful set (STS) which provides the ability to automatically create PVC and PV per pod via a volumeClaimTemplate (VTC).   Modify the verrazzano-monitoring-operator to specify the VCT.  Also, change ownership of the ES data directory on the PV so that the ES container can access it.

Deletion:
PVCs are created automatically by Kubernetes when the STS is created because the STS has a volumeClaimTemplate. However, the PVCs are not deleted when the STS is deleted.   In the VMO operator, update the each PVC owner reference to be the StatefulSet (STS) so that when the STS is deleted, the PVC will automatically get deleted. Because PVC is dynamic, when it is deleted, the bound PV will also get deleted. This cannot be done automatically using the STS VolumeClaimTemplate.