### PR TITLE
VZ-1640 - Single-node ES Topology for dekstop/laptop configuration

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -98,6 +98,12 @@ const ESHttpPort = 9200
 // ESTransportPort default Elasticsearch transport port
 const ESTransportPort = 9300
 
+// DefaultDevProfileESMemArgs default Elasticsearch dev mode memory settings
+const DefaultDevProfileESMemArgs = "-Xms512m -Xmx512m"
+
+// DefaultDevProfileESReplicas default Elasticsearch dev mode replicas
+const DefaultDevProfileESReplicas = 1
+
 // DefaultESIngestMemArgs default Elasticsearch Ingest memory settings
 const DefaultESIngestMemArgs = "-Xms2g -Xmx2g"
 

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -329,6 +329,4 @@ func IsDevProfile(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) bool {
 	_, present := os.LookupEnv("SINGLE_SYSTEM_VMI")
 	glog.V(4).Infof("Env var SINGLE_SYSTEM_VMI present? %v", present)
 	return present
-	//profile := vmo.Spec.Profile
-	//return len(profile) > 0 && strings.ToLower(profile) == DevelopmentProfile
 }

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -6,31 +6,45 @@ package services
 import (
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // Creates Elasticsearch Client service element
 func createElasticsearchIngestServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *corev1.Service {
-	return createServiceElement(vmo, config.ElasticsearchIngest)
+	var elasticsearchIngestService *corev1.Service = createServiceElement(vmo, config.ElasticsearchIngest)
+	if resources.IsDevProfile(vmo) {
+		elasticsearchIngestService.Spec.Selector = resources.GetSpecID(vmo.Name, config.ElasticsearchMaster.Name)
+		// In dev mode, only a single node/pod all ingest/data goes to the 9200 port on the back end node
+		elasticsearchIngestService.Spec.Ports = []corev1.ServicePort{resources.GetServicePort(config.ElasticsearchData)}
+	}
+	return elasticsearchIngestService
 }
 
 // Creates Elasticsearch Master service element
 func createElasticsearchMasterServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *corev1.Service {
 	elasticSearchMasterService := createServiceElement(vmo, config.ElasticsearchMaster)
-
-	// Master service is headless
-	elasticSearchMasterService.Spec.Type = corev1.ServiceTypeClusterIP
-	elasticSearchMasterService.Spec.ClusterIP = corev1.ClusterIPNone
+	if !resources.IsDevProfile(vmo) {
+		// Master service is headless
+		elasticSearchMasterService.Spec.Type = corev1.ServiceTypeClusterIP
+		elasticSearchMasterService.Spec.ClusterIP = corev1.ClusterIPNone
+	}
 	return elasticSearchMasterService
 }
 
 // Creates Elasticsearch Data service element
 func createElasticsearchDataServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *corev1.Service {
-	elasticsearchDataService := createServiceElement(vmo, config.ElasticsearchData)
-
+	var elasticsearchDataService *corev1.Service = createServiceElement(vmo, config.ElasticsearchData)
 	// Data k8s service only needs to expose NodeExporter port
+	// - in dev mode, preserve this as the front end ES data port, at least for now
 	elasticsearchDataService.Spec.Ports = []corev1.ServicePort{resources.GetServicePort(config.NodeExporter)}
+	if resources.IsDevProfile(vmo) {
+		// In dev mode, only a single node/pod all ingest/data goes to the 9200 port on the back end node
+		elasticsearchDataService.Spec.Selector = resources.GetSpecID(vmo.Name, config.ElasticsearchMaster.Name)
+		elasticsearchDataService.Spec.Ports[0].TargetPort = intstr.FromInt(constants.ESHttpPort)
+	}
 	return elasticsearchDataService
 }
 


### PR DESCRIPTION
Enable a single-node ES configuration for a small machine/workstation configuration

- Single collapsed ES node as master/data/ingest, with ephemeral storage and minimal RAM
- Maintain same services facade for in-cluster clients at least for now
- Triggered by an env-var, SINGLE_SYSTEM_VMI (at least for now)
- Remove es_wait init-container from Kibana pod for now

