### PR TITLE
VZ-1739.  Remove explicit dev profile hooks from verrazzano-monitoring-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ DIST_DIR:=dist
 BIN_DIR:=${DIST_DIR}/bin
 BIN_NAME:=${OPERATOR_NAME}
 K8S_EXTERNAL_IP:=localhost
-K8S_NAMESPACE:=default
+K8S_NAMESPACE:=verrazzano-system
 WATCH_NAMESPACE:=
 WATCH_VMI:=
 EXTRA_PARAMS=
@@ -69,7 +69,7 @@ go-install:
 
 .PHONY: go-run
 go-run: go-install
-	GO111MODULE=on $(GO) run cmd/verrazzano-monitoring-ctrl/main.go --kubeconfig=${KUBECONFIG} --v=4 --namespace=${K8S_NAMESPACE} --watchNamespace=${WATCH_NAMESPACE} --watchVmi=${WATCH_VMI} ${EXTRA_PARAMS}
+	GO111MODULE=on $(GO) run cmd/verrazzano-monitoring-ctrl/main.go --kubeconfig=${KUBECONFIG} --zap-log-level=debug --namespace=${K8S_NAMESPACE} --watchNamespace=${WATCH_NAMESPACE} --watchVmi=${WATCH_VMI} ${EXTRA_PARAMS}
 
 .PHONY: go-fmt
 go-fmt:

--- a/Makefile
+++ b/Makefile
@@ -183,8 +183,8 @@ unit-test: go-install
 #
 # Run all checks, convenient as a sanity-check before committing/pushing
 #
-.PHONY: check-all
-check-all: go-fmt go-lint go-ineffassign go-vet unit-test 
+.PHONY: check
+check: go-fmt go-lint go-ineffassign go-vet unit-test
 
 .PHONY: coverage
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,12 @@ push-tag-eswait:
 unit-test: go-install
 	GO111MODULE=on $(GO) test -v ./pkg/... ./cmd/...
 
+#
+# Run all checks, convenient as a sanity-check before committing/pushing
+#
+.PHONY: check-all
+check-all: go-fmt go-lint go-ineffassign go-vet unit-test 
+
 .PHONY: coverage
 coverage:
 	./build/scripts/coverage.sh html

--- a/eswait.go
+++ b/eswait.go
@@ -72,8 +72,10 @@ func (node ESNode) isSufficient(version string) bool {
 }
 
 func (node ESNode) isDataRole() bool {
-	// This should likely be a "contains" check as a node can be multiple roles
-	return strings.EqualFold(node.Role, "d")
+	// Check the role string for the data-node flag
+	// - role string consists of 1-3 chars, "d" (data), "i" (ingest), "m" (master), so look that it contains "d"
+	// - a node can be any combination of roles (e.g., single-node cluster would be "dim")
+	return strings.Contains(node.Role, "d")
 }
 
 // Send GET request to given URL, expected JSON response

--- a/eswait.go
+++ b/eswait.go
@@ -72,6 +72,7 @@ func (node ESNode) isSufficient(version string) bool {
 }
 
 func (node ESNode) isDataRole() bool {
+	// This should likely be a "contains" check as a node can be multiple roles
 	return strings.EqualFold(node.Role, "d")
 }
 

--- a/eswait_test.go
+++ b/eswait_test.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -49,7 +48,9 @@ func TestIsSufficientNotEnoughDataNodes(t *testing.T) {
 func TestIsSufficientDataNodesSingleNodeCluster(t *testing.T) {
 	clusterHealth := ClusterHealth{"yellow"}
 	nodes := []ESNode{{Version: "7.5.0", Role: "dim"}, {Version: "7.5.0", Role: "m"}, {Version: "7.5.0", Role: "i"}}
-	assert.True(t, isSufficient(&clusterHealth, &nodes, "7.5.0", 1))
+	if !isSufficient(&clusterHealth, &nodes, "7.5.0", 1) {
+		t.Fail()
+	}
 }
 
 func TestIsSufficientNotEnoughDataNodesAtExpectedVersion(t *testing.T) {

--- a/eswait_test.go
+++ b/eswait_test.go
@@ -3,7 +3,10 @@
 
 package main
 
-import "testing"
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 func TestIsSufficientNilInputs(t *testing.T) {
 	if isSufficient(nil, nil, "7.5.0", 1) {
@@ -41,6 +44,12 @@ func TestIsSufficientNotEnoughDataNodes(t *testing.T) {
 	if isSufficient(&clusterHealth, &nodes, "7.5.0", 2) {
 		t.Fail()
 	}
+}
+
+func TestIsSufficientDataNodesSingleNodeCluster(t *testing.T) {
+	clusterHealth := ClusterHealth{"yellow"}
+	nodes := []ESNode{{Version: "7.5.0", Role: "dim"}, {Version: "7.5.0", Role: "m"}, {Version: "7.5.0", Role: "i"}}
+	assert.True(t, isSufficient(&clusterHealth, &nodes, "7.5.0", 1))
 }
 
 func TestIsSufficientNotEnoughDataNodesAtExpectedVersion(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,10 +23,12 @@ func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*OperatorConfig, error
 	}
 	var config OperatorConfig
 	err := yaml.Unmarshal([]byte(configString), &config)
-	zap.S().Debugf("Unmarshalled configmap is:\n %s", configMap.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshall ConfigMap %s: %v", configMap.String(), err)
 	}
+	// Comment out the debug line below to avoid halting the debugger in Goland/IntelliJ
+	// see https://youtrack.jetbrains.com/issue/GO-8953
+	zap.S().Debugf("Unmarshalled configmap is:\n %s", configMap.String())
 
 	// Set defaults for any uninitialized values
 	zap.S().Infow("Setting config defaults")

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -101,9 +101,6 @@ const ESTransportPort = 9300
 // DefaultDevProfileESMemArgs default Elasticsearch dev mode memory settings
 const DefaultDevProfileESMemArgs = "-Xms512m -Xmx512m"
 
-// DefaultDevProfileESReplicas default Elasticsearch dev mode replicas
-const DefaultDevProfileESReplicas = 1
-
 // DefaultESIngestMemArgs default Elasticsearch Ingest memory settings
 const DefaultESIngestMemArgs = "-Xms2g -Xmx2g"
 
@@ -204,12 +201,3 @@ const K8sDefaultStorageClassBetaAnnotation = "storageclass.beta.kubernetes.io/is
 
 // MonitoringNamespace Monitoring namespace
 const MonitoringNamespace = "monitoring"
-
-// SystemVMIName name of the system Verrazzano Monitoring Instance
-//const SystemVMIName = "system"
-
-// ProductionProfile name of the Production Profile Installation
-//const ProductionProfile = "prod"
-
-// DevelopmentProfile name of the Development Profile Installation
-const DevelopmentProfile = "dev"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -206,10 +206,10 @@ const K8sDefaultStorageClassBetaAnnotation = "storageclass.beta.kubernetes.io/is
 const MonitoringNamespace = "monitoring"
 
 // SystemVMIName name of the system Verrazzano Monitoring Instance
-const SystemVMIName = "system"
+//const SystemVMIName = "system"
 
 // ProductionProfile name of the Production Profile Installation
-const ProductionProfile = "prod"
+//const ProductionProfile = "prod"
 
 // DevelopmentProfile name of the Development Profile Installation
 const DevelopmentProfile = "dev"

--- a/pkg/resources/deployments/deployment_test.go
+++ b/pkg/resources/deployments/deployment_test.go
@@ -5,7 +5,6 @@ package deployments
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
@@ -63,14 +62,6 @@ func TestVMOFullDeploymentSize(t *testing.T) {
 }
 
 func TestVMODevProfileFullDeploymentSize(t *testing.T) {
-	const envKey = "INSTALL_PROFILE"
-	os.Setenv(envKey, constants.DevelopmentProfile)
-	defer func() {
-		t.Log("Unsetting INSTALL_PROFILE")
-		os.Unsetenv(envKey)
-		_, ok := os.LookupEnv(envKey)
-		assert.False(t, ok, "Single node ES test cleanup, expected IsDevProfile to be false")
-	}()
 
 	vmo := &vmcontrollerv1.VerrazzanoMonitoringInstance{
 		Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
@@ -90,13 +81,13 @@ func TestVMODevProfileFullDeploymentSize(t *testing.T) {
 			},
 			Elasticsearch: vmcontrollerv1.Elasticsearch{
 				Enabled:    true,
-				IngestNode: vmcontrollerv1.ElasticsearchNode{Replicas: 1},
+				IngestNode: vmcontrollerv1.ElasticsearchNode{Replicas: 0},
 				MasterNode: vmcontrollerv1.ElasticsearchNode{Replicas: 1},
-				DataNode:   vmcontrollerv1.ElasticsearchNode{Replicas: 1},
+				DataNode:   vmcontrollerv1.ElasticsearchNode{Replicas: 0},
 			},
 		},
 	}
-	assert.True(t, resources.IsDevProfile(), "Single node ES setup, expected IsDevProfile to be true")
+	assert.True(t, resources.IsSingleNodeESCluster(vmo), "Single node ES setup, expected IsDevProfile to be true")
 
 	deployments, err := New(vmo, &config.OperatorConfig{}, map[string]string{}, "vmo", "changeme")
 	if err != nil {
@@ -338,7 +329,10 @@ func TestWaitForElasticsearchTargetVersion(t *testing.T) {
 				Enabled: true,
 			},
 			Elasticsearch: vmcontrollerv1.Elasticsearch{
-				Enabled: true,
+				Enabled:    true,
+				IngestNode: vmcontrollerv1.ElasticsearchNode{Replicas: 1},
+				DataNode:   vmcontrollerv1.ElasticsearchNode{Replicas: 1},
+				MasterNode: vmcontrollerv1.ElasticsearchNode{Replicas: 1},
 			},
 		},
 	}

--- a/pkg/resources/deployments/deployment_test.go
+++ b/pkg/resources/deployments/deployment_test.go
@@ -98,6 +98,38 @@ func TestVMODevProfileFullDeploymentSize(t *testing.T) {
 	assert.Equal(t, constants.VMOKind, deployments[0].ObjectMeta.OwnerReferences[0].Kind, "OwnerReferences is not set by default")
 }
 
+func TestVMODevProfileInvalidESTopology(t *testing.T) {
+
+	vmo := &vmcontrollerv1.VerrazzanoMonitoringInstance{
+		Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
+			CascadingDelete: true,
+			Grafana: vmcontrollerv1.Grafana{
+				Enabled: true,
+			},
+			Prometheus: vmcontrollerv1.Prometheus{
+				Enabled:  true,
+				Replicas: 1,
+			},
+			AlertManager: vmcontrollerv1.AlertManager{
+				Enabled: true,
+			},
+			Kibana: vmcontrollerv1.Kibana{
+				Enabled: true,
+			},
+			Elasticsearch: vmcontrollerv1.Elasticsearch{
+				Enabled:    true,
+				IngestNode: vmcontrollerv1.ElasticsearchNode{Replicas: 0},
+				MasterNode: vmcontrollerv1.ElasticsearchNode{Replicas: 0},
+				DataNode:   vmcontrollerv1.ElasticsearchNode{Replicas: 0},
+			},
+		},
+	}
+	assert.False(t, resources.IsSingleNodeESCluster(vmo), "Single node ES setup, expected IsDevProfile to be true")
+
+	_, err := New(vmo, &config.OperatorConfig{}, map[string]string{}, "vmo", "changeme")
+	assert.NotNil(t, err, "Did not get an error for an invalid ES configuration")
+}
+
 func TestVMOWithCascadingDelete(t *testing.T) {
 	// With CascadingDelete
 	vmo := &vmcontrollerv1.VerrazzanoMonitoringInstance{

--- a/pkg/resources/deployments/deployment_test.go
+++ b/pkg/resources/deployments/deployment_test.go
@@ -124,7 +124,7 @@ func TestVMODevProfileInvalidESTopology(t *testing.T) {
 			},
 		},
 	}
-	assert.False(t, resources.IsSingleNodeESCluster(vmo), "Single node ES setup, expected IsDevProfile to be true")
+	assert.False(t, resources.IsSingleNodeESCluster(vmo), "Invalid single node ES setup, expected IsDevProfile to be false")
 
 	_, err := New(vmo, &config.OperatorConfig{}, map[string]string{}, "vmo", "changeme")
 	assert.NotNil(t, err, "Did not get an error for an invalid ES configuration")

--- a/pkg/resources/helper_test.go
+++ b/pkg/resources/helper_test.go
@@ -42,3 +42,76 @@ func getItem(key, value string, scrapeConfigs []interface{}) map[interface{}]int
 	}
 	return nil
 }
+
+func TestIsSingleNodeESCluster(t *testing.T) {
+	vmo := &vmov1.VerrazzanoMonitoringInstance{
+		Spec: vmov1.VerrazzanoMonitoringInstanceSpec{
+			CascadingDelete: true,
+			Grafana: vmov1.Grafana{
+				Enabled: true,
+			},
+			Prometheus: vmov1.Prometheus{
+				Enabled:  true,
+				Replicas: 1,
+			},
+			AlertManager: vmov1.AlertManager{
+				Enabled: true,
+			},
+			Kibana: vmov1.Kibana{
+				Enabled: true,
+			},
+			Elasticsearch: vmov1.Elasticsearch{
+				Enabled:    true,
+				IngestNode: vmov1.ElasticsearchNode{Replicas: 0},
+				MasterNode: vmov1.ElasticsearchNode{Replicas: 1},
+				DataNode:   vmov1.ElasticsearchNode{Replicas: 0},
+			},
+		},
+	}
+	assert.True(t, IsSingleNodeESCluster(vmo), "IsSingleNodeCluster false for valid configuration")
+
+	vmo.Spec.Elasticsearch.MasterNode.Replicas = 2
+	assert.False(t, IsSingleNodeESCluster(vmo), "IsSingleNodeCluster true for invalid configuration")
+
+	vmo.Spec.Elasticsearch.MasterNode.Replicas = 1
+	vmo.Spec.Elasticsearch.IngestNode.Replicas = 1
+	assert.False(t, IsSingleNodeESCluster(vmo), "IsSingleNodeCluster true for invalid configuration")
+}
+
+func TestIsValidMultiNodeESCluster(t *testing.T) {
+	vmo := &vmov1.VerrazzanoMonitoringInstance{
+		Spec: vmov1.VerrazzanoMonitoringInstanceSpec{
+			CascadingDelete: true,
+			Grafana: vmov1.Grafana{
+				Enabled: true,
+			},
+			Prometheus: vmov1.Prometheus{
+				Enabled:  true,
+				Replicas: 1,
+			},
+			AlertManager: vmov1.AlertManager{
+				Enabled: true,
+			},
+			Kibana: vmov1.Kibana{
+				Enabled: true,
+			},
+			Elasticsearch: vmov1.Elasticsearch{
+				Enabled:    true,
+				IngestNode: vmov1.ElasticsearchNode{Replicas: 0},
+				MasterNode: vmov1.ElasticsearchNode{Replicas: 1},
+				DataNode:   vmov1.ElasticsearchNode{Replicas: 0},
+			},
+		},
+	}
+	assert.False(t, IsValidMultiNodeESCluster(vmo), "IsValidMultiNodeESCluster true for single-node configuration")
+
+	vmo.Spec.Elasticsearch.MasterNode.Replicas = 1
+	vmo.Spec.Elasticsearch.DataNode.Replicas = 1
+	vmo.Spec.Elasticsearch.IngestNode.Replicas = 1
+	assert.True(t, IsValidMultiNodeESCluster(vmo), "IsValidMultiNodeESCluster false for valid configuration")
+
+	vmo.Spec.Elasticsearch.MasterNode.Replicas = 3
+	vmo.Spec.Elasticsearch.DataNode.Replicas = 2
+	vmo.Spec.Elasticsearch.IngestNode.Replicas = 1
+	assert.True(t, IsValidMultiNodeESCluster(vmo), "IsValidMultiNodeESCluster true for valid configuration")
+}

--- a/pkg/resources/pvcs/pvc.go
+++ b/pkg/resources/pvcs/pvc.go
@@ -22,7 +22,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, storageClassName stri
 		}
 		pvcList = append(pvcList, pvcs...)
 	}
-	if !resources.IsDevProfile() && vmo.Spec.Elasticsearch.Enabled && vmo.Spec.Elasticsearch.Storage.Size != "" {
+	if vmo.Spec.Elasticsearch.Enabled && vmo.Spec.Elasticsearch.Storage.Size != "" {
 		pvcs, err := createPvcElements(vmo, &vmo.Spec.Elasticsearch.Storage, storageClassName)
 		if err != nil {
 			return pvcList, err

--- a/pkg/resources/pvcs/pvc_test.go
+++ b/pkg/resources/pvcs/pvc_test.go
@@ -4,7 +4,6 @@
 package pvcs
 
 import (
-	"os"
 	"testing"
 
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
@@ -94,14 +93,6 @@ func TestVMOWithStorageVolumes2(t *testing.T) {
 }
 
 func TestVMODevModeWithStorageVolumes(t *testing.T) {
-	const envKey = "INSTALL_PROFILE"
-	os.Setenv(envKey, constants.DevelopmentProfile)
-	defer func() {
-		t.Log("Unsetting INSTALL_PROFILE")
-		os.Unsetenv(envKey)
-		_, ok := os.LookupEnv(envKey)
-		assert.False(t, ok, "Single node ES test cleanup, expected IsDevProfile to be false")
-	}()
 	vmo := &vmcontrollerv1.VerrazzanoMonitoringInstance{
 		Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
 			Grafana: vmcontrollerv1.Grafana{
@@ -123,10 +114,11 @@ func TestVMODevModeWithStorageVolumes(t *testing.T) {
 			Elasticsearch: vmcontrollerv1.Elasticsearch{
 				Enabled: true,
 				Storage: vmcontrollerv1.Storage{
-					Size:               "50Gi",
-					AvailabilityDomain: "AD1",
-					PvcNames:           []string{"elasticsearch-pvc"},
+					Size: "",
 				},
+				IngestNode: vmcontrollerv1.ElasticsearchNode{Replicas: 0},
+				DataNode:   vmcontrollerv1.ElasticsearchNode{Replicas: 0},
+				MasterNode: vmcontrollerv1.ElasticsearchNode{Replicas: 1},
 			},
 		},
 	}

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -15,7 +15,7 @@ import (
 // Creates Elasticsearch Client service element
 func createElasticsearchIngestServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *corev1.Service {
 	var elasticsearchIngestService *corev1.Service = createServiceElement(vmo, config.ElasticsearchIngest)
-	if resources.IsDevProfile() {
+	if resources.IsSingleNodeESCluster(vmo) {
 		elasticsearchIngestService.Spec.Selector = resources.GetSpecID(vmo.Name, config.ElasticsearchMaster.Name)
 		// In dev mode, only a single node/pod all ingest/data goes to the 9200 port on the back end node
 		elasticsearchIngestService.Spec.Ports = []corev1.ServicePort{resources.GetServicePort(config.ElasticsearchData)}
@@ -26,7 +26,7 @@ func createElasticsearchIngestServiceElements(vmo *vmcontrollerv1.VerrazzanoMoni
 // Creates Elasticsearch Master service element
 func createElasticsearchMasterServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *corev1.Service {
 	elasticSearchMasterService := createServiceElement(vmo, config.ElasticsearchMaster)
-	if !resources.IsDevProfile() {
+	if !resources.IsSingleNodeESCluster(vmo) {
 		// Master service is headless
 		elasticSearchMasterService.Spec.Type = corev1.ServiceTypeClusterIP
 		elasticSearchMasterService.Spec.ClusterIP = corev1.ClusterIPNone
@@ -40,7 +40,7 @@ func createElasticsearchDataServiceElements(vmo *vmcontrollerv1.VerrazzanoMonito
 	// Data k8s service only needs to expose NodeExporter port
 	// - in dev mode, preserve this as the front end ES data port, at least for now
 	elasticsearchDataService.Spec.Ports = []corev1.ServicePort{resources.GetServicePort(config.NodeExporter)}
-	if resources.IsDevProfile() {
+	if resources.IsSingleNodeESCluster(vmo) {
 		// In dev mode, only a single node/pod all ingest/data goes to the 9200 port on the back end node
 		elasticsearchDataService.Spec.Selector = resources.GetSpecID(vmo.Name, config.ElasticsearchMaster.Name)
 		elasticsearchDataService.Spec.Ports[0].TargetPort = intstr.FromInt(constants.ESHttpPort)

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -11,7 +11,6 @@ import (
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/deployments"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/diff"
 	"go.uber.org/zap"
@@ -27,11 +26,6 @@ func CreateDeployments(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMon
 	// Assigning the following spec members seems like a hack; is any
 	// better way to make these values available where the deployments are created?
 	vmo.Spec.NatGatewayIPs = controller.operatorConfig.NatGatewayIPs
-
-	// If Dev Profile, allow System VMI to fall through and get created
-	if resources.IsDevProfile() && vmo.Name != constants.SystemVMIName {
-		return false, nil
-	}
 
 	deployList, err := deployments.New(vmo, controller.operatorConfig, pvcToAdMap, vmoUsername, vmoPassword)
 	if err != nil {

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -21,11 +21,6 @@ import (
 // CreateIngresses create/update VMO ingress k8s resources
 func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) error {
 
-	// If Dev Profile, allow System VMI to fall through and get created
-	//if resources.IsDevProfile() && vmo.Name != constants.SystemVMIName {
-	//	return nil
-	//}
-
 	ingList, err := ingresses.New(vmo)
 	if err != nil {
 		zap.S().Errorf("Failed to create Ingress specs for vmo: %s", err)

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -9,7 +9,6 @@ import (
 
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/ingresses"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/diff"
 	"go.uber.org/zap"
@@ -23,9 +22,9 @@ import (
 func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) error {
 
 	// If Dev Profile, allow System VMI to fall through and get created
-	if resources.IsDevProfile() && vmo.Name != constants.SystemVMIName {
-		return nil
-	}
+	//if resources.IsDevProfile() && vmo.Name != constants.SystemVMIName {
+	//	return nil
+	//}
 
 	ingList, err := ingresses.New(vmo)
 	if err != nil {

--- a/pkg/vmo/statefulset.go
+++ b/pkg/vmo/statefulset.go
@@ -24,9 +24,9 @@ import (
 // CreateStatefulSets creates/updates/deletes VMO statefulset k8s resources
 func CreateStatefulSets(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) error {
 	// If Dev Profile, allow System VMI to fall through and get created
-	if resources.IsDevProfile() && vmo.Name != constants.SystemVMIName {
-		return nil
-	}
+	//if resources.IsDevProfile() && vmo.Name != constants.SystemVMIName {
+	//	return nil
+	//}
 
 	statefulSetList, err := statefulsets.New(vmo)
 	if err != nil {
@@ -130,10 +130,10 @@ func updateOwnerForPVCs(controller *Controller, statefulSet *appsv1.StatefulSet,
 			return err
 		}
 	}
-	replicas := int(*statefulSet.Spec.Replicas)
-	numPVCs := len(existingPvcList)
-	if numPVCs != replicas {
-		return fmt.Errorf("PVC owner reference set in %v of %v PVCs for VMO %s", numPVCs, replicas, vmoName)
+	expectedNumPVCs := int(*statefulSet.Spec.Replicas) * len(statefulSet.Spec.VolumeClaimTemplates)
+	actualNumPVCs := len(existingPvcList)
+	if actualNumPVCs != expectedNumPVCs {
+		return fmt.Errorf("PVC owner reference set in %v of %v PVCs for VMO %s", actualNumPVCs, expectedNumPVCs, vmoName)
 	}
 	return nil
 }

--- a/pkg/vmo/statefulset.go
+++ b/pkg/vmo/statefulset.go
@@ -23,11 +23,6 @@ import (
 
 // CreateStatefulSets creates/updates/deletes VMO statefulset k8s resources
 func CreateStatefulSets(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) error {
-	// If Dev Profile, allow System VMI to fall through and get created
-	//if resources.IsDevProfile() && vmo.Name != constants.SystemVMIName {
-	//	return nil
-	//}
-
 	statefulSetList, err := statefulsets.New(vmo)
 	if err != nil {
 		zap.S().Errorf("Failed to create StatefulSet specs for vmo: %s", err)

--- a/pkg/vmo/vmospec.go
+++ b/pkg/vmo/vmospec.go
@@ -97,14 +97,8 @@ func InitializeVMOSpec(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMon
 	if vmo.Spec.AlertManager.Replicas == 0 {
 		vmo.Spec.AlertManager.Replicas = int32(*controller.operatorConfig.DefaultSimpleComponentReplicas)
 	}
-	if vmo.Spec.Elasticsearch.IngestNode.Replicas == 0 {
-		vmo.Spec.Elasticsearch.IngestNode.Replicas = int32(constants.DefaultElasticsearchIngestReplicas)
-	}
 	if vmo.Spec.Elasticsearch.MasterNode.Replicas == 0 {
 		vmo.Spec.Elasticsearch.MasterNode.Replicas = int32(constants.DefaultElasticsearchMasterReplicas)
-	}
-	if vmo.Spec.Elasticsearch.DataNode.Replicas == 0 {
-		vmo.Spec.Elasticsearch.DataNode.Replicas = int32(constants.DefaultElasticsearchDataReplicas)
 	}
 	for _, component := range config.StorageEnableComponents {
 		storageElement := resources.GetStorageElementForComponent(vmo, component)

--- a/run-vmo.sh
+++ b/run-vmo.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+ 
+# If on corporate network set proxy environment variables
+#profile=${1-:"dev"}
+
+# Customize these to provide the location of your verrazzano and verrazzano repos
+export THIS_REPO=$(pwd)
+export VERRAZZANO_INSTALLER_REPO=${THIS_REPO}/../verrazzano
+  
+echo "Building and installing the verrazzano-monitoring-operator."
+cd ${THIS_REPO}
+#make go-install
+#echo ""
+
+echo "Stopping the in-cluster verrazzano-monitoring-operator."
+set -x
+kubectl scale deployment verrazzano-monitoring-operator --replicas=0 -n verrazzano-system
+set +x
+echo ""
+  
+# Extract the images required by verrazzano-operator from values.yaml into environment variables.
+export GRAFANA_IMAGE=$(grep grafanaImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export PROMETHEUS_IMAGE=$(grep prometheusImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export PROMETHEUS_INIT_IMAGE=$(grep prometheusInitImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export PROMETHEUS_GATEWAY_IMAGE=$(grep prometheusGatewayImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export ALERT_MANAGER_IMAGE=$(grep alertManagerImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export ELASTICSEARCH_WAIT_TARGET_VERSION=7.6.1
+export ELASTICSEARCH_WAIT_IMAGE=$(grep esWaitImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export KIBANA_IMAGE=$(grep kibanaImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export ELASTICSEARCH_IMAGE=$(grep esImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export ELASTICSEARCH_INIT_IMAGE=$(grep esInitImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export VERRAZZANO_MONITORING_INSTANCE_API_IMAGE=$(grep monitoringInstanceApiImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export CONFIG_RELOADER_IMAGE=$(grep configReloaderImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export NODE_EXPORTER_IMAGE=$(grep nodeExporterImage ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | head -1 | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+
+# Extract the API server realm from values.yaml.
+export API_SERVER_REALM=$(grep apiServerRealm ${VERRAZZANO_INSTALLER_REPO}/install/chart/values.yaml | cut -d':' -f2 | sed -e 's/^[[:space:]]*//')
+  
+# Extract the Verrazzano system ingress IP from the NGINX ingress controller status.
+export VERRAZZANO_SYSTEM_INGRESS_IP=$(kubectl get svc -n ingress-nginx ingress-controller-nginx-ingress-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+export WATCH_VMI=${WATCH_VMI:-""}
+export WATCH_NAMESPACE=${WATCH_NAMESPACE:-""}
+
+cat <<EOF
+Variables:
+
+GRAFANA_IMAGE=${GRAFANA_IMAGE}
+PROMETHEUS_IMAGE=${PROMETHEUS_IMAGE}
+PROMETHEUS_INIT_IMAGE=${PROMETHEUS_INIT_IMAGE}
+PROMETHEUS_GATEWAY_IMAGE=${PROMETHEUS_GATEWAY_IMAGE}
+ALERT_MANAGER_IMAGE=${ALERT_MANAGER_IMAGE}
+ELASTICSEARCH_WAIT_TARGET_VERSION=${ELASTICSEARCH_WAIT_TARGET_VERSION}
+ELASTICSEARCH_WAIT_IMAGE=${ELASTICSEARCH_WAIT_IMAGE}
+KIBANA_IMAGE=${KIBANA_IMAGE}
+ELASTICSEARCH_IMAGE=${ELASTICSEARCH_IMAGE}
+ELASTICSEARCH_INIT_IMAGE=${ELASTICSEARCH_INIT_IMAGE}
+VERRAZZANO_MONITORING_INSTANCE_API_IMAGE=${VERRAZZANO_MONITORING_INSTANCE_API_IMAGE}
+CONFIG_RELOADER_IMAGE=${CONFIG_RELOADER_IMAGE}
+NODE_EXPORTER_IMAGE=${NODE_EXPORTER_IMAGE}
+
+WATCH_VMI=${WATCH_VMI}
+WATCH_NAMESPACE=${WATCH_NAMESPACE}
+EOF
+
+# Run the out-of-cluster Verrazzano operator.
+cmd="verrazzano-monitoring-ctrl \
+ --zap-log-level=debug \
+ --namespace=verrazzano-system \
+ --watchNamespace=${WATCH_NAMESPACE} \
+ --watchVmi=${WATCH_VMI} \
+ --kubeconfig=${KUBECONFIG:-${HOME}/.kube/config}"
+
+echo "Command"
+echo "${cmd}"
+eval ${cmd}

--- a/run-vmo.sh
+++ b/run-vmo.sh
@@ -1,8 +1,28 @@
 #!/bin/bash
 # Copyright (c) 2020, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-
-# If on corporate network set proxy environment variables
+#
+# This script will run the verrazzano-monitoring-operator outside of the cluster, for local debugging/testing
+# purposes.
+#
+# Pre-requisites:
+# - golang is installed as described in the README
+# - the verrazzano installer is cloned from github in a parallel directory named to this repo (https://github.com/verrazzano/verrazzano)
+# - kubectl is installed
+# - KUBECONFIG is pointing to a valid Kubernetes cluster
+# - If on corporate network set proxy environment variables
+#
+# Simply run
+#
+#    sh run-vmo.sh
+#
+# When executed, the script will
+#
+# - build the operator
+# - set up the required environment variables for the operator
+# - scale down the in-cluster monitoring operator to 0
+# - Execute the local operator
+# - Once the local operator is terminated (hit Ctrl-C), scale up the in-cluster operator to 1 replica again
 
 # Customize these to provide the location of your verrazzano and verrazzano repos
 export THIS_REPO=$(pwd)
@@ -75,3 +95,9 @@ cmd="verrazzano-monitoring-ctrl \
 echo "Command"
 echo "${cmd}"
 eval ${cmd}
+
+echo "Re-starting the in-cluster verrazzano-monitoring-operator."
+set -x
+kubectl scale deployment verrazzano-monitoring-operator --replicas=1 -n verrazzano-system
+set +x
+echo ""

--- a/run-vmo.sh
+++ b/run-vmo.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
- 
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
 # If on corporate network set proxy environment variables
-#profile=${1-:"dev"}
 
 # Customize these to provide the location of your verrazzano and verrazzano repos
 export THIS_REPO=$(pwd)
@@ -9,8 +10,8 @@ export VERRAZZANO_INSTALLER_REPO=${THIS_REPO}/../verrazzano
   
 echo "Building and installing the verrazzano-monitoring-operator."
 cd ${THIS_REPO}
-#make go-install
-#echo ""
+make go-install
+echo ""
 
 echo "Stopping the in-cluster verrazzano-monitoring-operator."
 set -x


### PR DESCRIPTION
Remove explicit dev/prod profile checks, and let the verrazzano-operator drive the VMI configuration 
- We do still enforce single-node cluster behaviors when appropriate (only a single master node replica is configured)
- We also enforce that a valid multi-node cluster configuration consists of at least 1 of each type of node (1 master, 1 data, 1 ingest)
- The VO will drive single/multi-node ES and any persistent storage usage via the fine-grained VMI settings
 