### PR TITLE
VZ-1885.  Patch Elasticsearch

### DIFF
--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -134,6 +134,7 @@ func updateNextDeployment(controller *Controller, vmo *vmcontrollerv1.Verrazzano
 	return false, nil
 }
 
+// Update all deployments in the list concurrently
 func updateAllDeployment(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, deployments []*appsv1.Deployment) (dirty bool, err error) {
 	for _, curDeployment := range deployments {
 		_, err := controller.deploymentLister.Deployments(vmo.Namespace).Get(curDeployment.Name)

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -134,7 +134,6 @@ func updateNextDeployment(controller *Controller, vmo *vmcontrollerv1.Verrazzano
 	return false, nil
 }
 
-// Temp hack, force all deployments to update regardless of diffs until we can figure out the rolling upgrade problem
 func updateAllDeployment(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, deployments []*appsv1.Deployment) (dirty bool, err error) {
 	for _, curDeployment := range deployments {
 		_, err := controller.deploymentLister.Deployments(vmo.Namespace).Get(curDeployment.Name)
@@ -142,7 +141,6 @@ func updateAllDeployment(controller *Controller, vmo *vmcontrollerv1.VerrazzanoM
 			return false, err
 		}
 
-		// FIXME: on the next pass, we need to figure out why we are getting diffs in the RequestMemory that we don't expect
 		_, err = controller.kubeclientset.AppsV1().Deployments(vmo.Namespace).Update(context.TODO(), curDeployment, metav1.UpdateOptions{})
 		if err != nil {
 			return false, err

--- a/run-vmo.sh
+++ b/run-vmo.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020, Oracle and/or its affiliates.
+# Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 #
 # This script will run the verrazzano-monitoring-operator outside of the cluster, for local debugging/testing
@@ -26,7 +26,7 @@
 
 # Customize these to provide the location of your verrazzano and verrazzano repos
 export THIS_REPO=$(pwd)
-export VERRAZZANO_INSTALLER_REPO=${THIS_REPO}/../verrazzano
+export VERRAZZANO_INSTALLER_REPO=${THIS_REPO}/../verrazzano/operator/scripts
   
 echo "Building and installing the verrazzano-monitoring-operator."
 cd ${THIS_REPO}


### PR DESCRIPTION
Force ES/Prometheus to apply updates to work around rolling upgrade bug
- VMO attempts to do a rolling upgrade of Prometheus and ES nodes, however the ES data nodes are getting stuck on a diff in the RequestMemory that seems out of our control
- For now, allow the upgrade to continue at the same time, and get the rolling upgrade working later if necessary
- Update run-vmo.sh to pick up images from correct values.yaml location