### PR TITLE
Fix standalone example

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,8 +20,18 @@ kubectl apply -f k8s/crds/verrazzano-monitoring-operator-crds.yaml --validate=fa
 ### Install Nginx Ingress Controller
 
 ```
-helm upgrade ingress-controller stable/nginx-ingress --install --version 1.27.0  --set controller.service.enableHttp=false \
-  --set controller.scope.enabled=true
+helm repo add stable https://charts.helm.sh/stable
+helm repo update
+kubectl create namespace ingress-nginx
+helm upgrade ingress-controller stable/nginx-ingress --install --namespace ingress-nginx \
+   --set controller.image.repository=container-registry.oracle.com/verrazzano/nginx-ingress-controller \
+   --set controller.image.tag=0.32-20201016205412-8580ea0ef --set controller.config.client-body-buffer-size=64k \
+   --set defaultBackend.image.repository=container-registry.oracle.com/verrazzano/nginx-ingress-default-backend \
+   --set defaultBackend.image.tag=0.32-20201016205412-8580ea0ef --set controller.metrics.enabled=true \
+   --set 'controller.podAnnotations.prometheus\.io/port=10254' --set 'controller.podAnnotations.prometheus\.io/scrape=true' \
+   --set 'controller.podAnnotations.system\.io/scrape=true' --version 1.27.0 --set controller.service.type=NodePort \
+   --set controller.publishService.enabled=true --timeout 15m0s --set controller.service.externalTrafficPolicy=Local \
+   --set controller.autoscaling.enabled=true --set controller.autoscaling.minReplicas=2 --wait
 ```
 
 ### Install VMO

--- a/k8s/examples/simple-vmi.yaml
+++ b/k8s/examples/simple-vmi.yaml
@@ -13,8 +13,6 @@ spec:
       enabled: true
     prometheus:
       enabled: true
-    alertmanager:
-      enabled: true
     elasticsearch:
       enabled: true
     kibana:

--- a/k8s/examples/vmi-with-data-volumes.yaml
+++ b/k8s/examples/vmi-with-data-volumes.yaml
@@ -17,8 +17,6 @@ spec:
       enabled: true
       storage:
         size: "50Gi"
-    alertmanager:
-      enabled: true
     elasticsearch:
       enabled: true
       storage:

--- a/k8s/examples/vmi-with-ingress.yaml
+++ b/k8s/examples/vmi-with-ingress.yaml
@@ -14,8 +14,6 @@ spec:
       enabled: true
     prometheus:
       enabled: true
-    alertmanager:
-      enabled: true
     elasticsearch:
       enabled: true
     kibana:

--- a/k8s/manifests/verrazzano-monitoring-operator.yaml
+++ b/k8s/manifests/verrazzano-monitoring-operator.yaml
@@ -282,7 +282,7 @@ spec:
       containers:
       - name: verrazzano-monitoring-operator
         imagePullPolicy: Always
-        image: container-registry.oracle.com/verrazzano/verrazzano-monitoring-operator:latest
+        image: container-registry.oracle.com/verrazzano/verrazzano-monitoring-operator:0.7.0-20201210185706-c4d3a23
         ports:
         - containerPort: 8080
           name: http
@@ -301,10 +301,36 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         args:
-          - --v=4
+          - --zap-log-level=info
+          - --zap-devel=false
           - --namespace=default
-          - --watchNamespace=default
-          - --watchVmi=
+        env:
+        - name: GRAFANA_IMAGE
+          value: container-registry.oracle.com/olcne/grafana:v6.4.4
+        - name: PROMETHEUS_IMAGE
+          value: container-registry.oracle.com/olcne/prometheus:v2.13.1
+        - name: PROMETHEUS_INIT_IMAGE
+          value: container-registry.oracle.com/os/oraclelinux:7-slim
+        - name: PROMETHEUS_GATEWAY_IMAGE
+          value: container-registry.oracle.com/verrazzano/prometheus-pushgateway:1.2.0-20201016205229-164dd8b
+        - name: ALERT_MANAGER_IMAGE
+          value: noimage
+        - name: ELASTICSEARCH_WAIT_IMAGE
+          value: container-registry.oracle.com/verrazzano/verrazzano-monitoring-instance-eswait:0.7.0-20201210185706-c4d3a23
+        - name: ELASTICSEARCH_IMAGE
+          value: container-registry.oracle.com/verrazzano/elasticsearch:7.6.1-20201130145440-5c76ab1
+        - name: ELASTICSEARCH_INIT_IMAGE
+          value: container-registry.oracle.com/os/oraclelinux:7.8
+        - name: KIBANA_IMAGE
+          value: container-registry.oracle.com/verrazzano/kibana:7.6.1-20201130145840-7717e73
+        - name: ELASTICSEARCH_WAIT_TARGET_VERSION
+          value: 7.6.1
+        - name: VERRAZZANO_MONITORING_INSTANCE_API_IMAGE
+          value: container-registry.oracle.com/verrazzano/verrazzano-monitoring-instance-api:0.7.0-20201210185702-26267a3
+        - name: CONFIG_RELOADER_IMAGE
+          value: container-registry.oracle.com/verrazzano/configmap-reload:0.3-20201016205243-4f24a0e
+        - name: NODE_EXPORTER_IMAGE
+          value: container-registry.oracle.com/verrazzano/node-exporter:0.18.1-20201016212926-e3dc9ad
       serviceAccountName: verrazzano-monitoring-operator
 ---
 apiVersion: v1


### PR DESCRIPTION
Existing documentation and examples of a standalone verrazzano-monitoring-operator deployment do not work, this PR resolves this and fixes #34.

I haven't performed testing of the containers and ideally the image names would be automatically patched but this PR at least lets the containers start.