### PR TITLE
Add Istio sidecar to Prometheus

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -158,6 +158,9 @@ const PrometheusConfigMountPath = "/etc/prometheus/config"
 // PrometheusRulesMountPath Prometheus rules mountpath
 const PrometheusRulesMountPath = "/etc/prometheus/rules"
 
+// PrometheusIstioCertsMountPath Prometheus Istio certs mountpath
+const PrometheusIstioCertsMountPath = "/etc/istio-certs/"
+
 // PrometheusConfigContainerLocation Prometheus config inside container
 const PrometheusConfigContainerLocation = "/etc/prometheus/config/prometheus.yml"
 

--- a/pkg/resources/deployments/prometheus.go
+++ b/pkg/resources/deployments/prometheus.go
@@ -11,6 +11,7 @@ import (
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // Creates Prometheus node deployment elements
@@ -105,6 +106,9 @@ func createPrometheusNodeDeploymentElements(vmo *vmcontrollerv1.VerrazzanoMonito
 			prometheusDeployment.Spec.Template.Spec.Containers[2].VolumeMounts = nodeExporterMount
 		}
 
+		// Istio proxy container
+		prometheusDeployment.Spec.Template.Spec.Containers = append(prometheusDeployment.Spec.Template.Spec.Containers, *createPrometheusIstioProxyContainer())
+
 		// Prometheus init container
 		prometheusDeployment.Spec.Template.Spec.InitContainers = []corev1.Container{
 			{
@@ -124,9 +128,209 @@ func createPrometheusNodeDeploymentElements(vmo *vmcontrollerv1.VerrazzanoMonito
 				corev1.VolumeMount{Name: constants.StorageVolumeName, MountPath: config.Prometheus.DataDir})
 		}
 
+		// Add the istio volumes
+		volume := corev1.Volume{
+			Name: "istio-certs",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: corev1.StorageMediumMemory,
+				},
+			},
+		}
+		prometheusDeployment.Spec.Template.Spec.Volumes = append(prometheusDeployment.Spec.Template.Spec.Volumes, volume)
+
+		volume = corev1.Volume{
+			Name: "istio-envoy",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: corev1.StorageMediumMemory,
+				},
+			},
+		}
+		prometheusDeployment.Spec.Template.Spec.Volumes = append(prometheusDeployment.Spec.Template.Spec.Volumes, volume)
+
+		var defaultMode int32 = 420
+		var expirationSeconds int64 = 43200
+		volume = corev1.Volume{
+			Name: "istio-token",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					DefaultMode: &defaultMode,
+					Sources: []corev1.VolumeProjection{
+						{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Audience:          "istio-ca",
+							ExpirationSeconds: &expirationSeconds,
+							Path:              "istio-token",
+						}},
+					},
+				},
+			},
+		}
+		prometheusDeployment.Spec.Template.Spec.Volumes = append(prometheusDeployment.Spec.Template.Spec.Volumes, volume)
+
+		volume = corev1.Volume{
+			Name: "istiod-ca-cert",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					DefaultMode: &defaultMode,
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "istio-ca-root-cert",
+					},
+				},
+			},
+		}
+		prometheusDeployment.Spec.Template.Spec.Volumes = append(prometheusDeployment.Spec.Template.Spec.Volumes, volume)
+
 		prometheusNodeDeployments = append(prometheusNodeDeployments, prometheusDeployment)
 	}
 	return prometheusNodeDeployments
+}
+
+func createPrometheusIstioProxyContainer() *corev1.Container {
+	container := &corev1.Container{
+		Name:            "istio-proxy",
+		Image:           "ghcr.io/verrazzano/proxyv2:1.7.3",
+		ImagePullPolicy: constants.DefaultImagePullPolicy,
+		Args: []string{
+			"proxy",
+			"sidecar",
+			"--domain",
+			"$(POD_NAMESPACE).svc.cluster.local",
+			"--serviceCluster",
+			"istio-proxy-prometheus",
+			"--proxyLogLevel=warning",
+			"--proxyComponentLogLevel=misc:error",
+			"--trust-domain=cluster.local",
+			"--concurrency",
+			"2",
+		},
+		Env: []corev1.EnvVar{
+			{
+				Name:  "OUTPUT_CERTS",
+				Value: "/etc/istio-certs",
+			},
+			{
+				Name:  "JWT_POLICY",
+				Value: "third-party-jwt",
+			},
+			{
+				Name:  "CA_ADDR",
+				Value: "istiod.istio-system.svc:15012",
+			},
+			{
+				Name:  "PILOT_CERT_PROVIDER",
+				Value: "istiod",
+			},
+			{
+				Name: "POD_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.name",
+					},
+				},
+			},
+			{
+				Name: "POD_NAMESPACE",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+			{
+				Name: "INSTANCE_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "status.podIP",
+					},
+				},
+			},
+			{
+				Name: "SERVICE_ACCOUNT",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "spec.serviceAccountName",
+					},
+				},
+			},
+			{
+				Name: "HOST_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "status.hostIP",
+					},
+				},
+			},
+			{
+				Name: "ISTIO_META_POD_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.name",
+					},
+				},
+			},
+			{
+				Name: "ISTIO_META_CONFIG_NAMESPACE",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+			{
+				Name:  "ISTIO_META_MESH_ID",
+				Value: "cluster.local",
+			},
+			{
+				Name:  "ISTIO_META_CLUSTER_ID",
+				Value: "Kubernetes",
+			},
+		},
+		Ports: []corev1.ContainerPort{
+			{
+				ContainerPort: 15090,
+				Name:          "http-envoy-prom",
+				Protocol:      corev1.ProtocolTCP,
+			},
+		},
+		ReadinessProbe: &corev1.Probe{
+			FailureThreshold: 30,
+			Handler: corev1.Handler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/healthz/ready",
+					Port: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 15020,
+					},
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			InitialDelaySeconds: 1,
+			PeriodSeconds:       2,
+			SuccessThreshold:    1,
+			TimeoutSeconds:      1,
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				MountPath: "/var/run/secrets/istio",
+				Name:      "istiod-ca-cert",
+			},
+			{
+				MountPath: "/etc/istio/proxy",
+				Name:      "istio-envoy",
+			},
+			{
+				MountPath: "/var/run/secrets/tokens",
+				Name:      "istio-token",
+			},
+			{
+				MountPath: "/etc/istio-certs/",
+				Name:      "istio-certs",
+			},
+		},
+	}
+
+	return container
 }
 
 // Creates Prometheus Push Gateway deployment element

--- a/pkg/resources/deployments/prometheus_test.go
+++ b/pkg/resources/deployments/prometheus_test.go
@@ -34,8 +34,8 @@ func TestPrometheusDeploymentsNoStorage(t *testing.T) {
 		t.Error(err)
 	}
 
-	assert.Equal(t, 3, len(promDeployment.Spec.Template.Spec.Containers), "Length of generated containers")
-	assert.Equal(t, 3, len(promDeployment.Spec.Template.Spec.Volumes), "Length of generated volumes")
+	assert.Equal(t, 4, len(promDeployment.Spec.Template.Spec.Containers), "Length of generated containers")
+	assert.Equal(t, 7, len(promDeployment.Spec.Template.Spec.Volumes), "Length of generated volumes")
 	assert.Equal(t, 3, len(promDeployment.Spec.Template.Spec.Containers[0].VolumeMounts), "Length of generated mounts for Prometheus node")
 	assert.Equal(t, 0, len(promDeployment.Spec.Template.Spec.Containers[2].VolumeMounts), "Length of generated mounts for Node exporter")
 	assert.Equal(t, 3, len(deployments), "Length of generated deployments")
@@ -65,8 +65,8 @@ func TestPrometheusDeploymentsWithStorage(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equal(t, 3, len(promDeployment.Spec.Template.Spec.Containers), "Length of generated containers")
-	assert.Equal(t, 3, len(promDeployment.Spec.Template.Spec.Volumes), "Length of generated volumes")
+	assert.Equal(t, 4, len(promDeployment.Spec.Template.Spec.Containers), "Length of generated containers")
+	assert.Equal(t, 7, len(promDeployment.Spec.Template.Spec.Volumes), "Length of generated volumes")
 	assert.Equal(t, 3, len(promDeployment.Spec.Template.Spec.Containers[0].VolumeMounts), "Length of generated mounts for Prometheus node")
 	assert.Equal(t, 1, len(promDeployment.Spec.Template.Spec.Containers[2].VolumeMounts), "Length of generated mounts for Node exporter")
 	assert.Equal(t, 3, len(deployments), "Length of generated deployments")

--- a/pkg/resources/deployments/prometheus_test.go
+++ b/pkg/resources/deployments/prometheus_test.go
@@ -10,7 +10,9 @@ import (
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestPrometheusDeploymentsNoStorage(t *testing.T) {
@@ -110,4 +112,80 @@ func TestPrometheusDeploymentElementsWithMultiplePVCs(t *testing.T) {
 		t.Error(err)
 	}
 	assert.Equal(t, "prometheus-pvc-2", promDeployment2.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName, "Associated pvc for Prometheus 2")
+}
+
+// TestCreatePrometheusIstioProxyContainer tests the creation of the istio-proxy container
+//  WHEN createPrometheusIstioProxyContainer is called
+//  THEN a container is returned with the istio-proxy container configuration
+func TestCreatePrometheusIstioProxyContainer(t *testing.T) {
+	container := createPrometheusIstioProxyContainer()
+
+	assert.Equal(t, "istio-proxy", container.Name)
+	assert.Equal(t, constants.DefaultImagePullPolicy, container.ImagePullPolicy)
+
+	assert.Equal(t, 11, len(container.Args))
+	assert.Equal(t, "proxy", container.Args[0])
+	assert.Equal(t, "sidecar", container.Args[1])
+	assert.Equal(t, "--domain", container.Args[2])
+	assert.Equal(t, "$(POD_NAMESPACE).svc.cluster.local", container.Args[3])
+	assert.Equal(t, "--serviceCluster", container.Args[4])
+	assert.Equal(t, "istio-proxy-prometheus", container.Args[5])
+	assert.Equal(t, "--proxyLogLevel=warning", container.Args[6])
+	assert.Equal(t, "--proxyComponentLogLevel=misc:error", container.Args[7])
+	assert.Equal(t, "--trust-domain=cluster.local", container.Args[8])
+	assert.Equal(t, "--concurrency", container.Args[9])
+	assert.Equal(t, "2", container.Args[10])
+
+	assert.Equal(t, 13, len(container.Env))
+	assert.Equal(t, "OUTPUT_CERTS", container.Env[0].Name)
+	assert.Equal(t, "/etc/istio-certs", container.Env[0].Value)
+	assert.Equal(t, "JWT_POLICY", container.Env[1].Name)
+	assert.Equal(t, "third-party-jwt", container.Env[1].Value)
+	assert.Equal(t, "CA_ADDR", container.Env[2].Name)
+	assert.Equal(t, "istiod.istio-system.svc:15012", container.Env[2].Value)
+	assert.Equal(t, "PILOT_CERT_PROVIDER", container.Env[3].Name)
+	assert.Equal(t, "istiod", container.Env[3].Value)
+	assert.Equal(t, "POD_NAME", container.Env[4].Name)
+	assert.Equal(t, "metadata.name", container.Env[4].ValueFrom.FieldRef.FieldPath)
+	assert.Equal(t, "POD_NAMESPACE", container.Env[5].Name)
+	assert.Equal(t, "metadata.namespace", container.Env[5].ValueFrom.FieldRef.FieldPath)
+	assert.Equal(t, "INSTANCE_IP", container.Env[6].Name)
+	assert.Equal(t, "status.podIP", container.Env[6].ValueFrom.FieldRef.FieldPath)
+	assert.Equal(t, "SERVICE_ACCOUNT", container.Env[7].Name)
+	assert.Equal(t, "spec.serviceAccountName", container.Env[7].ValueFrom.FieldRef.FieldPath)
+	assert.Equal(t, "HOST_IP", container.Env[8].Name)
+	assert.Equal(t, "status.hostIP", container.Env[8].ValueFrom.FieldRef.FieldPath)
+	assert.Equal(t, "ISTIO_META_POD_NAME", container.Env[9].Name)
+	assert.Equal(t, "metadata.name", container.Env[9].ValueFrom.FieldRef.FieldPath)
+	assert.Equal(t, "ISTIO_META_CONFIG_NAMESPACE", container.Env[10].Name)
+	assert.Equal(t, "metadata.namespace", container.Env[10].ValueFrom.FieldRef.FieldPath)
+	assert.Equal(t, "ISTIO_META_MESH_ID", container.Env[11].Name)
+	assert.Equal(t, "cluster.local", container.Env[11].Value)
+	assert.Equal(t, "ISTIO_META_CLUSTER_ID", container.Env[12].Name)
+	assert.Equal(t, "Kubernetes", container.Env[12].Value)
+
+	assert.Equal(t, 1, len(container.Ports))
+	assert.Equal(t, int32(15090), container.Ports[0].ContainerPort)
+	assert.Equal(t, "http-envoy-prom", container.Ports[0].Name)
+	assert.Equal(t, corev1.ProtocolTCP, container.Ports[0].Protocol)
+
+	assert.Equal(t, int32(30), container.ReadinessProbe.FailureThreshold)
+	assert.Equal(t, "/healthz/ready", container.ReadinessProbe.HTTPGet.Path)
+	assert.Equal(t, intstr.Int, container.ReadinessProbe.HTTPGet.Port.Type)
+	assert.Equal(t, int32(15020), container.ReadinessProbe.HTTPGet.Port.IntVal)
+	assert.Equal(t, corev1.URISchemeHTTP, container.ReadinessProbe.HTTPGet.Scheme)
+	assert.Equal(t, int32(1), container.ReadinessProbe.InitialDelaySeconds)
+	assert.Equal(t, int32(2), container.ReadinessProbe.PeriodSeconds)
+	assert.Equal(t, int32(1), container.ReadinessProbe.SuccessThreshold)
+	assert.Equal(t, int32(1), container.ReadinessProbe.TimeoutSeconds)
+
+	assert.Equal(t, 4, len(container.VolumeMounts))
+	assert.Equal(t, "/var/run/secrets/istio", container.VolumeMounts[0].MountPath)
+	assert.Equal(t, "istiod-ca-cert", container.VolumeMounts[0].Name)
+	assert.Equal(t, "/etc/istio/proxy", container.VolumeMounts[1].MountPath)
+	assert.Equal(t, "istio-envoy", container.VolumeMounts[1].Name)
+	assert.Equal(t, "/var/run/secrets/tokens", container.VolumeMounts[2].MountPath)
+	assert.Equal(t, "istio-token", container.VolumeMounts[2].Name)
+	assert.Equal(t, constants.PrometheusIstioCertsMountPath, container.VolumeMounts[3].MountPath)
+	assert.Equal(t, "istio-certs", container.VolumeMounts[3].Name)
 }

--- a/pkg/resources/deployments/prometheus_test.go
+++ b/pkg/resources/deployments/prometheus_test.go
@@ -36,7 +36,7 @@ func TestPrometheusDeploymentsNoStorage(t *testing.T) {
 
 	assert.Equal(t, 4, len(promDeployment.Spec.Template.Spec.Containers), "Length of generated containers")
 	assert.Equal(t, 7, len(promDeployment.Spec.Template.Spec.Volumes), "Length of generated volumes")
-	assert.Equal(t, 3, len(promDeployment.Spec.Template.Spec.Containers[0].VolumeMounts), "Length of generated mounts for Prometheus node")
+	assert.Equal(t, 4, len(promDeployment.Spec.Template.Spec.Containers[0].VolumeMounts), "Length of generated mounts for Prometheus node")
 	assert.Equal(t, 0, len(promDeployment.Spec.Template.Spec.Containers[2].VolumeMounts), "Length of generated mounts for Node exporter")
 	assert.Equal(t, 3, len(deployments), "Length of generated deployments")
 }
@@ -67,7 +67,7 @@ func TestPrometheusDeploymentsWithStorage(t *testing.T) {
 	}
 	assert.Equal(t, 4, len(promDeployment.Spec.Template.Spec.Containers), "Length of generated containers")
 	assert.Equal(t, 7, len(promDeployment.Spec.Template.Spec.Volumes), "Length of generated volumes")
-	assert.Equal(t, 3, len(promDeployment.Spec.Template.Spec.Containers[0].VolumeMounts), "Length of generated mounts for Prometheus node")
+	assert.Equal(t, 4, len(promDeployment.Spec.Template.Spec.Containers[0].VolumeMounts), "Length of generated mounts for Prometheus node")
 	assert.Equal(t, 1, len(promDeployment.Spec.Template.Spec.Containers[2].VolumeMounts), "Length of generated mounts for Node exporter")
 	assert.Equal(t, 3, len(deployments), "Length of generated deployments")
 }

--- a/run-vmo.sh
+++ b/run-vmo.sh
@@ -40,6 +40,7 @@ set +x
 echo ""
   
 # Extract the images required by verrazzano-operator from values.yaml into environment variables.
+export ISTIO_PROXY_IMAGE=$(grep istioProxyImage ${VERRAZZANO_INSTALLER_REPO}//values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
 export GRAFANA_IMAGE=$(grep grafanaImage ${VERRAZZANO_INSTALLER_REPO}//values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
 export PROMETHEUS_IMAGE=$(grep prometheusImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
 export PROMETHEUS_INIT_IMAGE=$(grep prometheusInitImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
@@ -66,6 +67,7 @@ export WATCH_NAMESPACE=${WATCH_NAMESPACE:-""}
 cat <<EOF
 Variables:
 
+ISTIO_PROXY_IMAGE=${ISTIO_PROXY_IMAGE}
 GRAFANA_IMAGE=${GRAFANA_IMAGE}
 PROMETHEUS_IMAGE=${PROMETHEUS_IMAGE}
 PROMETHEUS_INIT_IMAGE=${PROMETHEUS_INIT_IMAGE}


### PR DESCRIPTION
This pull request adds the istio-proxy sidecar containing certs to Prometheus.  This allows Prometheus to scrape metrics for pods that are in the Istio mesh with mutual TLS enabled.