### PR TITLE
oidc oauth reverse proxy sidecar

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -98,6 +98,9 @@ const ESHttpPort = 9200
 // ESTransportPort default Elasticsearch transport port
 const ESTransportPort = 9300
 
+// OidcProxyPort default OidcProxy HTTP port
+const OidcProxyPort = 8775
+
 // DefaultDevProfileESMemArgs default Elasticsearch dev mode memory settings
 const DefaultDevProfileESMemArgs = "-Xms512m -Xmx512m"
 

--- a/pkg/constants/oidc_proxy.go
+++ b/pkg/constants/oidc_proxy.go
@@ -1,0 +1,565 @@
+// Copyright (C) 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package constants
+
+// OidcCallbackPath is the callback URL path of OIDC authentication redirect
+const OidcCallbackPath = "/_authentication_callback"
+
+// OidcConfLua defines the conf.lua file name in OIDC proxy ConfigMap
+const OidcConfLua = "conf.lua"
+
+// OidcConfLuaTemp is the template of conf.lua file in OIDC proxy ConfigMap
+const OidcConfLuaTemp = `-- conf.lua
+    local ingressUri = 'https://'..'%s'
+    local oidcProviderHost = "%s"
+    local oidcProviderHostInCluster = "%s"
+    local realm ="%s"
+    local callbackPath = "%s"
+    local oidcClient = "%s"
+    local oidcDirectAccessClient = "%s"
+    local cookieKey = "%s"
+    local authStateTtlInSec = %v
+    local bearerServiceAccountToken = false
+
+    local oidcProviderInClusterUri = ""
+    if oidcProviderHostInCluster and oidcProviderHostInCluster ~= "" then
+        oidcProviderInClusterUri = 'http://'..oidcProviderHostInCluster..'/auth/realms/'..realm
+    end
+    local oidcProviderUri = 'https://'..oidcProviderHost.. '/auth/realms/'..realm
+    
+    local auth = require("auth").config({
+        ingressUri = ingressUri,
+        callbackPath = callbackPath,
+        callbackUri = ingressUri..callbackPath,
+        oidcProviderUri = oidcProviderUri,
+        oidcProviderAuthUri = oidcProviderUri..'/protocol/openid-connect/auth',
+        oidcProviderInClusterUri = oidcProviderInClusterUri,
+        oidcClient = oidcClient,
+        oidcDirectAccessClient = oidcDirectAccessClient,
+        authStateTtlInSec = authStateTtlInSec,
+        cookieKey = cookieKey,
+        bearerServiceAccountToken = bearerServiceAccountToken
+    })
+    ngx.header["Access-Control-Allow-Origin"] =  ngx.req.get_headers()["origin"]
+    ngx.header["Access-Control-Allow-Headers"] =  "authorization"
+    if ngx.req.get_method() == "OPTIONS" then
+        ngx.status = 200
+        ngx.exit(ngx.HTTP_OK)
+    end
+    auth.info("Extracting authorization header from request.")
+    local authHeader = ngx.req.get_headers()["authorization"]
+    if not authHeader then
+        if string.find(ngx.var.request_uri, callbackPath) then
+            auth.handleCallback()
+        end
+        if auth.authenticated() then
+            return
+        else
+            auth.authenticate()
+        end
+    else
+        auth.authHeader(authHeader) 
+    end
+`
+
+// OidcAuthLua defines the auth.lua file name in OIDC proxy ConfigMap
+const OidcAuthLua = "auth.lua"
+
+// OidcAuthLuaScripts is the content of auth.lua file in OIDC proxy ConfigMap
+const OidcAuthLuaScripts = `-- auth.lua
+    local me = {}
+    local random = require("resty.random")
+    local base64 = require("ngx.base64")
+    local cjson = require "cjson"
+    local jwt = require "resty.jwt"
+    
+    function me.config(opts)
+        for key, val in pairs(opts) do
+            me[key] = val
+        end
+        local aes = require "resty.aes"
+        me.aes256 = aes:new(me.cookieKey, nil, aes.cipher(256))
+        return me
+    end
+    
+    function me.log(logLevel, msg, name, value)
+        local logObj = {message = msg}
+        if name then
+            logObj[name] = value
+        end
+        ngx.log(logLevel,  cjson.encode(logObj))
+    end
+    
+    function me.logJson(logLevel, msg, err)
+        if err then
+            me.log(logLevel, msg, 'error', err)
+        else
+            me.log(logLevel, msg)
+        end
+    end
+      
+    function me.info(msg, obj)
+        if obj then
+            me.log(ngx.INFO, msg, 'object', obj)
+        else
+            me.log(ngx.INFO, msg)
+        end
+    end
+      
+    function me.queryParams(req_uri)
+         local i = req_uri:find("?")
+         if not i then
+             i = 0
+         else
+             i = i + 1
+         end
+         return ngx.decode_args(req_uri:sub(i), 0)
+    end
+      
+    function me.query(req_uri, name)
+        local i = req_uri:find("&"..name.."=")
+        if not i then
+        i = req_uri:find("?"..name.."=")
+        end
+        if not i then
+            return nil
+        else
+            local begin = i+2+name:len()
+            local endin = req_uri:find("&", begin)
+            if not endin then
+                return req_uri:sub(begin)
+            end
+            return req_uri:sub(begin, endin-1)
+        end
+    end
+      
+    function me.unauthorized(msg, err)
+        ngx.status = 401
+        me.logJson(ngx.ERR, meg, err)
+        ngx.exit(ngx.HTTP_UNAUTHORIZED)
+    end
+      
+    function me.randomBase64(size)
+        local randBytes = random.bytes(size)
+        return base64.encode_base64url(randBytes)
+    end
+      
+    function me.read_file(path)
+        local file = io.open(path, "rb")
+        if not file then return nil end
+        local content = file:read "*a"
+        file:close()
+        return content
+    end
+
+    function me.authenticate()
+        local sha256 = (require 'resty.sha256'):new()
+        local codeVerifier = me.randomBase64(32)
+        sha256:update(codeVerifier)
+        local codeChallenge = base64.encode_base64url(sha256:final())
+        local state = me.randomBase64(32)
+        local nonce = me.randomBase64(32)
+        local stateData = {
+            state = state,
+            request_uri = ngx.var.request_uri,
+            code_verifier = codeVerifier,
+            code_challenge = codeChallenge,
+            nonce = nonce
+        }
+        local redirectArgs = ngx.encode_args({
+            client_id = me.oidcClient,
+            response_type = 'code',
+            scope = 'openid',
+            code_challenge_method = 'S256',
+            code_challenge = codeChallenge,
+            state = state,
+            nonce = nonce,
+            redirect_uri = me.callbackUri
+        })
+        local redirtURL = me.oidcProviderAuthUri..'?'..redirectArgs
+        me.setCookie("state", stateData, me.authStateTtlInSec)
+        ngx.header["Cache-Control"] = "no-cache, no-store, max-age=0"
+        ngx.redirect(redirtURL)
+    end
+      
+    function me.tokenRequest(formArgs) 
+        local tokenUri = me.oidcProviderUri.."/protocol/openid-connect/token"
+        if me.oidcProviderInClusterUri and me.oidcProviderInClusterUri ~= "" then
+            tokenUri = me.oidcProviderInClusterUri.."/protocol/openid-connect/token" 
+        end
+        local http = require "resty.http"
+        local httpc = http.new()
+        local res, err = httpc:request_uri(tokenUri, {
+            method = "POST",
+            body = ngx.encode_args(formArgs),
+            headers = {
+                ["Content-Type"] = "application/x-www-form-urlencoded",
+            }
+        })
+        -- ,keepalive_timeout = 60000,
+        -- keepalive_pool = 10
+        return cjson.decode(res.body)
+    end
+      
+    function me.authenticated()
+        local ck = me.readCookie("authn")
+        if ck then
+            local rft = ck.rt
+            local now = ngx.time()
+            local expiry = tonumber(ck.expiry)
+            local refresh_expiry = tonumber(ck.refresh_expiry)
+            if now > refresh_expiry then
+                -- refresh_token expired, redirt to authenticate
+                me.authenticate()
+            else
+                if now > expiry then
+                    -- token expired refresh
+                    local tokenRef = me.tokenToCookie({
+                        grant_type = 'refresh_token',
+                        client_id = me.oidcClient,
+                        refresh_token = rft,
+                        redirect_uri = me.callbackUri
+                    })
+                    me.info("token refreshed",  tokenRef)
+                end
+            end
+        end
+        return ck
+    end
+      
+    function me.handleCallback() 
+        local queryParams = me.queryParams(ngx.var.request_uri)
+        local state = queryParams.state
+        local code = queryParams.code
+        local nonce = queryParams.nonce
+        local cookie = me.readCookie("state")
+        if not cookie then
+            me.log(ngx.ERR, "Missing callback state redirect to authenticate")
+            me.authenticate()
+        end
+        local stateCk = cookie.state
+        -- local nonceCk = cookie.nonce
+        local request_uri = cookie.request_uri
+
+        if (state == nil) or (stateCk == nil) then
+            me.log(ngx.ERR, "Missing callback state redirect to authenticate")
+            me.authenticate()
+        else
+            if state ~= stateCk then
+                me.log(ngx.ERR, "Invalid callback state redirect to authenticate")
+                me.authenticate()
+            end
+            if not cookie.code_verifier then
+                me.log(ngx.ERR, "Invalid callback state redirect to authenticate")
+                me.authenticate()
+            end
+            local formArgs = {
+                grant_type = 'authorization_code',
+                client_id = me.oidcClient,
+                code = code,
+                code_verifier = cookie.code_verifier,
+                redirect_uri = me.callbackUri
+            } 
+            local tokenRes = me.tokenToCookie(formArgs)
+            ngx.redirect(request_uri) 
+        end
+    end
+      
+    function me.tokenToCookie(formArgs) 
+        local tokenRes = me.tokenRequest(formArgs)
+        -- Do we need access_token? too big > 4k
+        local cookiePairs = {
+            rt = tokenRes.refresh_token,
+            -- at = tokenRes.access_token,
+            it = tokenRes.id_token
+        }
+        local id_token = jwt:load_jwt(tokenRes.id_token)
+        local expires_in = tonumber(tokenRes.expires_in)
+        local refresh_expires_in = tonumber(tokenRes.refresh_expires_in)
+        local now = ngx.time()
+        local issued_at = now
+        if id_token and id_token.payload then
+            if id_token.payload.iat then
+                issued_at = tonumber(id_token.payload.iat)
+            else
+                if id_token.payload.auth_time then
+                    issued_at = tonumber(id_token.payload.auth_time)
+                end
+            end
+            --if id_token.payload.email then
+            --    cookiePairs.email = id_token.payload.email
+            --end
+        end
+        local skew = now - issued_at
+        -- Expire 30 secs before actual time
+        local expiryBuffer = 30 
+        cookiePairs.expiry = now + expires_in - skew - expiryBuffer
+        cookiePairs.refresh_expiry = now + refresh_expires_in - skew - expiryBuffer
+        me.setCookie("authn", cookiePairs, tonumber(tokenRes.refresh_expires_in)-expiryBuffer) 
+    end
+
+    function me.setCookie(ckName, cookiePairs, expiresInSec) 
+        local expires = ngx.cookie_time(ngx.time() + expiresInSec)
+        local attributes = "; Path=/; Secure; HttpOnly; Expires="..expires
+        local encrypted = me.aes256:encrypt(cjson.encode(cookiePairs))
+        local cookie = base64.encode_base64url(encrypted)
+        ngx.header["Set-Cookie"] = ckName..'='..cookie..attributes
+    end
+
+    function me.readCookie(ckName)
+        if not ckName then
+            return nil
+        end
+        local cookie, err = require("resty.cookie"):new()
+        local ck = cookie:get(ckName)
+        if not ck then
+            return nil
+        end
+        local decoded = base64.decode_base64url(ck)
+        if not decoded then
+            return nil
+        end
+        local json = me.aes256:decrypt(decoded)
+        if not json then    
+            return nil
+        end
+        return cjson.decode(json) 
+    end
+      
+    -- handle auth header: Authorization: <type> <credentials>
+    function me.authHeader(authHeader)
+        local found, index = authHeader:find('Bearer')
+        if found then
+            me.info("Extract jwt token from authorization header.")
+            local token = string.sub(authHeader, index+2)
+            me.handleBearer(token) 
+        else
+            found, index = authHeader:find('Basic')
+            if found then
+                local basicCred = string.sub(authHeader, index+2)
+                me.handleBasicAuth(basicCred) 
+            else
+                me.unauthorized("Invalid authorization header "..authHeader)
+            end
+        end
+    end
+
+    local certs = {}
+    function me.realmCerts(kid) 
+        local pk = certs[kid]	
+        if pk then
+            return pk
+        end
+        local http = require "resty.http"
+        local httpc = http.new()
+        local providerUri = me.oidcProviderUri
+        if me.oidcProviderInClusterUri and me.oidcProviderInClusterUri ~= "" then
+            providerUri = me.oidcProviderInClusterUri
+        end
+        local certsUri = providerUri..'/protocol/openid-connect/certs'
+        local res, err = httpc:request_uri(certsUri)
+        if err then
+            return nil
+        end
+        local data = cjson.decode(res.body)
+        if not (data.keys) then
+            return nil
+        end
+        for i, key in pairs(data.keys) do
+            if key.kid and key.x5c then
+                certs[key.kid] = key.x5c
+            end
+        end
+        return certs[kid]
+    end
+
+    function me.publicKey(kid) 
+        local x5c = me.realmCerts(kid)
+        if (not x5c) or (#x5c == 0) then
+            return nil
+        end
+        return "-----BEGIN CERTIFICATE-----\n"..x5c[1].."\n-----END CERTIFICATE-----"
+    end
+    
+    function me.handleBearer(token) 
+        if not (token) then
+            me.unauthorized("Invalid bearer token in authorization header")    
+        end
+        me.logJson(ngx.INFO, "Validate JWT token.")
+        local jwt = require "resty.jwt"
+        local jwt_obj = jwt:load_jwt(token)
+        if (not jwt_obj.header) or (not jwt_obj.header.kid) then
+            me.unauthorized("Invalid JWT token", jwt_obj.reason)
+        end
+        local publicKey = me.publicKey(jwt_obj.header.kid)
+        if not publicKey then
+            me.unauthorized("No public_key retreived from keycloak")
+        end
+        local verified = jwt:verify_jwt_obj(publicKey, jwt_obj)
+        if (tostring(jwt_obj.valid) == "false" or tostring(jwt_obj.verified) == "false") then
+            me.unauthorized("Invalid JWT token", jwt_obj.reason)
+        end
+        me.logJson(ngx.INFO, "Check for groups in jwt token.")
+        if ( not (jwt_obj.payload) or not (jwt_obj.payload.groups)) then
+            me.unauthorized("No groups asscoiated with user.")
+        end
+        ngx.req.clear_header("Authorization")
+        if jwt_obj.payload and jwt_obj.payload.email then
+            ngx.header['x-proxy-user'] = jwt_obj.payload.email
+        end
+        if jwt_obj.payload and jwt_obj.payload.k8s_user then
+            ngx.header['x-k8s-user'] = jwt_obj.payload.k8s_user
+        end
+        for i,group in pairs(jwt_obj.payload.groups) do
+            ngx.req.set_header("Impersonate-Group", group)
+        end
+        if me.bearerServiceAccountToken then
+            me.logJson(ngx.INFO, "Check for k8s_user in jwt token.")
+            if ( not (jwt_obj.payload) or not (jwt_obj.payload.k8s_user)) then
+               me.unauthorized("No k8s_user asscoiated with user.")
+            end
+            me.logJson(ngx.INFO, "Read service account token.")
+            local serviceAccountToken = me.read_file("/run/secrets/kubernetes.io/serviceaccount/token");
+            if not (serviceAccountToken) then
+               me.unauthorized("No service account token presnet in pod.")
+            end
+            ngx.req.set_header("Authorization", "Bearer " .. serviceAccountToken)
+            ngx.req.set_header("Impersonate-User", jwt_obj.payload.k8s_user)
+        end
+    end
+      
+    local basicCache = {}
+      
+    function me.handleBasicAuth(basicCred) 
+        local now = ngx.time() 
+        local basicAuth = basicCache[basicCred]
+        if basicAuth and (now < basicAuth.expiry) then
+            return
+        end
+        local decode = ngx.decode_base64(basicCred)
+        local found = decode:find(':')
+        if not found then
+            me.unauthorized("Invalid BasicAuth authorization header")
+        end
+        local u = decode:sub(1, found-1)
+        local p = decode:sub(found+1)
+        local formArgs = {
+            grant_type = 'password',
+            client_id = me.oidcDirectAccessClient,
+            password = p,
+            username = u
+        }
+        local tokenRes = me.tokenRequest(formArgs)
+        if tokenRes.error or tokenRes.error_description then
+            me.unauthorized(tokenRes.error_description)
+        end
+        local refresh_expires_in = tonumber(tokenRes.refresh_expires_in)
+        for key, val in pairs(basicCache) do
+            if val.expiry and now > val.expiry then
+                basicCache[key] = nil
+            end
+        end
+        basicCache[basicCred] = {
+            -- access_token = tokenRes.access_token,
+            id_token = tokenRes.id_token,
+            expiry = now + refresh_expires_in
+        }
+    end
+      
+    return me
+`
+
+// OidcNginxConf defines the nginx.lua file name in OIDC proxy ConfigMap
+const OidcNginxConf = "nginx.conf"
+
+// OidcNginxConfTemp is the template of nginx.conf file in OIDC proxy ConfigMap
+const OidcNginxConfTemp = `#user  nobody;
+worker_processes  1;
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+#pid        logs/nginx.pid;
+events {
+    worker_connections  1024;
+}
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    #                  '$status $body_bytes_sent "$http_referer" '
+    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+    error_log  logs/error.log  info;
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+    #
+    lua_package_path '/usr/local/share/lua/5.1/?.lua;;';
+    lua_package_cpath '/usr/local/lib/lua/5.1/?.so;;';
+    resolver _NAMESERVER_;
+    # cache for discovery metadata documents
+    lua_shared_dict discovery 1m;
+    #  cache for JWKs
+    lua_shared_dict jwks 1m;
+
+    upstream http_backend {
+        server  %s:%v  fail_timeout=30s max_fails=10;
+    }
+    server {
+        listen       8775;
+        server_name  apiserver;
+        root     /opt/nginx/html;
+        #charset koi8-r;
+
+        rewrite_by_lua_file /etc/nginx/conf.lua;
+        #access_log  logs/host.access.log  main;
+        expires           0;
+        add_header        Cache-Control private;
+        location / {
+            proxy_pass http://http_backend;
+        }
+
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+
+        #error_page  404              /404.html;
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   html;
+        }
+    }
+}
+`
+
+// OidcStartup defines the startup.sh file name in OIDC proxy ConfigMap
+const OidcStartup = "startup.sh"
+
+// OidcStartupTemp is the template of startup.sh file in OIDC proxy ConfigMap
+const OidcStartupTemp = `#!/bin/bash
+startupDir=%s
+cd $startupDir
+cp $startupDir/nginx.conf /etc/nginx/nginx.conf
+cp $startupDir/auth.lua /etc/nginx/auth.lua
+cp $startupDir/conf.lua /etc/nginx/conf.lua
+nameserver=$(grep -i nameserver /etc/resolv.conf | awk '{split($0,line," "); print line[2]}')
+sed -i -e "s|_NAMESERVER_|${nameserver}|g" /etc/nginx/nginx.conf
+mkdir -p /usr/local/nginx/logs
+touch /usr/local/nginx/logs/error.log
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+/usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -t
+/usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf
+while [ $? -ne 0 ]; do
+    sleep 20
+    echo "retry nginx startup ..."
+    /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf
+done
+tail -f /usr/local/nginx/logs/error.log
+`

--- a/pkg/resources/deployments/deployment_test.go
+++ b/pkg/resources/deployments/deployment_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestVMOEmptyDeploymentSize(t *testing.T) {
@@ -270,6 +270,8 @@ func TestVMOWithResourceConstraints(t *testing.T) {
 			// No resources specified on API endpoint
 		} else if deployment.Name == resources.GetMetaName(vmo.Name, config.PrometheusGW.Name) {
 			// No resources specified on Prometheus GW
+		} else if deployment.Name == resources.OidcProxyMetaName(vmo.Name, config.ElasticsearchIngest.Name) {
+			// No resources specified on OIDC proxy
 		} else {
 			t.Log("ESDataName: " + esDataName)
 			t.Error("Unknown Deployment Name: " + deployment.Name)

--- a/pkg/resources/deployments/elasticsearch.go
+++ b/pkg/resources/deployments/elasticsearch.go
@@ -112,7 +112,11 @@ func (es ElasticsearchBasic) createElasticsearchIngestDeploymentElements(vmo *vm
 		corev1.EnvVar{Name: "node.data", Value: "false"},
 		corev1.EnvVar{Name: "ES_JAVA_OPTS", Value: javaOpts},
 	)
-
+	if config.ElasticsearchIngest.OidcProxy != nil {
+		oidcVolume, oidcProxy := resources.CreateOidcProxy(vmo, &vmo.Spec.Elasticsearch.IngestNode.Resources, &config.ElasticsearchIngest)
+		elasticsearchIngestDeployment.Spec.Template.Spec.Volumes = append(elasticsearchIngestDeployment.Spec.Template.Spec.Volumes, *oidcVolume)
+		elasticsearchIngestDeployment.Spec.Template.Spec.Containers = append(elasticsearchIngestDeployment.Spec.Template.Spec.Containers, *oidcProxy)
+	}
 	return []*appsv1.Deployment{elasticsearchIngestDeployment}
 }
 

--- a/pkg/resources/deployments/prometheus_test.go
+++ b/pkg/resources/deployments/prometheus_test.go
@@ -36,8 +36,8 @@ func TestPrometheusDeploymentsNoStorage(t *testing.T) {
 		t.Error(err)
 	}
 
-	assert.Equal(t, 4, len(promDeployment.Spec.Template.Spec.Containers), "Length of generated containers")
-	assert.Equal(t, 7, len(promDeployment.Spec.Template.Spec.Volumes), "Length of generated volumes")
+	assert.Equal(t, 5, len(promDeployment.Spec.Template.Spec.Containers), "Length of generated containers")
+	assert.Equal(t, 8, len(promDeployment.Spec.Template.Spec.Volumes), "Length of generated volumes")
 	assert.Equal(t, 4, len(promDeployment.Spec.Template.Spec.Containers[0].VolumeMounts), "Length of generated mounts for Prometheus node")
 	assert.Equal(t, 0, len(promDeployment.Spec.Template.Spec.Containers[2].VolumeMounts), "Length of generated mounts for Node exporter")
 	assert.Equal(t, 3, len(deployments), "Length of generated deployments")
@@ -67,8 +67,8 @@ func TestPrometheusDeploymentsWithStorage(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	assert.Equal(t, 4, len(promDeployment.Spec.Template.Spec.Containers), "Length of generated containers")
-	assert.Equal(t, 7, len(promDeployment.Spec.Template.Spec.Volumes), "Length of generated volumes")
+	assert.Equal(t, 5, len(promDeployment.Spec.Template.Spec.Containers), "Length of generated containers")
+	assert.Equal(t, 8, len(promDeployment.Spec.Template.Spec.Volumes), "Length of generated volumes")
 	assert.Equal(t, 4, len(promDeployment.Spec.Template.Spec.Containers[0].VolumeMounts), "Length of generated mounts for Prometheus node")
 	assert.Equal(t, 1, len(promDeployment.Spec.Template.Spec.Containers[2].VolumeMounts), "Length of generated mounts for Node exporter")
 	assert.Equal(t, 3, len(deployments), "Length of generated deployments")

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -48,11 +48,22 @@ func createElasticsearchDataServiceElements(vmo *vmcontrollerv1.VerrazzanoMonito
 	return elasticsearchDataService
 }
 
+func createElasticsearchOidcProxyService(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *corev1.Service {
+	service := resources.OidcProxyService(vmo, &config.ElasticsearchIngest)
+	if resources.IsSingleNodeESCluster(vmo) {
+		service.Spec.Selector = resources.GetSpecID(vmo.Name, config.ElasticsearchMaster.Name)
+	}
+	return service
+}
+
 // Creates *all* Elasticsearch service elements
 func createElasticsearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) []*corev1.Service {
 	var services []*corev1.Service
 	services = append(services, createElasticsearchIngestServiceElements(vmo))
 	services = append(services, createElasticsearchMasterServiceElements(vmo))
 	services = append(services, createElasticsearchDataServiceElements(vmo))
+	if config.ElasticsearchIngest.OidcProxy != nil {
+		services = append(services, createElasticsearchOidcProxyService(vmo))
+	}
 	return services
 }

--- a/pkg/resources/services/elasticsearch_test.go
+++ b/pkg/resources/services/elasticsearch_test.go
@@ -4,15 +4,16 @@
 package services
 
 import (
+	"testing"
+
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestElasticsearchDefaultServices1(t *testing.T) {
@@ -30,14 +31,14 @@ func TestElasticsearchDefaultServices1(t *testing.T) {
 		},
 	}
 	services := createElasticsearchServiceElements(vmo)
-	assert.Equal(t, 3, len(services), "Length of generated services")
+	assert.Equal(t, 4, len(services), "Length of generated services")
 }
 
 func TestElasticsearchDevProfileDefaultServices(t *testing.T) {
 	vmo := createDevProfileES()
 
 	services := createElasticsearchServiceElements(vmo)
-	assert.Equal(t, 3, len(services), "Length of generated services")
+	assert.Equal(t, 4, len(services), "Length of generated services")
 
 	ingestService := services[0]
 	masterService := services[1]

--- a/pkg/resources/services/service.go
+++ b/pkg/resources/services/service.go
@@ -20,12 +20,18 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*corev1.Service, e
 	if vmo.Spec.Grafana.Enabled {
 		service := createServiceElement(vmo, config.Grafana)
 		services = append(services, service)
+		if config.Grafana.OidcProxy != nil {
+			services = append(services, resources.OidcProxyService(vmo, &config.Grafana))
+		}
 	}
 	if vmo.Spec.Prometheus.Enabled {
 		service := createServiceElement(vmo, config.Prometheus)
 		service.Spec.Ports = append(service.Spec.Ports, resources.GetServicePort(config.NodeExporter))
 		services = append(services, service)
 		services = append(services, createServiceElement(vmo, config.PrometheusGW))
+		if config.Prometheus.OidcProxy != nil {
+			services = append(services, resources.OidcProxyService(vmo, &config.Prometheus))
+		}
 	}
 	if vmo.Spec.AlertManager.Enabled {
 		alertManagerService := createServiceElement(vmo, config.AlertManager)
@@ -43,6 +49,9 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*corev1.Service, e
 	if vmo.Spec.Kibana.Enabled {
 		service := createServiceElement(vmo, config.Kibana)
 		services = append(services, service)
+		if config.Kibana.OidcProxy != nil {
+			services = append(services, resources.OidcProxyService(vmo, &config.Kibana))
+		}
 	}
 
 	services = append(services, createServiceElement(vmo, config.API))

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -5,8 +5,9 @@ package statefulsets
 
 import (
 	"fmt"
-	"go.uber.org/zap"
 	"strings"
+
+	"go.uber.org/zap"
 
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
@@ -208,6 +209,11 @@ fi`,
 				},
 			},
 		}
+	}
+	if resources.IsSingleNodeESCluster(vmo) && config.ElasticsearchIngest.OidcProxy != nil {
+		oidcConfig, oidcProxy := resources.CreateOidcProxy(vmo, &vmo.Spec.Elasticsearch.MasterNode.Resources, &config.ElasticsearchIngest)
+		statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes, *oidcConfig)
+		statefulSet.Spec.Template.Spec.Containers = append(statefulSet.Spec.Template.Spec.Containers, *oidcProxy)
 	}
 	return statefulSet
 }

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -5,12 +5,13 @@ package statefulsets
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"strings"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
@@ -321,7 +322,7 @@ func verifyElasticSearchDevProfile(t *testing.T, vmo *vmcontrollerv1.VerrazzanoM
 	assert.Equal(elasticsearchUID, *sts.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser,
 		"Incorrect Elasticsearch.SecurityContext.RunAsUser")
 
-	assert.Len(sts.Spec.Template.Spec.Containers, 1, "Incorrect number of Containers")
+	assert.Len(sts.Spec.Template.Spec.Containers, 2, "Incorrect number of Containers")
 	assert.Len(sts.Spec.Template.Spec.Containers[0].Ports, 2, "Incorrect number of Ports")
 	assert.Equal("transport", sts.Spec.Template.Spec.Containers[0].Ports[0].Name, "Incorrect Container Port")
 	assert.Zero(sts.Spec.Template.Spec.Containers[0].Ports[0].HostPort, "Incorrect Container HostPort")
@@ -381,7 +382,7 @@ func verifyElasticSearchDevProfile(t *testing.T, vmo *vmcontrollerv1.VerrazzanoM
 	assert.Len(sts.Spec.VolumeClaimTemplates, 0, "Incorrect number of VolumeClaimTemplates")
 
 	volumes := sts.Spec.Template.Spec.Volumes
-	assert.Len(volumes, 1)
+	assert.Len(volumes, 2)
 	assert.Equal(esMasterVolName, volumes[0].Name, "Incorrect name for master volume")
 	volumeSource := volumes[0].VolumeSource
 	assert.NotNil(volumeSource.EmptyDir, "volumeSource should be EmptyDir")

--- a/pkg/vmo/configmap_test.go
+++ b/pkg/vmo/configmap_test.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package vmo
+
+import (
+	"context"
+	"testing"
+
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+
+	"github.com/stretchr/testify/assert"
+	vmctl "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestCreateConfigmaps(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	controller := &Controller{
+		kubeclientset:   client,
+		configMapLister: &simpleConfigMapLister{kubeClient: client},
+	}
+	vmo := &vmctl.VerrazzanoMonitoringInstance{}
+	vmo.Name = "system"
+	vmo.Namespace = "verrazzano-system"
+	vmo.Spec.URI = "vmi.system.v8o-env.oracledx.com"
+	vmo.Spec.Grafana.DashboardsConfigMap = "myDashboardsConfigMap"
+	vmo.Spec.Grafana.DatasourcesConfigMap = "myDatasourcesConfigMap"
+	vmo.Spec.AlertManager.ConfigMap = "myAlertManagerConfigMap"
+	vmo.Spec.AlertManager.VersionsConfigMap = "myAlertManagerVersionsConfigMap"
+	vmo.Spec.Prometheus.RulesConfigMap = "myPrometheusRulesConfigMap"
+	vmo.Spec.Prometheus.RulesVersionsConfigMap = "myPrometheusRulesVersionsConfigMap"
+	vmo.Spec.Prometheus.ConfigMap = "myPrometheusConfigMap"
+	vmo.Spec.Prometheus.VersionsConfigMap = "myPrometheusVersionsConfigMap"
+	err := CreateConfigmaps(controller, vmo)
+	assert.Nil(t, err)
+	all, _ := client.CoreV1().ConfigMaps(vmo.Namespace).List(context.TODO(), metav1.ListOptions{})
+	assert.Equal(t, 12, len(all.Items))
+}
+
+// simple ConfigMapLister implementation
+type simpleConfigMapLister struct {
+	kubeClient kubernetes.Interface
+}
+
+// lists all ConfigMaps
+func (s *simpleConfigMapLister) List(selector labels.Selector) ([]*v1.ConfigMap, error) {
+	namespaces, err := s.kubeClient.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var pods []*v1.ConfigMap
+	for _, namespace := range namespaces.Items {
+
+		list, err := s.ConfigMaps(namespace.Name).List(selector)
+		if err != nil {
+			return nil, err
+		}
+		pods = append(pods, list...)
+	}
+	return pods, nil
+}
+
+// ConfigMaps returns an object that can list and get ConfigMaps.
+func (s *simpleConfigMapLister) ConfigMaps(namespace string) corelistersv1.ConfigMapNamespaceLister {
+	return simpleConfigMapNamespaceLister{
+		namespace:  namespace,
+		kubeClient: s.kubeClient,
+	}
+}
+
+// configMapNamespaceLister implements the ConfigMapNamespaceLister
+// interface.
+type simpleConfigMapNamespaceLister struct {
+	namespace  string
+	kubeClient kubernetes.Interface
+}
+
+// List lists all ConfigMaps for a given namespace.
+func (s simpleConfigMapNamespaceLister) List(selector labels.Selector) ([]*v1.ConfigMap, error) {
+	var configMaps []*v1.ConfigMap
+
+	list, err := s.kubeClient.CoreV1().ConfigMaps(s.namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range list.Items {
+		if selector.Matches(labels.Set(list.Items[i].Labels)) {
+			configMaps = append(configMaps, &list.Items[i])
+		}
+	}
+	return configMaps, nil
+}
+
+// Get retrieves the ConfigMap for a given namespace and name.
+func (s simpleConfigMapNamespaceLister) Get(name string) (*v1.ConfigMap, error) {
+	return s.kubeClient.CoreV1().ConfigMaps(s.namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}

--- a/run-vmo.sh
+++ b/run-vmo.sh
@@ -54,6 +54,7 @@ export ELASTICSEARCH_INIT_IMAGE=$(grep esInitImage ${VERRAZZANO_INSTALLER_REPO}/
 export VERRAZZANO_MONITORING_INSTANCE_API_IMAGE=$(grep monitoringInstanceApiImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
 export CONFIG_RELOADER_IMAGE=$(grep configReloaderImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
 export NODE_EXPORTER_IMAGE=$(grep nodeExporterImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml | head -1 | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
+export OIDC_PROXY_IMAGE=$(grep oidcProxyImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml | head -1 | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
 
 # Extract the API server realm from values.yaml.
 export API_SERVER_REALM=$(grep apiServerRealm ${VERRAZZANO_INSTALLER_REPO}/values.yaml | cut -d':' -f2 | sed -e 's/^[[:space:]]*//')
@@ -81,6 +82,7 @@ ELASTICSEARCH_INIT_IMAGE=${ELASTICSEARCH_INIT_IMAGE}
 VERRAZZANO_MONITORING_INSTANCE_API_IMAGE=${VERRAZZANO_MONITORING_INSTANCE_API_IMAGE}
 CONFIG_RELOADER_IMAGE=${CONFIG_RELOADER_IMAGE}
 NODE_EXPORTER_IMAGE=${NODE_EXPORTER_IMAGE}
+OIDC_PROXY_IMAGE=${OIDC_PROXY_IMAGE}
 
 WATCH_VMI=${WATCH_VMI}
 WATCH_NAMESPACE=${WATCH_NAMESPACE}


### PR DESCRIPTION
Add oidc oauth reverse proxy sidecar to elasticsearch, prometheus, kibana, and grafana
* redirect unauthenticated browser access to keycloak to login
* require Bearer type authorization header for API access
* continue to support Basic auth for API access