### PR TITLE
Remove verrazzano-monitoring-instance-api image from Verrazzano 

### DIFF
--- a/pkg/config/components.go
+++ b/pkg/config/components.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"go.uber.org/zap"
 	"os"
 	"strings"
 
@@ -26,6 +27,8 @@ type ComponentDetails struct {
 	RunAsUser         int64
 	EnvName           string
 	OidcProxy         *ComponentDetails
+	Optional          bool
+	Disabled          bool
 }
 
 // AllComponentDetails is array of all ComponentDetails
@@ -180,6 +183,7 @@ var API = ComponentDetails{
 	LivenessHTTPPath:  "/healthcheck",
 	ReadinessHTTPPath: "/healthcheck",
 	Privileged:        false,
+	Optional:          true,
 }
 
 // ConfigReloader is the default config-reloader configuration
@@ -216,7 +220,12 @@ func InitComponentDetails() error {
 		if len(component.EnvName) > 0 {
 			component.Image = os.Getenv(component.EnvName)
 			if len(component.Image) == 0 {
-				return fmt.Errorf("The environment variable %s translated to an empty string for component %s", component.EnvName, component.Name)
+				if !component.Optional {
+					return fmt.Errorf("The environment variable %s translated to an empty string for component %s", component.EnvName, component.Name)
+				}
+				// if no image is provided for an optional component then disable it
+				zap.S().Infof("The environment variable %s translated to an empty string for optional component %s.  Marking component disabled.", component.EnvName, component.Name)
+				component.Disabled = true
 			}
 		}
 		if !oidcAuthEnabled {

--- a/pkg/config/components_test.go
+++ b/pkg/config/components_test.go
@@ -13,19 +13,56 @@ import (
 )
 
 func TestNoImages(t *testing.T) {
+	unsetEnvVars(t, AllComponentDetails)
 	err := InitComponentDetails()
 	assert.Error(t, err)
 }
 
 func TestAllImages(t *testing.T) {
-	// Create environment variable for each component
+	createEnvVars(t, AllComponentDetails)
+	testImages(t, AllComponentDetails, nil)
+}
+
+func TestOptionalImages(t *testing.T) {
+	var components = []*ComponentDetails{}
+	var optionalComponents = []*ComponentDetails{}
+
+	// separate the optional components
 	for _, component := range AllComponentDetails {
+		if component.Optional {
+			optionalComponents = append(optionalComponents, component)
+		} else {
+			components = append(components, component)
+		}
+	}
+	createEnvVars(t, components)
+	unsetEnvVars(t, optionalComponents)
+	testImages(t, components, optionalComponents)
+}
+
+func createEnvVars(t *testing.T, components []*ComponentDetails) {
+	// Create environment variable for each component
+	for _, component := range components {
 		if len(component.EnvName) > 0 {
 			zap.S().Infof("Setting environment variable %s", component.EnvName)
 			err := os.Setenv(component.EnvName, "TEST")
 			assert.Nil(t, err, fmt.Sprintf("setting environment variable %s", component.EnvName))
 		}
 	}
+}
+
+func unsetEnvVars(t *testing.T, components []*ComponentDetails) {
+	// Unset variable for each component
+	for _, component := range components {
+		if len(component.EnvName) > 0 {
+			zap.S().Infof("Unsetting environment variable %s", component.EnvName)
+			err := os.Unsetenv(component.EnvName)
+			assert.Nil(t, err, fmt.Sprintf("unsetting environment variable %s", component.EnvName))
+		}
+	}
+}
+
+func testImages(t *testing.T, components []*ComponentDetails, disabledComponents []*ComponentDetails) {
 	err := os.Setenv(eswaitTargetVersionEnv, "es.TEST")
 	assert.Nil(t, err, fmt.Sprintf("setting environment variable %s", eswaitTargetVersionEnv))
 
@@ -33,9 +70,13 @@ func TestAllImages(t *testing.T) {
 	assert.Nil(t, err, "Expected initComponentDetails to succeed")
 
 	// Test the image names were set as expected
-	for _, component := range AllComponentDetails {
+	for _, component := range components {
 		if len(component.EnvName) > 0 {
 			assert.Equal(t, "TEST", component.Image, fmt.Sprintf("checking image name field for %s", component.Name))
 		}
+	}
+	// Test the disabled status is set as expected
+	for _, component := range disabledComponents {
+		assert.True(t, component.Disabled, fmt.Sprintf("checking disabled status for %s", component.Name))
 	}
 }

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -188,25 +188,27 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, operatorConfig *confi
 	}
 
 	// API
-	deployment := createDeploymentElement(vmo, nil, nil, config.API)
-	deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = config.API.ImagePullPolicy
-	deployment.Spec.Replicas = resources.NewVal(vmo.Spec.API.Replicas)
-	deployment.Spec.Template.Spec.Affinity = resources.CreateZoneAntiAffinityElement(vmo.Name, config.API.Name)
-	deployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
-		{Name: "VMI_NAME", Value: vmo.Name},
-		{Name: "NAMESPACE", Value: vmo.Namespace},
-		{Name: "ENV_NAME", Value: operatorConfig.EnvName},
-	}
-	if len(vmo.Spec.NatGatewayIPs) > 0 {
-		deployment.Spec.Template.Spec.Containers[0].Args = []string{fmt.Sprintf("--natGatewayIPs=%s", strings.Join(vmo.Spec.NatGatewayIPs, ","))}
-	}
+	if !config.API.Disabled {
+		deployment := createDeploymentElement(vmo, nil, nil, config.API)
+		deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = config.API.ImagePullPolicy
+		deployment.Spec.Replicas = resources.NewVal(vmo.Spec.API.Replicas)
+		deployment.Spec.Template.Spec.Affinity = resources.CreateZoneAntiAffinityElement(vmo.Name, config.API.Name)
+		deployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+			{Name: "VMI_NAME", Value: vmo.Name},
+			{Name: "NAMESPACE", Value: vmo.Namespace},
+			{Name: "ENV_NAME", Value: operatorConfig.EnvName},
+		}
+		if len(vmo.Spec.NatGatewayIPs) > 0 {
+			deployment.Spec.Template.Spec.Containers[0].Args = []string{fmt.Sprintf("--natGatewayIPs=%s", strings.Join(vmo.Spec.NatGatewayIPs, ","))}
+		}
 
-	deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds = 15
-	deployment.Spec.Template.Spec.Containers[0].LivenessProbe.TimeoutSeconds = 3
-	deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds = 5
-	deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TimeoutSeconds = 3
+		deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds = 15
+		deployment.Spec.Template.Spec.Containers[0].LivenessProbe.TimeoutSeconds = 3
+		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds = 5
+		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TimeoutSeconds = 3
 
-	deployments = append(deployments, deployment)
+		deployments = append(deployments, deployment)
+	}
 
 	return deployments, err
 }

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -109,21 +109,23 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*extensions_v1beta
 	}
 
 	// Create Ingress Rule for API Endpoint
-	ingRule := createIngressRuleElement(vmo, config.API)
-	host := config.API.Name + "." + vmo.Spec.URI
-	healthLocations := noAuthOnHealthCheckSnippet(vmo, "", config.API)
-	ingress, err := createIngressElement(vmo, host, config.API, ingRule, healthLocations)
-	if err != nil {
-		return ingresses, err
+	if !config.API.Disabled {
+		ingRule := createIngressRuleElement(vmo, config.API)
+		host := config.API.Name + "." + vmo.Spec.URI
+		healthLocations := noAuthOnHealthCheckSnippet(vmo, "", config.API)
+		ingress, err := createIngressElement(vmo, host, config.API, ingRule, healthLocations)
+		if err != nil {
+			return ingresses, err
+		}
+		ingresses = append(ingresses, ingress)
 	}
-	ingresses = append(ingresses, ingress)
 
 	if vmo.Spec.Grafana.Enabled {
 		if config.Grafana.OidcProxy != nil {
 			ingresses = append(ingresses, newOidcProxyIngress(vmo, &config.Grafana))
 		} else {
 			// Create Ingress Rule for Grafana Endpoint
-			ingRule = createIngressRuleElement(vmo, config.Grafana)
+			ingRule := createIngressRuleElement(vmo, config.Grafana)
 			host := config.Grafana.Name + "." + vmo.Spec.URI
 			ingress, err := createIngressElementNoBasicAuth(vmo, host, config.Grafana, ingRule)
 			if err != nil {
@@ -133,10 +135,10 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*extensions_v1beta
 		}
 	}
 	if vmo.Spec.Prometheus.Enabled {
-		ingRule = createIngressRuleElement(vmo, config.PrometheusGW)
-		host = config.PrometheusGW.Name + "." + vmo.Spec.URI
-		healthLocations = noAuthOnHealthCheckSnippet(vmo, "", config.PrometheusGW)
-		ingress, err = createIngressElement(vmo, host, config.PrometheusGW, ingRule, healthLocations)
+		ingRule := createIngressRuleElement(vmo, config.PrometheusGW)
+		host := config.PrometheusGW.Name + "." + vmo.Spec.URI
+		healthLocations := noAuthOnHealthCheckSnippet(vmo, "", config.PrometheusGW)
+		ingress, err := createIngressElement(vmo, host, config.PrometheusGW, ingRule, healthLocations)
 		if err != nil {
 			return ingresses, err
 		}
@@ -157,10 +159,10 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*extensions_v1beta
 	}
 	if vmo.Spec.AlertManager.Enabled {
 		// Create Ingress Rule for AlertManager Endpoint
-		ingRule = createIngressRuleElement(vmo, config.AlertManager)
-		host = config.AlertManager.Name + "." + vmo.Spec.URI
-		healthLocations = noAuthOnHealthCheckSnippet(vmo, "", config.AlertManager)
-		ingress, err = createIngressElement(vmo, host, config.AlertManager, ingRule, healthLocations)
+		ingRule := createIngressRuleElement(vmo, config.AlertManager)
+		host := config.AlertManager.Name + "." + vmo.Spec.URI
+		healthLocations := noAuthOnHealthCheckSnippet(vmo, "", config.AlertManager)
+		ingress, err := createIngressElement(vmo, host, config.AlertManager, ingRule, healthLocations)
 		if err != nil {
 			return ingresses, err
 		}
@@ -171,11 +173,11 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*extensions_v1beta
 			ingresses = append(ingresses, newOidcProxyIngress(vmo, &config.Kibana))
 		} else {
 			// Create Ingress Rule for Kibana Endpoint
-			ingRule = createIngressRuleElement(vmo, config.Kibana)
+			ingRule := createIngressRuleElement(vmo, config.Kibana)
 			host := config.Kibana.Name + "." + vmo.Spec.URI
-			healthLocations = noAuthOnHealthCheckSnippet(vmo, "", config.Kibana)
+			healthLocations := noAuthOnHealthCheckSnippet(vmo, "", config.Kibana)
 
-			ingress, err = createIngressElement(vmo, host, config.Kibana, ingRule, healthLocations)
+			ingress, err := createIngressElement(vmo, host, config.Kibana, ingRule, healthLocations)
 			if err != nil {
 				return ingresses, err
 			}
@@ -187,10 +189,10 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*extensions_v1beta
 			ingresses = append(ingresses, newOidcProxyIngress(vmo, &config.ElasticsearchIngest))
 		} else {
 			var ingress *extensions_v1beta1.Ingress
-			ingRule = createIngressRuleElement(vmo, config.ElasticsearchIngest)
-			host = config.ElasticsearchIngest.EndpointName + "." + vmo.Spec.URI
-			healthLocations = noAuthOnHealthCheckSnippet(vmo, "", config.ElasticsearchIngest)
-			ingress, err = createIngressElement(vmo, host, config.ElasticsearchIngest, ingRule, healthLocations)
+			ingRule := createIngressRuleElement(vmo, config.ElasticsearchIngest)
+			host := config.ElasticsearchIngest.EndpointName + "." + vmo.Spec.URI
+			healthLocations := noAuthOnHealthCheckSnippet(vmo, "", config.ElasticsearchIngest)
+			ingress, err := createIngressElement(vmo, host, config.ElasticsearchIngest, ingRule, healthLocations)
 			if err != nil {
 				return ingresses, err
 			}

--- a/pkg/resources/services/service.go
+++ b/pkg/resources/services/service.go
@@ -53,8 +53,9 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*corev1.Service, e
 			services = append(services, resources.OidcProxyService(vmo, &config.Kibana))
 		}
 	}
-
-	services = append(services, createServiceElement(vmo, config.API))
+	if !config.API.Disabled {
+		services = append(services, createServiceElement(vmo, config.API))
+	}
 
 	return services, nil
 }


### PR DESCRIPTION
Required for: VZ-2452

Changes to VMO to allow for the removal of the verrazzano-monitoring-instance-api image completely from Verrazzano `platform-operator/helm_config/charts/verrazzano/values.yaml`.

- Allow for optional components.
- Disable optional components if image is not specified.
- Make API component optional.
- Check for disabled flag for API component.
- Add unit test for optional components.

