### PR TITLE
VZ-2347: Verrazzano Monitoring Instances (VMIs) should use Keycloak for authZ

### DIFF
--- a/pkg/constants/oidc_proxy.go
+++ b/pkg/constants/oidc_proxy.go
@@ -136,7 +136,7 @@ const OidcAuthLuaScripts = `-- auth.lua
       
     function me.unauthorized(msg, err)
         ngx.status = 401
-        me.logJson(ngx.ERR, meg, err)
+        me.logJson(ngx.ERR, msg, err)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
       
@@ -210,7 +210,7 @@ const OidcAuthLuaScripts = `-- auth.lua
             local expiry = tonumber(ck.expiry)
             local refresh_expiry = tonumber(ck.refresh_expiry)
             if now > refresh_expiry then
-                -- refresh_token expired, redirt to authenticate
+                -- refresh_token expired, redirect to authenticate
                 me.authenticate()
             else
                 if now > expiry then
@@ -394,7 +394,7 @@ const OidcAuthLuaScripts = `-- auth.lua
         end
         local publicKey = me.publicKey(jwt_obj.header.kid)
         if not publicKey then
-            me.unauthorized("No public_key retreived from keycloak")
+            me.unauthorized("No public_key retrieved from keycloak")
         end
         local verified = jwt:verify_jwt_obj(publicKey, jwt_obj)
         if (tostring(jwt_obj.valid) == "false" or tostring(jwt_obj.verified) == "false") then
@@ -402,7 +402,7 @@ const OidcAuthLuaScripts = `-- auth.lua
         end
         me.logJson(ngx.INFO, "Check for groups in jwt token.")
         if ( not (jwt_obj.payload) or not (jwt_obj.payload.groups)) then
-            me.unauthorized("No groups asscoiated with user.")
+            me.unauthorized("No groups associated with user.")
         end
         ngx.req.clear_header("Authorization")
         if jwt_obj.payload and jwt_obj.payload.email then
@@ -417,7 +417,7 @@ const OidcAuthLuaScripts = `-- auth.lua
         if me.bearerServiceAccountToken then
             me.logJson(ngx.INFO, "Check for k8s_user in jwt token.")
             if ( not (jwt_obj.payload) or not (jwt_obj.payload.k8s_user)) then
-               me.unauthorized("No k8s_user asscoiated with user.")
+               me.unauthorized("No k8s_user associated with user.")
             end
             me.logJson(ngx.INFO, "Read service account token.")
             local serviceAccountToken = me.read_file("/run/secrets/kubernetes.io/serviceaccount/token");

--- a/pkg/constants/oidc_proxy.go
+++ b/pkg/constants/oidc_proxy.go
@@ -6,6 +6,9 @@ package constants
 // OidcCallbackPath is the callback URL path of OIDC authentication redirect
 const OidcCallbackPath = "/_authentication_callback"
 
+// OidcLogoutCallbackPath is the callback URL path after logout
+const OidcLogoutCallbackPath = "/_logout"
+
 // OidcConfLua defines the conf.lua file name in OIDC proxy ConfigMap
 const OidcConfLua = "conf.lua"
 
@@ -16,9 +19,11 @@ const OidcConfLuaTemp = `-- conf.lua
     local oidcProviderHostInCluster = "%s"
     local realm ="%s"
     local callbackPath = "%s"
+    local logoutCallbackPath = "%s"
     local oidcClient = "%s"
     local oidcDirectAccessClient = "%s"
     local cookieKey = "%s"
+    local requiredRole = "%s"
     local authStateTtlInSec = %v
     local bearerServiceAccountToken = false
 
@@ -32,6 +37,7 @@ const OidcConfLuaTemp = `-- conf.lua
         ingressUri = ingressUri,
         callbackPath = callbackPath,
         callbackUri = ingressUri..callbackPath,
+        logoutCallbackUri = ingressUri..logoutCallbackPath,
         oidcProviderUri = oidcProviderUri,
         oidcProviderAuthUri = oidcProviderUri..'/protocol/openid-connect/auth',
         oidcProviderInClusterUri = oidcProviderInClusterUri,
@@ -52,9 +58,23 @@ const OidcConfLuaTemp = `-- conf.lua
     if not authHeader then
         if string.find(ngx.var.request_uri, callbackPath) then
             auth.handleCallback()
+        elseif string.find(ngx.var.request_uri, logoutCallbackPath) then
+            auth.handleLogoutCallback()
         end
-        if auth.authenticated() then
-            return
+        local ck = auth.authenticated()
+        if ck then
+            if ck.realm_roles then
+                for _, role in ipairs(ck.realm_roles) do
+                    if role == requiredRole then
+                        return
+                    end
+                end
+                auth.logout()
+                return
+            else
+                auth.logout()
+                return
+            end
         else
             auth.authenticate()
         end
@@ -135,11 +155,18 @@ const OidcAuthLuaScripts = `-- auth.lua
     end
       
     function me.unauthorized(msg, err)
-        ngx.status = 401
+        ngx.status = ngx.HTTP_UNAUTHORIZED
         me.logJson(ngx.ERR, msg, err)
         ngx.exit(ngx.HTTP_UNAUTHORIZED)
     end
       
+    function me.forbidden(msg, err)
+        ngx.status = ngx.HTTP_FORBIDDEN
+        me.deleteCookie("authn")
+        me.logJson(ngx.ERR, msg, err)
+        ngx.exit(ngx.HTTP_FORBIDDEN)
+    end
+
     function me.randomBase64(size)
         local randBytes = random.bytes(size)
         return base64.encode_base64url(randBytes)
@@ -265,7 +292,19 @@ const OidcAuthLuaScripts = `-- auth.lua
             ngx.redirect(request_uri) 
         end
     end
-      
+
+    function me.logout()
+        local redirectArgs = ngx.encode_args({
+            redirect_uri = me.logoutCallbackUri
+        })
+        local redirURL = me.oidcProviderUri.."/protocol/openid-connect/logout?"..redirectArgs
+        ngx.redirect(redirURL)
+    end
+
+    function me.handleLogoutCallback()
+        me.forbidden("User does not have a required realm role")
+    end
+
     function me.tokenToCookie(formArgs) 
         local tokenRes = me.tokenRequest(formArgs)
         -- Do we need access_token? too big > 4k
@@ -287,6 +326,9 @@ const OidcAuthLuaScripts = `-- auth.lua
                     issued_at = tonumber(id_token.payload.auth_time)
                 end
             end
+            if id_token.payload.realm_access and id_token.payload.realm_access.roles then
+                cookiePairs.realm_roles = id_token.payload.realm_access.roles
+            end
             --if id_token.payload.email then
             --    cookiePairs.email = id_token.payload.email
             --end
@@ -305,6 +347,10 @@ const OidcAuthLuaScripts = `-- auth.lua
         local encrypted = me.aes256:encrypt(cjson.encode(cookiePairs))
         local cookie = base64.encode_base64url(encrypted)
         ngx.header["Set-Cookie"] = ckName..'='..cookie..attributes
+    end
+
+    function me.deleteCookie(ckName)
+        ngx.header["Set-Cookie"] = ckName..'=; Path=/; Secure; HttpOnly; Expires=Thu, 01 Jan 1970 00:00:00 UTC;'
     end
 
     function me.readCookie(ckName)

--- a/pkg/vmo/configmap.go
+++ b/pkg/vmo/configmap.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package vmo
@@ -298,10 +298,12 @@ func oidcConfLuaScripts(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compon
 		oidcProviderHostInCluster,
 		"verrazzano-system", //realm
 		constants.OidcCallbackPath,
+		constants.OidcLogoutCallbackPath,
 		"webui",     //oidc-client-id
 		"admin-cli", //direct-access client
 		randomString(32),
-		300) //authn state TTL
+		"console_users", // required realm role
+		300)             //authn state TTL
 }
 
 func addOidcProxyConfig(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) (string, error) {


### PR DESCRIPTION
This adds role checking to the Lua sidecar scripts used in the VMIs. If the user does not have the "console_users" keycloak realm role, the user will see a 403 Forbidden error when attempting to access any of the VMI consoles.

I tested this with one user that does not have the role and one user that does have the role and verified the behavior is as expected. Once this PR is merged and a new VMO is built, I will submit a Verrazzano Platform Operator PR that pulls in the latest version of the VMO and also includes updates to the keycloak.json configuration to add the realm role and make it default.