### PR TITLE
VZ-2347: Add support for asserting user identity to Grafana

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -55,11 +55,17 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, operatorConfig *confi
 			}...)
 		} else {
 			deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, []corev1.EnvVar{
-				{Name: "GF_AUTH_ANONYMOUS_ENABLED", Value: "true"},
+				{Name: "GF_AUTH_ANONYMOUS_ENABLED", Value: "false"},
 				{Name: "GF_AUTH_BASIC_ENABLED", Value: "false"},
 				{Name: "GF_USERS_ALLOW_SIGN_UP", Value: "false"},
+				{Name: "GF_USERS_AUTO_ASSIGN_ORG", Value: "true"},
+				{Name: "GF_USERS_AUTO_ASSIGN_ORG_ROLE", Value: "Editor"},
 				{Name: "GF_AUTH_DISABLE_LOGIN_FORM", Value: "true"},
 				{Name: "GF_AUTH_DISABLE_SIGNOUT_MENU", Value: "true"},
+				{Name: "GF_AUTH_PROXY_ENABLED", Value: "true"},
+				{Name: "GF_AUTH_PROXY_HEADER_NAME", Value: "X-WEBAUTH-USER"},
+				{Name: "GF_AUTH_PROXY_HEADER_PROPERTY", Value: "username"},
+				{Name: "GF_AUTH_PROXY_AUTO_SIGN_UP", Value: "true"},
 			}...)
 		}
 		if vmo.Spec.URI != "" {


### PR DESCRIPTION
This PR extends the VMI auth proxy to assert the user's identity to Grafana. The changes include overriding Grafana config to enable auth, setting an nginx variable based on the OIDC username, and adding a proxy header with that username. Grafana then uses that username and creates a local user.

I tested this with the verrazzano user and also created a new user in keycloak and it looks like it's doing the right thing. Grafana shows the current user in the lower left of the window, and you can view the user profile.