### PR TITLE
VZ-2347: Re-enable Grafana anonymous auth

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -55,7 +55,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, operatorConfig *confi
 			}...)
 		} else {
 			deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, []corev1.EnvVar{
-				{Name: "GF_AUTH_ANONYMOUS_ENABLED", Value: "false"},
+				{Name: "GF_AUTH_ANONYMOUS_ENABLED", Value: "true"},
 				{Name: "GF_AUTH_BASIC_ENABLED", Value: "false"},
 				{Name: "GF_USERS_ALLOW_SIGN_UP", Value: "false"},
 				{Name: "GF_USERS_AUTO_ASSIGN_ORG", Value: "true"},


### PR DESCRIPTION
I had disabled anonymous auth for Grafana when I added identity assertion, which works fine when accessing the Grafana UI, but it breaks accessing the Grafana API. This PR re-enables anonymous auth until I can work out a solution with @wmhopkins.

Note this does NOT disable security. We still require authN and authZ, this just allows requests that don't assert the user's identity to Grafana.
