### PR TITLE
VZ-2347: More authZ updates

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -55,7 +55,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, operatorConfig *confi
 			}...)
 		} else {
 			deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, []corev1.EnvVar{
-				{Name: "GF_AUTH_ANONYMOUS_ENABLED", Value: "true"},
+				{Name: "GF_AUTH_ANONYMOUS_ENABLED", Value: "false"},
 				{Name: "GF_AUTH_BASIC_ENABLED", Value: "false"},
 				{Name: "GF_USERS_ALLOW_SIGN_UP", Value: "false"},
 				{Name: "GF_USERS_AUTO_ASSIGN_ORG", Value: "true"},

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -55,7 +55,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, operatorConfig *confi
 			}...)
 		} else {
 			deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, []corev1.EnvVar{
-				{Name: "GF_AUTH_ANONYMOUS_ENABLED", Value: "false"},
+				{Name: "GF_AUTH_ANONYMOUS_ENABLED", Value: "true"},
 				{Name: "GF_AUTH_BASIC_ENABLED", Value: "false"},
 				{Name: "GF_USERS_ALLOW_SIGN_UP", Value: "false"},
 				{Name: "GF_USERS_AUTO_ASSIGN_ORG", Value: "true"},

--- a/pkg/vmo/configmap.go
+++ b/pkg/vmo/configmap.go
@@ -299,8 +299,8 @@ func oidcConfLuaScripts(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compon
 		"verrazzano-system", //realm
 		constants.OidcCallbackPath,
 		constants.OidcLogoutCallbackPath,
-		"webui",     //oidc-client-id
-		"admin-cli", //direct-access client
+		"webui",                   //oidc-client-id
+		"verrazzano-oauth-client", //direct-access client
 		randomString(32),
 		"console_users", // required realm role
 		300)             //authn state TTL


### PR DESCRIPTION
This PR adds role checking and Grafana identity propagation to the basic auth path. Previously I was only doing the role check and identity propagation for the VMI console UI flow. After looking through the code and talking to Will, I added the same role check and identity propagation to the basic auth flow. This fixes hitting the Grafana API using basic auth.

I refactored the Lua script a bit to support code re-use in the multiple auth paths. I also removed the roles and username from the "authn" cookie.