### PR TITLE
client_max_body_size for fluentd/elasticsearch

### DIFF
--- a/pkg/constants/oidc_proxy.go
+++ b/pkg/constants/oidc_proxy.go
@@ -560,7 +560,7 @@ http {
     error_log  logs/error.log  info;
     sendfile        on;
     #tcp_nopush     on;
-
+    client_max_body_size 65m;
     #keepalive_timeout  0;
     keepalive_timeout  65;
 


### PR DESCRIPTION
increase client_max_body_size to fix  "HTTP 413 (Request Entity Too Large)"
* nginx defaults it to 1MB which is too small for fluentd and caused errors of "HTTP 413 (Request Entity Too Large)"
