### PR TITLE
JIRA:VZ-2518 Annotations to allow communication between ES resources

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -182,6 +182,12 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, operatorConfig *confi
 			deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, oidcVolumes...)
 			deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, *oidcProxy)
 		}
+		// add the required istio annotations to allow inter-es component communication
+		if deployment.Spec.Template.Annotations == nil {
+			deployment.Spec.Template.Annotations = make(map[string]string)
+		}
+		deployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9200"
+
 		deployments = append(deployments, deployment)
 	}
 

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -186,7 +186,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, operatorConfig *confi
 		if deployment.Spec.Template.Annotations == nil {
 			deployment.Spec.Template.Annotations = make(map[string]string)
 		}
-		deployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9200"
+		deployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9200,9300"
 
 		deployments = append(deployments, deployment)
 	}

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -186,7 +186,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, operatorConfig *confi
 		if deployment.Spec.Template.Annotations == nil {
 			deployment.Spec.Template.Annotations = make(map[string]string)
 		}
-		deployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9200,9300"
+		deployment.Spec.Template.Annotations["traffic.sidecar.istio.io/includeOutboundPorts"] = fmt.Sprintf("%d", constants.ESHttpPort)
 
 		deployments = append(deployments, deployment)
 	}

--- a/pkg/resources/deployments/elasticsearch.go
+++ b/pkg/resources/deployments/elasticsearch.go
@@ -117,6 +117,13 @@ func (es ElasticsearchBasic) createElasticsearchIngestDeploymentElements(vmo *vm
 		elasticsearchIngestDeployment.Spec.Template.Spec.Volumes = append(elasticsearchIngestDeployment.Spec.Template.Spec.Volumes, oidcVolumes...)
 		elasticsearchIngestDeployment.Spec.Template.Spec.Containers = append(elasticsearchIngestDeployment.Spec.Template.Spec.Containers, *oidcProxy)
 	}
+	// add the required istio annotations to allow inter-es component communication
+	if elasticsearchIngestDeployment.Spec.Template.Annotations == nil {
+		elasticsearchIngestDeployment.Spec.Template.Annotations = make(map[string]string)
+	}
+	elasticsearchIngestDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = "9200,9300"
+	elasticsearchIngestDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9300"
+
 	return []*appsv1.Deployment{elasticsearchIngestDeployment}
 }
 
@@ -183,6 +190,13 @@ func (es ElasticsearchBasic) createElasticsearchDataDeploymentElements(vmo *vmco
 			corev1.EnvVar{Name: "node.data", Value: "true"},
 			corev1.EnvVar{Name: "ES_JAVA_OPTS", Value: javaOpts},
 		)
+
+		// add the required istio annotations to allow inter-es component communication
+		if elasticsearchDataDeployment.Spec.Template.Annotations == nil {
+			elasticsearchDataDeployment.Spec.Template.Annotations = make(map[string]string)
+		}
+		elasticsearchDataDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = "9300"
+		elasticsearchDataDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9300"
 
 		deployList = append(deployList, elasticsearchDataDeployment)
 	}

--- a/pkg/resources/deployments/elasticsearch.go
+++ b/pkg/resources/deployments/elasticsearch.go
@@ -121,8 +121,8 @@ func (es ElasticsearchBasic) createElasticsearchIngestDeploymentElements(vmo *vm
 	if elasticsearchIngestDeployment.Spec.Template.Annotations == nil {
 		elasticsearchIngestDeployment.Spec.Template.Annotations = make(map[string]string)
 	}
-	elasticsearchIngestDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = "9200,9300"
-	elasticsearchIngestDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9300"
+	elasticsearchIngestDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = fmt.Sprintf("%d", constants.ESTransportPort)
+	elasticsearchIngestDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = fmt.Sprintf("%d", constants.ESTransportPort)
 
 	return []*appsv1.Deployment{elasticsearchIngestDeployment}
 }
@@ -195,8 +195,8 @@ func (es ElasticsearchBasic) createElasticsearchDataDeploymentElements(vmo *vmco
 		if elasticsearchDataDeployment.Spec.Template.Annotations == nil {
 			elasticsearchDataDeployment.Spec.Template.Annotations = make(map[string]string)
 		}
-		elasticsearchDataDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = "9300"
-		elasticsearchDataDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9300"
+		elasticsearchDataDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = fmt.Sprintf("%d", constants.ESTransportPort)
+		elasticsearchDataDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = fmt.Sprintf("%d", constants.ESTransportPort)
 
 		deployList = append(deployList, elasticsearchDataDeployment)
 	}

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -220,8 +220,8 @@ fi`,
 	if statefulSet.Spec.Template.Annotations == nil {
 		statefulSet.Spec.Template.Annotations = make(map[string]string)
 	}
-	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = "9200,9300"
-	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9200,9300"
+	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = fmt.Sprintf("%d", constants.ESTransportPort)
+	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = fmt.Sprintf("%d", constants.ESTransportPort)
 
 	return statefulSet
 }

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -220,8 +220,8 @@ fi`,
 	if statefulSet.Spec.Template.Annotations == nil {
 		statefulSet.Spec.Template.Annotations = make(map[string]string)
 	}
-	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = "9300"
-	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9300"
+	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = "9200,9300"
+	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9200,9300"
 
 	return statefulSet
 }

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -215,6 +215,14 @@ fi`,
 		statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes, oidcVolumes...)
 		statefulSet.Spec.Template.Spec.Containers = append(statefulSet.Spec.Template.Spec.Containers, *oidcProxy)
 	}
+
+	// add istio annotations required for inter component communication
+	if statefulSet.Spec.Template.Annotations == nil {
+		statefulSet.Spec.Template.Annotations = make(map[string]string)
+	}
+	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = "9300"
+	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "9300"
+
 	return statefulSet
 }
 


### PR DESCRIPTION
The ES deployments/stateful sets had to be updated to allow communication between ES resources that isn't proxied by the istio envoys