### PR TITLE
Scrape NGINX ingress controller metrics only on the port specified by prometheus.io/port

### DIFF
--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -283,6 +283,11 @@ scrape_configs:
    - source_labels: [__meta_kubernetes_namespace]
      action: replace
      target_label: kubernetes_namespace
+   - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+     action: replace
+     regex: ([^:]+)(?::\d+)?;(\d+)
+     replacement: $1:10254
+     target_label: __address__
    - source_labels: [__meta_kubernetes_pod_name]
      action: replace
      target_label: kubernetes_pod_name

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -217,7 +217,6 @@ func GetDefaultPrometheusConfiguration(vmo *vmcontrollerv1.VerrazzanoMonitoringI
 	re := regexp.MustCompile("[^a-zA-Z0-9_]")
 	prometheusValidLabelName := re.ReplaceAllString(vmo.Name, "")
 	dynamicScrapeAnnotation := prometheusValidLabelName + "_io_scrape"
-	namespace := vmo.Namespace
 	nginxNamespace := "ingress-nginx"
 	istioNamespace := "istio-system"
 	var prometheusConfig = []byte(`
@@ -267,12 +266,11 @@ scrape_configs:
      target_label: __metrics_path__
      replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
 
- - job_name: 'kubernetes-pods'
+ - job_name: 'nginx-ingress-controller'
    kubernetes_sd_configs:
    - role: pod
      namespaces:
        names:
-         - "` + namespace + `"
          - "` + nginxNamespace + `"
    relabel_configs:
    - source_labels: [__meta_kubernetes_pod_annotation_` + dynamicScrapeAnnotation + `]

--- a/pkg/resources/helper_test.go
+++ b/pkg/resources/helper_test.go
@@ -43,12 +43,12 @@ func TestGetDefaultPrometheusConfiguration(t *testing.T) {
 	role = kubernetesSdConfigs.([]interface{})[0].(map[interface{}]interface{})["role"]
 	assert.Equal(t, "pod", role, "kubernetes_sd_configs should have - role: pod")
 
-	kubernetesPods := getItem("job_name", "kubernetes-pods", scrapeConfigs.([]interface{}))
-	assert.NotNil(t, kubernetesPods)
-	kubernetesSdConfigs = kubernetesPods["kubernetes_sd_configs"]
+	ingressController := getItem("job_name", "nginx-ingress-controller", scrapeConfigs.([]interface{}))
+	assert.NotNil(t, ingressController)
+	kubernetesSdConfigs = ingressController["kubernetes_sd_configs"]
 	role = kubernetesSdConfigs.([]interface{})[0].(map[interface{}]interface{})["role"]
 	assert.Equal(t, "pod", role, "kubernetes_sd_configs should have - role: pod")
-	relabelConfigs = kubernetesPods["relabel_configs"]
+	relabelConfigs = ingressController["relabel_configs"]
 	relabelConfig = getItem("target_label", "__address__", relabelConfigs.([]interface{}))
 	assert.Equal(t, "$1:10254", relabelConfig["replacement"], "relabelConfig.replacement")
 }

--- a/pkg/resources/helper_test.go
+++ b/pkg/resources/helper_test.go
@@ -42,6 +42,15 @@ func TestGetDefaultPrometheusConfiguration(t *testing.T) {
 	kubernetesSdConfigs = envoyStats["kubernetes_sd_configs"]
 	role = kubernetesSdConfigs.([]interface{})[0].(map[interface{}]interface{})["role"]
 	assert.Equal(t, "pod", role, "kubernetes_sd_configs should have - role: pod")
+
+	kubernetesPods := getItem("job_name", "kubernetes-pods", scrapeConfigs.([]interface{}))
+	assert.NotNil(t, kubernetesPods)
+	kubernetesSdConfigs = kubernetesPods["kubernetes_sd_configs"]
+	role = kubernetesSdConfigs.([]interface{})[0].(map[interface{}]interface{})["role"]
+	assert.Equal(t, "pod", role, "kubernetes_sd_configs should have - role: pod")
+	relabelConfigs = kubernetesPods["relabel_configs"]
+	relabelConfig = getItem("target_label", "__address__", relabelConfigs.([]interface{}))
+	assert.Equal(t, "$1:10254", relabelConfig["replacement"], "relabelConfig.replacement")
 }
 
 func getItem(key, value string, scrapeConfigs []interface{}) map[interface{}]interface{} {


### PR DESCRIPTION
This PR changes renames the job kubernetes-pods to nginx-ingress-controller, after removing the verrazzano-system namespace from the job. As part of this change, the job configuration is updated to scrape NGINX ingress controller metrics only on port 10254. As part of NGINX ingress controller installation, Verrazzano overrides the chart value prometheus.io/port to set "10254". 