### PR TITLE
Remove status.hash

### DIFF
--- a/pkg/apis/vmcontroller/v1/types.go
+++ b/pkg/apis/vmcontroller/v1/types.go
@@ -4,9 +4,6 @@
 package v1
 
 import (
-	"encoding/json"
-	"hash/fnv"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -140,7 +137,6 @@ type (
 		EnvName      string       `json:"envName" yaml:"envName"`
 		State        string       `json:"state" yaml:"state"`
 		CreationTime *metav1.Time `json:"creationTime,omitempty" yaml:"creationTime"`
-		Hash         uint32       `json:"hash"`
 	}
 
 	// Storage details
@@ -234,19 +230,6 @@ type (
 		Items           []VerrazzanoMonitoringInstance `json:"items"`
 	}
 )
-
-// Hash function to identify VerrazzanoMonitoringInstance changes
-func (c *VerrazzanoMonitoringInstance) Hash() (uint32, error) {
-	b, err := json.Marshal(c.Spec)
-	if err != nil {
-		return 0, err
-	}
-	h := fnv.New32a()
-	if _, err := h.Write(b); err != nil {
-		return 0, err
-	}
-	return h.Sum32(), nil
-}
 
 // GetObjectKind to get kind
 func (c *VerrazzanoMonitoringInstance) GetObjectKind() schema.ObjectKind {

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -513,15 +513,6 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 		}
 	}
 
-	// Create a Hash on vmo/Status object to identify changes to vmo spec
-	hash, err := vmo.Hash()
-	if err != nil {
-		zap.S().Errorf("Error getting VMO hash: %v", err)
-	}
-	if vmo.Status.Hash != hash {
-		vmo.Status.Hash = hash
-	}
-
 	zap.S().Infof("Successfully synced '%s/%s'", vmo.Namespace, vmo.Name)
 
 	return nil


### PR DESCRIPTION
The `status.hash` field is not used by the application, and can be removed.  Note that the instance is not persisted via `UpdateStatus()` after setting this field, and that the preceding calls to `Update()` only update the `spec` stanza and ignore the `status` stanza.  Also, the field is never read.

This commit removes the field, the function that derives a value for this field from a vmo instance, and the code that calls that function.