### PR TITLE
Update resty dependency in verrazzano monitoring operator

### DIFF
--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1237,6 +1237,14 @@ PERFORMANCE OF THIS SOFTWARE.
 
 ----------------------- Dependencies Grouped by License ------------
 -------- Dependency
+github.com/go-resty/resty/v2
+-------- Copyrights
+Copyright (c) 2015-2021 Jeevanandam M., https://myjeeva.com <jeeva@myjeeva.com>
+Copyright (c) 2015-2021 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+Copyright (c) 2015-2021 Jeevanandam M (jeeva@myjeeva.com)
+Copyright (c) 2015-2021 Jeevanandam M. (jeeva@myjeeva.com), All rights reserved.
+
+-------- Dependency
 github.com/json-iterator/go
 -------- Copyrights
 Copyright (c) 2016 json-iterator
@@ -1265,20 +1273,12 @@ Copyright (c) 2020 Uber Technologies, Inc.
 Copyright (c) 2016, 2017 Uber Technologies, Inc.
 Copyright (c) 2018 Uber Technologies, Inc.
 
--------- Dependency
-gopkg.in/resty.v1
--------- Copyrights
-Copyright (c) 2015-2019 Jeevanandam M., https://myjeeva.com <jeeva@myjeeva.com>
-Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
-Copyright (c) 2015-2019 Jeevanandam M (jeeva@myjeeva.com)
-Copyright (c) 2015-2019 Jeevanandam M. (jeeva@myjeeva.com), All rights reserved.
-
 -------- Dependencies Summary
+github.com/go-resty/resty/v2
 github.com/json-iterator/go
 go.uber.org/atomic
 go.uber.org/multierr
 go.uber.org/zap
-gopkg.in/resty.v1
 
 -------- License used by Dependencies
 SPDX:MIT
@@ -1364,4 +1364,4 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: 494b5efc99b2069f53e20e2785bb6829
+License file based on go.mod with md5 sum: 48a0b4cef48e7788b309a7fb2747e1ea

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/verrazzano/verrazzano-monitoring-operator
 go 1.13
 
 require (
+	github.com/go-resty/resty/v2 v2.6.0
 	github.com/gordonklaus/ineffassign v0.0.0-20210522101830-0589229737b2 // indirect
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/oracle/oci-go-sdk v24.3.0+incompatible // indirect
@@ -13,7 +14,6 @@ require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
 	golang.org/x/tools v0.1.3 // indirect
-	gopkg.in/resty.v1 v1.12.0
 	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.21.1
 	k8s.io/apiextensions-apiserver v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,7 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
+github.com/go-resty/resty/v2 v2.6.0/go.mod h1:PwvJS6hvaPkjtjNg9ph+VrSD92bi5Zq73w/BIH7cC3Q=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,7 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
+github.com/go-resty/resty/v2 v2.6.0 h1:joIR5PNLM2EFqqESUjCMGXrWmXNHEU9CEiK813oKYS4=
 github.com/go-resty/resty/v2 v2.6.0/go.mod h1:PwvJS6hvaPkjtjNg9ph+VrSD92bi5Zq73w/BIH7cC3Q=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/test/integ/framework/framework.go
+++ b/test/integ/framework/framework.go
@@ -5,15 +5,12 @@ package framework
 
 import (
 	"flag"
-	"fmt"
-	"os"
 
 	"math/rand"
 	"time"
 
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/test/integ/client"
-	"gopkg.in/resty.v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -69,14 +66,6 @@ func Setup() error {
 
 	if *operatorNamespace == "" {
 		operatorNamespace = namespace
-	}
-	// Set proxy for resty clients
-	if *externalIP != "localhost" {
-		proxyURL := os.Getenv("http_proxy")
-		if proxyURL != "" {
-			fmt.Println("Setting proxy for resty clients to :" + proxyURL)
-			resty.SetProxy(proxyURL)
-		}
 	}
 
 	cfg, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)

--- a/test/integ/framework/framework.go
+++ b/test/integ/framework/framework.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package framework

--- a/test/integ/util/utils.go
+++ b/test/integ/util/utils.go
@@ -1,10 +1,13 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package util
 
 import (
+	"fmt"
+	"github.com/go-resty/resty/v2"
 	"github.com/verrazzano/verrazzano-monitoring-operator/test/integ/framework"
+	"os"
 )
 
 // RunBeforePhase returns, based on the given framework object, whether or not to run the before phase.
@@ -20,4 +23,20 @@ func RunAfterPhase(f *framework.Framework) bool {
 // SkipTeardown returns, based on the given framework object, whether or not to skip teardown
 func SkipTeardown(f *framework.Framework) bool {
 	return f.SkipTeardown || framework.Before == f.Phase
+}
+
+// GetClient gets a client, setting the proxy if appropriate
+func GetClient() *resty.Client {
+	restyClient := resty.New()
+
+	f := framework.Global
+	// Set proxy for resty clients
+	if f.ExternalIP != "localhost" {
+		proxyURL := os.Getenv("http_proxy")
+		if proxyURL != "" {
+			fmt.Println("Setting proxy for resty clients to :" + proxyURL)
+			restyClient.SetProxy(proxyURL)
+		}
+	}
+	return restyClient
 }

--- a/test/integ/util/utils.go
+++ b/test/integ/util/utils.go
@@ -30,7 +30,7 @@ func GetClient() *resty.Client {
 	restyClient := resty.New()
 
 	f := framework.Global
-	// Set proxy for resty clients
+	// Set proxy for resty client
 	if f.ExternalIP != "localhost" {
 		proxyURL := os.Getenv("http_proxy")
 		if proxyURL != "" {

--- a/test/integ/util/wait.go
+++ b/test/integ/util/wait.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package util
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"gopkg.in/resty.v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -230,7 +229,7 @@ func WaitForEndpointAvailable(name string, externalIP string, port int32, urlPat
 	var err error
 	endpointURL := fmt.Sprintf("http://%s:%d%s", externalIP, port, urlPath)
 	fmt.Printf("Waiting for %s (%s) to reach status code %d...\n", name, endpointURL, expectedStatusCode)
-	restyClient := resty.New()
+	restyClient := GetClient()
 	restyClient.SetTimeout(10 * time.Second)
 	startTime := time.Now()
 	err = Retry(backoff, func() (bool, error) {


### PR DESCRIPTION
Update resty dependency in verrazzano monitoring operator.

- removed `gopkg.in/resty.v1 v1.12.0` from `go.mod` 
- added `github.com/go-resty/resty/v2 v2.6.0` to `go.mod`
- minor refactorings in test code due to resty changes
- run attribution-helper to update `THIRD_PARTY_LICENSES.txt`

