### PR TITLE
Use well know certificates when the ca-bundle is empty

### DIFF
--- a/pkg/proxy/nginx_conf_template.go
+++ b/pkg/proxy/nginx_conf_template.go
@@ -67,7 +67,7 @@ const OidcNginxConfFileTemplate = `#user  nobody;
 {{- if eq .Mode "oauth-proxy" }}
 {{- if eq .SSLEnabled true }}
         lua_ssl_verify_depth 2;
-        lua_ssl_trusted_certificate /etc/nginx/allcacerts.pem;
+        lua_ssl_trusted_certificate /etc/nginx/all-ca-certs.pem;
 {{- end }}
 
         upstream http_backend {

--- a/pkg/proxy/nginx_conf_template.go
+++ b/pkg/proxy/nginx_conf_template.go
@@ -67,7 +67,7 @@ const OidcNginxConfFileTemplate = `#user  nobody;
 {{- if eq .Mode "oauth-proxy" }}
 {{- if eq .SSLEnabled true }}
         lua_ssl_verify_depth 2;
-        lua_ssl_trusted_certificate /etc/ssl/certs/ca-bundle.crt;
+        lua_ssl_trusted_certificate /etc/nginx/allcacerts.pem;
 {{- end }}
 
         upstream http_backend {

--- a/pkg/proxy/nginx_conf_template.go
+++ b/pkg/proxy/nginx_conf_template.go
@@ -67,7 +67,7 @@ const OidcNginxConfFileTemplate = `#user  nobody;
 {{- if eq .Mode "oauth-proxy" }}
 {{- if eq .SSLEnabled true }}
         lua_ssl_verify_depth 2;
-        lua_ssl_trusted_certificate /secret/ca-bundle;
+        lua_ssl_trusted_certificate /etc/ssl/certs/ca-bundle.crt;
 {{- end }}
 
         upstream http_backend {

--- a/pkg/proxy/startup_sh_template.go
+++ b/pkg/proxy/startup_sh_template.go
@@ -32,6 +32,11 @@ const OidcStartupFileTemplate = `#!/bin/bash
 
 {{- if eq .Mode "api-proxy" }}
     cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/upstream.pem
+{{- else if eq .Mode "oauth-proxy" }}
+    # Create pem file that contains all well known ca certs plus
+    # the ca-bundle from the managed cluster registration secret
+    cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/allcacerts.pem
+    cat /secret/ca-bundle >> /etc/nginx/allcacerts.pem
 {{- end }}
 
     /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -p /etc/nginx -t

--- a/pkg/proxy/startup_sh_template.go
+++ b/pkg/proxy/startup_sh_template.go
@@ -33,10 +33,11 @@ const OidcStartupFileTemplate = `#!/bin/bash
 {{- if eq .Mode "api-proxy" }}
     cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/upstream.pem
 {{- else if eq .Mode "oauth-proxy" }}
-    # Create pem file that contains all well known ca certs plus
-    # the ca-bundle from the managed cluster registration secret
-    cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/allcacerts.pem
-    cat /secret/ca-bundle >> /etc/nginx/allcacerts.pem
+    # Create a pem file that contains all well known ca certs plus
+    # the ca-bundle from the managed cluster registration secret.
+    # It is valid for ca-bundle to be empty.
+    cat /etc/ssl/certs/ca-bundle.crt > /etc/nginx/all-ca-certs.pem
+    cat /secret/ca-bundle >> /etc/nginx/all-ca-certs.pem
 {{- end }}
 
     /usr/local/nginx/sbin/nginx -c /etc/nginx/nginx.conf -p /etc/nginx -t


### PR DESCRIPTION
When the mode is oauth-proxy, always include the list of certificates contained in /etc/ssl/certs/ca-bundle.crt.

This PR fixes the problem where no valid certificates were being used when the verrazzano-cluster-registration secret contained an empty ca-bundle (which is valid).  This change is to always include both the contents of ca-bundle and /etc/ssl/certs/ca-bundle.crt.

The problem resolved by this PR manifested itself when using a multicluster environment and OKE clusters configured with OCIDNS.  The ca-bundle of the registration secret was empty, and this resulted in the admin cluster not being able to scrape metrics from the managed cluster due to not having any valid certificates.


vz-3125