### PR TITLE
Use ghcr.io instead of OCR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ifdef INTEG_INGRESS
 endif
 
 DOCKER_NAMESPACE ?= verrazzano
-DOCKER_REPO ?= container-registry.oracle.com
+DOCKER_REPO ?= ghcr.io
 DIST_DIR:=dist
 BIN_DIR:=${DIST_DIR}/bin
 BIN_NAME:=${OPERATOR_NAME}

--- a/docker-images/verrazzano-monitoring-instance-eswait/Dockerfile
+++ b/docker-images/verrazzano-monitoring-instance-eswait/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (C) 2020, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-FROM cghcr.io/oracle/oraclelinux:7-slim AS build_base
+FROM ghcr.io/oracle/oraclelinux:7-slim AS build_base
 
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \

--- a/docker-images/verrazzano-monitoring-instance-eswait/Dockerfile
+++ b/docker-images/verrazzano-monitoring-instance-eswait/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (C) 2020, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:fcc6f54bb01fc83319990bf5fa1b79f1dec93cbb87db3c5a8884a5a44148e7bb AS build_base
+FROM cghcr.io/oracle/oraclelinux:7-slim AS build_base
 
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \
@@ -25,7 +25,7 @@ RUN go build \
     -ldflags "-X main.buildVersion=${BUILDVERSION} -X main.buildDate=${BUILDDATE}" \
     -o /usr/bin/eswait eswait.go
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:fcc6f54bb01fc83319990bf5fa1b79f1dec93cbb87db3c5a8884a5a44148e7bb AS final
+FROM ghcr.io/oracle/oraclelinux:7-slim AS final
 
 RUN yum update -y \
     && yum install -y ca-certificates curl openssl && yum clean all && rm -rf /var/cache/yum

--- a/docker-images/verrazzano-monitoring-operator/Dockerfile
+++ b/docker-images/verrazzano-monitoring-operator/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (C) 2020, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:fcc6f54bb01fc83319990bf5fa1b79f1dec93cbb87db3c5a8884a5a44148e7bb AS build_base
+FROM ghcr.io/oracle/oraclelinux:7-slim AS build_base
 
 RUN yum update -y \
     && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \
@@ -24,7 +24,7 @@ RUN go build \
     -o /usr/bin/verrazzano-monitoring-operator ./cmd/verrazzano-monitoring-ctrl
 
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:fcc6f54bb01fc83319990bf5fa1b79f1dec93cbb87db3c5a8884a5a44148e7bb AS final
+FROM ghcr.io/oracle/oraclelinux:7-slim AS final
 
 RUN yum update -y && yum-config-manager --save --setopt=ol7_ociyum_config.skip_if_unavailable=true \
     && yum install -y ca-certificates curl openssl && yum clean all && rm -rf /var/cache/yum


### PR DESCRIPTION
This PR changes the docker builds to get the OL base image from ghcr.io instead of OCR, bringing this repo into line with all the others. 