### PR TITLE
JIRA: VZ-3731 support for image name creation for release branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     environment {
         DOCKER_CI_IMAGE_NAME_OPERATOR = 'verrazzano-monitoring-operator-jenkins'
         DOCKER_PUBLISH_IMAGE_NAME_OPERATOR = 'verrazzano-monitoring-operator'
-        DOCKER_IMAGE_NAME_OPERATOR = "${env.BRANCH_NAME == 'master' ? env.DOCKER_PUBLISH_IMAGE_NAME_OPERATOR : env.DOCKER_CI_IMAGE_NAME_OPERATOR}"
+        DOCKER_IMAGE_NAME_OPERATOR = "${env.BRANCH_NAME ==~ /^release-.*/ || env.BRANCH_NAME == 'master' ? env.DOCKER_PUBLISH_IMAGE_NAME_OPERATOR : env.DOCKER_CI_IMAGE_NAME_OPERATOR}"
 
         DOCKER_CI_IMAGE_NAME_ESWAIT = 'verrazzano-monitoring-instance-eswait-jenkins'
         DOCKER_PUBLISH_IMAGE_NAME_ESWAIT = 'verrazzano-monitoring-instance-eswait'


### PR DESCRIPTION
As part of the effort to update the VMO image it was discovered that the latest master build of VMO is incompatible with the release 1.0 branch of Verrazzano.  Therefore it is appropriate to create a release-1.0 branch of the VMO.  This PR updates the VMO Jenkins file to allow for the generation of standard named docker images for release branches.