### PR TITLE
VZ-3747 fix - delete the Prometheus config map at startup rather than overwrite

### DIFF
--- a/cmd/verrazzano-monitoring-ctrl/main.go
+++ b/cmd/verrazzano-monitoring-ctrl/main.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package main

--- a/cmd/verrazzano-monitoring-ctrl/main.go
+++ b/cmd/verrazzano-monitoring-ctrl/main.go
@@ -60,6 +60,9 @@ func main() {
 
 	vmo.StartHTTPServer(controller)
 
+	// Run any cleanup that needs to happen pre-startup of the controller
+	controller.PreStartCleanup()
+
 	if err = controller.Run(1); err != nil {
 		zap.S().Fatalf("Error running controller: %s", err.Error())
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -205,6 +205,10 @@ const MonitoringNamespace = "monitoring"
 // MCRegistrationSecret - the name of the secret that contains the cluster registration information
 const MCRegistrationSecret = "verrazzano-cluster-registration" //nolint:gosec //#gosec G101
 
+// MCLocalRegistrationSecret - the name of the secret that contains the local cluster info (used when the cluster
+// is not registered as a managed cluster)
+const MCLocalRegistrationSecret = "verrazzano-local-registration" //nolint:gosec //#gosec G101
+
 // ClusterNameData - the field name in MCRegistrationSecret that contains this managed cluster's name
 const ClusterNameData = "managed-cluster-name"
 
@@ -213,3 +217,7 @@ const KeycloakURLData = "keycloak-url"
 
 // KeycloakCABundleData - the field name in MCRegistrationSecret that contains the admin cluster's Keycloak ca-bundle
 const KeycloakCABundleData = "ca-bundle"
+
+// PrometheusClusterNameLabel - the label name attached to all metrics to indicate the Verrazzano
+// cluster name where the metric originated
+const PrometheusClusterNameLabel = "verrazzano_cluster"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -56,6 +56,12 @@ const ResyncPeriod = 30 * time.Second
 // VMOServiceNamePrefix to be applied to all VMO services
 const VMOServiceNamePrefix = "vmi-"
 
+// VMODefaultName is the default value (and currently only possible value) for the VMO name
+const VMODefaultName = "system"
+
+// VerrazzanoSystemNamespace is the Verrazzano System namespace
+const VerrazzanoSystemNamespace = "verrazzano-system"
+
 // StorageVolumeName constant for storage volume
 const StorageVolumeName = "storage-volume"
 

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -212,7 +212,7 @@ func GetElasticsearchInitContainer() *corev1.Container {
 }
 
 // GetDefaultPrometheusConfiguration returns the default Prometheus configuration for a VMO instance
-func GetDefaultPrometheusConfiguration(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) string {
+func GetDefaultPrometheusConfiguration(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, vzClusterName string) string {
 	alertmanagerURL := fmt.Sprintf(GetMetaName(vmo.Name, config.AlertManager.Name)+":%d", config.AlertManager.Port)
 	// Prometheus does not allow any special characters in their label names, So they need to be removed using reg exp
 	re := regexp.MustCompile("[^a-zA-Z0-9_]")
@@ -236,6 +236,8 @@ scrape_configs:
    scrape_timeout: 15s
    static_configs:
    - targets: ['localhost:9090']
+     labels:
+       ` + constants.PrometheusClusterNameLabel + ": " + vzClusterName + `
 
  - job_name: 'node-exporter'
    scrape_interval: 20s
@@ -246,6 +248,10 @@ scrape_configs:
    - source_labels: [__meta_kubernetes_endpoints_name]
      regex: 'node-exporter'
      action: keep
+   - source_labels: null
+     action: replace
+     target_label: ` + constants.PrometheusClusterNameLabel + `
+     replacement: ` + vzClusterName + `
 
  - job_name: 'cadvisor'
    scrape_interval: 20s
@@ -266,6 +272,10 @@ scrape_configs:
      regex: (.+)
      target_label: __metrics_path__
      replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+   - source_labels: null
+     action: replace
+     target_label: ` + constants.PrometheusClusterNameLabel + `
+     replacement: ` + vzClusterName + `
 
  - job_name: 'nginx-ingress-controller'
    kubernetes_sd_configs:
@@ -290,6 +300,10 @@ scrape_configs:
    - source_labels: [__meta_kubernetes_pod_name]
      action: replace
      target_label: kubernetes_pod_name
+   - source_labels: null
+     action: replace
+     target_label: ` + constants.PrometheusClusterNameLabel + `
+     replacement: ` + vzClusterName + `
 
  # Scrape config for Istio envoy stats
  - job_name: 'envoy-stats'
@@ -313,6 +327,10 @@ scrape_configs:
    - source_labels: [__meta_kubernetes_pod_name]
      action: replace
      target_label: pod_name
+   - source_labels: null
+     action: replace
+     target_label: ` + constants.PrometheusClusterNameLabel + `
+     replacement: ` + vzClusterName + `
 
  # Scrape config for Istio - mesh and istiod metrics
  - job_name: 'pilot'
@@ -326,7 +344,11 @@ scrape_configs:
      action: keep
      regex: istiod;http-monitoring
    - source_labels: [__meta_kubernetes_service_label_app]
-     target_label: app`)
+     target_label: app
+   - source_labels: null
+     action: replace
+     target_label: ` + constants.PrometheusClusterNameLabel + `
+     replacement: ` + vzClusterName)
 
 	return string(prometheusConfig)
 }

--- a/pkg/resources/helper_test.go
+++ b/pkg/resources/helper_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 
 	"gopkg.in/yaml.v2"
 
@@ -15,33 +16,53 @@ import (
 
 func TestGetDefaultPrometheusConfiguration(t *testing.T) {
 	vmi := &vmov1.VerrazzanoMonitoringInstance{}
-	configText := GetDefaultPrometheusConfiguration(vmi)
+	configText := GetDefaultPrometheusConfiguration(vmi, "myclustername")
 	var config map[interface{}]interface{}
 	err := yaml.Unmarshal([]byte(configText), &config)
 	if err != nil {
 		t.Fatalf("Error parsing PrometheusConfiguration yaml %v", err)
 	}
 	scrapeConfigs := config["scrape_configs"]
-	cadvisor := getItem("job_name", "cadvisor", scrapeConfigs.([]interface{}))
-	kubernetesSdConfigs := cadvisor["kubernetes_sd_configs"]
+
+	prometheus := getItem("job_name", "prometheus", scrapeConfigs.([]interface{}))
+	assert.NotNil(t, prometheus)
+	staticConfigs := prometheus["static_configs"]
+	assert.NotNil(t, staticConfigs)
+	staticCfg := staticConfigs.([]interface{})[0].(map[interface{}]interface{})
+	assert.Equal(t, "localhost:9090", staticCfg["targets"].([]interface{})[0])
+	staticLabels := staticCfg["labels"].(map[interface{}]interface{})
+	assert.Equal(t, "myclustername", staticLabels[constants.PrometheusClusterNameLabel])
+
+	nodeExporter := getItem("job_name", "node-exporter", scrapeConfigs.([]interface{}))
+	assert.NotNil(t, nodeExporter)
+	kubernetesSdConfigs := nodeExporter["kubernetes_sd_configs"]
 	role := kubernetesSdConfigs.([]interface{})[0].(map[interface{}]interface{})["role"]
-	assert.Equal(t, "node", role, "kubernetes_sd_configs should have - role: node")
+	assert.Equal(t, "endpoints", role, "kubernetes_sd_configs for node-exporter should have - role: endpoints")
+	assertVzClusterNameRelabelConfig(t, nodeExporter["relabel_configs"], "myclustername")
+
+	cadvisor := getItem("job_name", "cadvisor", scrapeConfigs.([]interface{}))
+	kubernetesSdConfigs = cadvisor["kubernetes_sd_configs"]
+	role = kubernetesSdConfigs.([]interface{})[0].(map[interface{}]interface{})["role"]
+	assert.Equal(t, "node", role, "kubernetes_sd_configs for cadvisor should have - role: node")
 	relabelConfigs := cadvisor["relabel_configs"]
 	relabelConfig := getItem("target_label", "__metrics_path__", relabelConfigs.([]interface{}))
 	assert.Equal(t, "__meta_kubernetes_node_name", relabelConfig["source_labels"].([]interface{})[0], "relabelConfig.source_labels")
 	assert.Equal(t, "/api/v1/nodes/$1/proxy/metrics/cadvisor", relabelConfig["replacement"], "relabelConfig.replacement")
+	assertVzClusterNameRelabelConfig(t, relabelConfigs, "myclustername")
 
 	pilot := getItem("job_name", "pilot", scrapeConfigs.([]interface{}))
 	assert.NotNil(t, pilot)
 	kubernetesSdConfigs = pilot["kubernetes_sd_configs"]
 	role = kubernetesSdConfigs.([]interface{})[0].(map[interface{}]interface{})["role"]
 	assert.Equal(t, "endpoints", role, "kubernetes_sd_configs should have - role: endpoints")
+	assertVzClusterNameRelabelConfig(t, pilot["relabel_configs"], "myclustername")
 
 	envoyStats := getItem("job_name", "envoy-stats", scrapeConfigs.([]interface{}))
 	assert.NotNil(t, envoyStats)
 	kubernetesSdConfigs = envoyStats["kubernetes_sd_configs"]
 	role = kubernetesSdConfigs.([]interface{})[0].(map[interface{}]interface{})["role"]
 	assert.Equal(t, "pod", role, "kubernetes_sd_configs should have - role: pod")
+	assertVzClusterNameRelabelConfig(t, envoyStats["relabel_configs"], "myclustername")
 
 	ingressController := getItem("job_name", "nginx-ingress-controller", scrapeConfigs.([]interface{}))
 	assert.NotNil(t, ingressController)
@@ -51,6 +72,17 @@ func TestGetDefaultPrometheusConfiguration(t *testing.T) {
 	relabelConfigs = ingressController["relabel_configs"]
 	relabelConfig = getItem("target_label", "__address__", relabelConfigs.([]interface{}))
 	assert.Equal(t, "$1:10254", relabelConfig["replacement"], "relabelConfig.replacement")
+	assertVzClusterNameRelabelConfig(t, ingressController["relabel_configs"], "myclustername")
+}
+
+// asserts that the relabel config for adding the verrazzano cluster name label to the metric exists and is
+// as expected
+func assertVzClusterNameRelabelConfig(t *testing.T, relabelConfigs interface{}, expectedClusterName string) {
+	clusterNameRelabelConfig := getItem("target_label", constants.PrometheusClusterNameLabel, relabelConfigs.([]interface{}))
+	assert.NotNil(t, clusterNameRelabelConfig)
+	assert.Equal(t, "replace", clusterNameRelabelConfig["action"])
+	assert.Equal(t, expectedClusterName, clusterNameRelabelConfig["replacement"])
+	assert.Equal(t, nil, clusterNameRelabelConfig["source_labels"])
 }
 
 func getItem(key, value string, scrapeConfigs []interface{}) map[interface{}]interface{} {

--- a/pkg/vmo/configmap.go
+++ b/pkg/vmo/configmap.go
@@ -91,7 +91,11 @@ func CreateConfigmaps(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMoni
 	configMaps = append(configMaps, vmo.Spec.Prometheus.RulesVersionsConfigMap)
 
 	//configmap for prometheus config
-	err = createConfigMapIfDoesntExist(controller, vmo, vmo.Spec.Prometheus.ConfigMap, map[string]string{"prometheus.yml": resources.GetDefaultPrometheusConfiguration(vmo)})
+	vzClusterName := controller.clusterInfo.clusterName
+	if vzClusterName == "" {
+		vzClusterName, _ = GetClusterNameFromSecret(controller, vmo.Namespace)
+	}
+	err = createOrUpdateConfigMap(controller, vmo, vmo.Spec.Prometheus.ConfigMap, map[string]string{"prometheus.yml": resources.GetDefaultPrometheusConfiguration(vmo, vzClusterName)})
 	if err != nil {
 		zap.S().Errorf("Failed to create configmap %s for reason %v", vmo.Spec.Prometheus.ConfigMap, err)
 		return err
@@ -124,6 +128,34 @@ func CreateConfigmaps(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMoni
 				zap.S().Errorf("Failed to delete config map %s, for the reason (%v)", configMap.Name, err)
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+// Create config map or update it if it already exists
+func createOrUpdateConfigMap(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, configmapName string, data map[string]string) error {
+	configMap := configmaps.NewConfig(vmo, configmapName, data)
+	existingConfigMap, err := getConfigMap(controller, vmo, configmapName)
+	if err != nil {
+		zap.S().Errorf("Failed to get configmap %s for vmo %s", vmo.Name, configmapName)
+		return err
+	}
+	if existingConfigMap != nil {
+		zap.S().Debugf("Updating existing configmap for %s ", existingConfigMap.Name)
+		specDiffs := diff.Diff(existingConfigMap, configMap)
+		if specDiffs != "" {
+			zap.S().Infof("ConfigMap %s : Spec differences %s", configMap.Name, specDiffs)
+			_, err := controller.kubeclientset.CoreV1().ConfigMaps(vmo.Namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+			if err != nil {
+				zap.S().Errorf("Failed to update existing configmap %s: %s ", configMap.Name, err.Error())
+			}
+		}
+	} else {
+		_, err := controller.kubeclientset.CoreV1().ConfigMaps(vmo.Namespace).Create(context.TODO(), configMap, metav1.CreateOptions{})
+		if err != nil {
+			zap.S().Errorf("Failed to create configmap %s for vmo %s", vmo.Name, configmapName)
+			return err
 		}
 	}
 	return nil

--- a/pkg/vmo/configmap_test.go
+++ b/pkg/vmo/configmap_test.go
@@ -24,6 +24,7 @@ func TestCreateConfigmaps(t *testing.T) {
 	controller := &Controller{
 		kubeclientset:   client,
 		configMapLister: &simpleConfigMapLister{kubeClient: client},
+		secretLister:    &simpleSecretLister{kubeClient: client},
 	}
 	vmo := &vmctl.VerrazzanoMonitoringInstance{}
 	vmo.Name = "system"
@@ -101,4 +102,63 @@ func (s simpleConfigMapNamespaceLister) List(selector labels.Selector) ([]*v1.Co
 // Get retrieves the ConfigMap for a given namespace and name.
 func (s simpleConfigMapNamespaceLister) Get(name string) (*v1.ConfigMap, error) {
 	return s.kubeClient.CoreV1().ConfigMaps(s.namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+// simple SecretLister implementation
+type simpleSecretLister struct {
+	kubeClient kubernetes.Interface
+}
+
+// lists all Secrets
+func (s *simpleSecretLister) List(selector labels.Selector) ([]*v1.Secret, error) {
+	namespaces, err := s.kubeClient.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var secrets []*v1.Secret
+	for _, namespace := range namespaces.Items {
+
+		list, err := s.Secrets(namespace.Name).List(selector)
+		if err != nil {
+			return nil, err
+		}
+		secrets = append(secrets, list...)
+	}
+	return secrets, nil
+}
+
+// Secrets returns an object that can get Secrets.
+func (s *simpleSecretLister) Secrets(namespace string) corelistersv1.SecretNamespaceLister {
+	return simpleSecretNamespaceLister{
+		namespace:  namespace,
+		kubeClient: s.kubeClient,
+	}
+}
+
+// simpleSecretNamespaceLister implements the SecretNamespaceLister
+// interface.
+type simpleSecretNamespaceLister struct {
+	namespace  string
+	kubeClient kubernetes.Interface
+}
+
+// List lists all Secrets for a given namespace.
+func (s simpleSecretNamespaceLister) List(selector labels.Selector) ([]*v1.Secret, error) {
+	var secrets []*v1.Secret
+
+	list, err := s.kubeClient.CoreV1().Secrets(s.namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range list.Items {
+		if selector.Matches(labels.Set(list.Items[i].Labels)) {
+			secrets = append(secrets, &list.Items[i])
+		}
+	}
+	return secrets, nil
+}
+
+// Get retrieves the Secret for a given namespace and name.
+func (s simpleSecretNamespaceLister) Get(name string) (*v1.Secret, error) {
+	return s.kubeClient.CoreV1().Secrets(s.namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }

--- a/pkg/vmo/configmap_test.go
+++ b/pkg/vmo/configmap_test.go
@@ -64,7 +64,7 @@ func TestDeleteConfigMapIfExists(t *testing.T) {
 	assert.NoError(t, err)
 
 	//make sure config map was deleted
-	cm, err := getConfigMap(controller, constants.VerrazzanoSystemNamespace, promConfigMapName)
+	cm, _ := getConfigMap(controller, constants.VerrazzanoSystemNamespace, promConfigMapName)
 	assert.Nil(t, cm)
 
 	// Repeat the test with a non-existent config map and ensure that deleteConfigMapIfExists ignores rather than

--- a/pkg/vmo/configmap_test.go
+++ b/pkg/vmo/configmap_test.go
@@ -50,7 +50,7 @@ func TestCreateConfigmaps(t *testing.T) {
 
 // TestDeleteConfigMapIfExists tests the deleteConfigMapIfExists function
 func TestDeleteConfigMapIfExists(t *testing.T) {
-	configMap := &v1.ConfigMap{};
+	configMap := &v1.ConfigMap{}
 	configMap.SetNamespace(constants.VerrazzanoSystemNamespace)
 	promConfigMapName := resources.GetMetaName(constants.VMODefaultName, config.Prometheus.Name)
 	configMap.SetName(promConfigMapName)

--- a/pkg/vmo/configmap_test.go
+++ b/pkg/vmo/configmap_test.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	corelistersv1 "k8s.io/client-go/listers/core/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -27,8 +30,8 @@ func TestCreateConfigmaps(t *testing.T) {
 		secretLister:    &simpleSecretLister{kubeClient: client},
 	}
 	vmo := &vmctl.VerrazzanoMonitoringInstance{}
-	vmo.Name = "system"
-	vmo.Namespace = "verrazzano-system"
+	vmo.Name = constants.VMODefaultName
+	vmo.Namespace = constants.VerrazzanoSystemNamespace
 	vmo.Spec.URI = "vmi.system.v8o-env.oracledx.com"
 	vmo.Spec.Grafana.DashboardsConfigMap = "myDashboardsConfigMap"
 	vmo.Spec.Grafana.DatasourcesConfigMap = "myDatasourcesConfigMap"
@@ -43,6 +46,31 @@ func TestCreateConfigmaps(t *testing.T) {
 	assert.Nil(t, err)
 	all, _ := client.CoreV1().ConfigMaps(vmo.Namespace).List(context.TODO(), metav1.ListOptions{})
 	assert.Equal(t, 8, len(all.Items))
+}
+
+// TestDeleteConfigMapIfExists tests the deleteConfigMapIfExists function
+func TestDeleteConfigMapIfExists(t *testing.T) {
+	configMap := &v1.ConfigMap{};
+	configMap.SetNamespace(constants.VerrazzanoSystemNamespace)
+	promConfigMapName := resources.GetMetaName(constants.VMODefaultName, config.Prometheus.Name)
+	configMap.SetName(promConfigMapName)
+	client := fake.NewSimpleClientset(configMap)
+	controller := &Controller{
+		kubeclientset:   client,
+		configMapLister: &simpleConfigMapLister{kubeClient: client},
+		secretLister:    &simpleSecretLister{kubeClient: client},
+	}
+	err := deleteConfigMapIfExists(controller, constants.VerrazzanoSystemNamespace, promConfigMapName)
+	assert.NoError(t, err)
+
+	//make sure config map was deleted
+	cm, err := getConfigMap(controller, constants.VerrazzanoSystemNamespace, promConfigMapName)
+	assert.Nil(t, cm)
+
+	// Repeat the test with a non-existent config map and ensure that deleteConfigMapIfExists ignores rather than
+	// return error
+	err = deleteConfigMapIfExists(controller, constants.VerrazzanoSystemNamespace, "nonexistentCM")
+	assert.NoError(t, err)
 }
 
 // simple ConfigMapLister implementation

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -579,6 +579,7 @@ func (c *Controller) IsHealthy() bool {
 // the prometheus config map so that it can be re-created. Other operators that reconcile the config map will
 // eventually catch up and fix up the config map
 func (c *Controller) PreStartCleanup() {
+	zap.S().Infof("Deleting Prometheus config map at startup if it exists: %s/%s", constants.VerrazzanoSystemNamespace, constants.PrometheusConfig)
 	deleteConfigMapIfExists(c, constants.VerrazzanoSystemNamespace,
-		resources.GetMetaName(constants.VMODefaultName, config.Prometheus.Name))
+		resources.GetMetaName(constants.VMODefaultName, constants.PrometheusConfig))
 }


### PR DESCRIPTION
Overwriting the Prometheus config map is causing it to change constantly since other operators write to it as well. Instead, delete the config map at VMO startup so that it gets re-created once by VMO and the edits from other operators stay instead of disappearing.