### PR TITLE
add prometheus. http2Enabled in VMI CRD

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,9 +171,8 @@ pipeline {
             when { not { buildingTag() } }
             steps {
                 script {
-                    clairScanTemp "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME_OPERATOR}:${DOCKER_IMAGE_TAG}"
+                    scanContainerImage "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME_OPERATOR}:${DOCKER_IMAGE_TAG}"
                 }
-                sh "mv scanning-report.json verrazzano-monitoring-operator.scanning-report.json"
             }
             post {
                 always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 def DOCKER_IMAGE_TAG
@@ -199,7 +199,7 @@ pipeline {
             }
             steps {
                 script {
-                    clairScanTemp "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME_ESWAIT}:${DOCKER_IMAGE_TAG}"
+                    scanContainerImage "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME_ESWAIT}:${DOCKER_IMAGE_TAG}"
                 }
                 sh "mv scanning-report.json verrazzano-monitoring-instance-eswait.scanning-report.json"
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,7 +201,6 @@ pipeline {
                 script {
                     scanContainerImage "${env.DOCKER_REPO}/${env.DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME_ESWAIT}:${DOCKER_IMAGE_TAG}"
                 }
-                sh "mv scanning-report.json verrazzano-monitoring-instance-eswait.scanning-report.json"
             }
             post {
                 always {

--- a/pkg/apis/vmcontroller/v1/types.go
+++ b/pkg/apis/vmcontroller/v1/types.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package v1
@@ -94,6 +94,7 @@ type (
 		Resources              Resources `json:"resources,omitempty"`
 		RetentionPeriod        int32     `json:"retentionPeriod,omitempty"`
 		Replicas               int32     `json:"replicas,omitempty"`
+		Http2Enabled           bool      `json:"http2Enabled" yaml:"http2Enabled"`
 	}
 
 	// AlertManager details

--- a/pkg/apis/vmcontroller/v1/types.go
+++ b/pkg/apis/vmcontroller/v1/types.go
@@ -94,7 +94,7 @@ type (
 		Resources              Resources `json:"resources,omitempty"`
 		RetentionPeriod        int32     `json:"retentionPeriod,omitempty"`
 		Replicas               int32     `json:"replicas,omitempty"`
-		Http2Enabled           bool      `json:"http2Enabled" yaml:"http2Enabled"`
+		HTTP2Enabled           bool      `json:"http2Enabled" yaml:"http2Enabled"`
 	}
 
 	// AlertManager details

--- a/pkg/resources/deployments/prometheus.go
+++ b/pkg/resources/deployments/prometheus.go
@@ -43,7 +43,7 @@ func createPrometheusNodeDeploymentElements(vmo *vmcontrollerv1.VerrazzanoMonito
 		env := prometheusDeployment.Spec.Template.Spec.Containers[0].Env
 		env = append(env, corev1.EnvVar{Name: "AVAILABILITY_DOMAIN", Value: getAvailabilityDomainForPvcIndex(&vmo.Spec.Prometheus.Storage, pvcToAdMap, i)})
 		http2 := "disabled"
-		if vmo.Spec.Prometheus.Http2Enabled {
+		if vmo.Spec.Prometheus.HTTP2Enabled {
 			http2 = ""
 		}
 		env = append(env, corev1.EnvVar{Name: "PROMETHEUS_COMMON_DISABLE_HTTP2", Value: http2})

--- a/pkg/resources/deployments/prometheus.go
+++ b/pkg/resources/deployments/prometheus.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package deployments
@@ -42,6 +42,11 @@ func createPrometheusNodeDeploymentElements(vmo *vmcontrollerv1.VerrazzanoMonito
 		// Not strictly necessary, but makes debugging easier to have a trace of the AD in the deployment itself
 		env := prometheusDeployment.Spec.Template.Spec.Containers[0].Env
 		env = append(env, corev1.EnvVar{Name: "AVAILABILITY_DOMAIN", Value: getAvailabilityDomainForPvcIndex(&vmo.Spec.Prometheus.Storage, pvcToAdMap, i)})
+		http2 := "disabled"
+		if vmo.Spec.Prometheus.Http2Enabled {
+			http2 = ""
+		}
+		env = append(env, corev1.EnvVar{Name: "PROMETHEUS_COMMON_DISABLE_HTTP2", Value: http2})
 		prometheusDeployment.Spec.Template.Spec.Containers[0].Env = env
 
 		err := setIstioAnnotations(prometheusDeployment, kubeclientset)


### PR DESCRIPTION
Prometheus scraper in 2.31.1 by default connects to target endpoints using http2, which doesn't work with Verrazzano applications.
In VMI CRD, prometheus. http2Enabled is added to indicate if or not to use http2 in Prometheus.  The default is to NOT use http2.  The default works with both Prometheus 2.21.0 and 2.31.1.
