### PR TITLE
VZ-4588: add CN to vmi ingress cert subject

### DIFF
--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package ingresses
@@ -77,6 +77,9 @@ func createIngressElementNoBasicAuth(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 	} else {
 		ingress.Annotations["kubernetes.io/tls-acme"] = "false"
 	}
+
+	ingress.Annotations["cert-manager.io/common-name"] = "*." + vmo.Spec.URI
+
 	return ingress, nil
 }
 
@@ -272,5 +275,6 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 	}
 	ingress.Annotations["nginx.ingress.kubernetes.io/rewrite-target"] = "/$2"
 	setNginxRoutingAnnotations(ingress)
+	ingress.Annotations["cert-manager.io/common-name"] = "*." + vmo.Spec.URI
 	return ingress
 }


### PR DESCRIPTION
As a part of https://jira.oraclecorp.com/jira/browse/VZ-4588, add CN to vmi ingress cert subject.

In VMI, multiple ingresses (vmi-system-es-ingest, vmi-system-grafana, vmi-system-kibana, vmi-system-prometheus, etc) share the same cert.  So, the CN has * in it, something like *.vmi.system.default.172.18.0.231.nip.io.