### PR TITLE
wildcard tls.hosts for VMI ingresses

### DIFF
--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package ingresses
@@ -44,7 +44,6 @@ func createIngressRuleElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, 
 }
 
 func createIngressElementNoBasicAuth(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, hostName string, componentDetails config.ComponentDetails, ingressRule extensions_v1beta1.IngressRule) (*extensions_v1beta1.Ingress, error) {
-	var hosts = []string{hostName}
 	ingress := &extensions_v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations:     map[string]string{},
@@ -56,7 +55,7 @@ func createIngressElementNoBasicAuth(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 		Spec: extensions_v1beta1.IngressSpec{
 			TLS: []extensions_v1beta1.IngressTLS{
 				{
-					Hosts:      hosts,
+					Hosts:      []string{"*." + vmo.Spec.URI},
 					SecretName: vmo.Name + "-tls",
 				},
 			},
@@ -253,7 +252,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 		Spec: extensions_v1beta1.IngressSpec{
 			TLS: []extensions_v1beta1.IngressTLS{
 				{
-					Hosts:      []string{ingressHost},
+					Hosts:      []string{"*." + vmo.Spec.URI},
 					SecretName: vmo.Name + "-tls",
 				},
 			},

--- a/pkg/resources/ingresses/ingress_test.go
+++ b/pkg/resources/ingresses/ingress_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package ingresses
@@ -59,6 +59,7 @@ func TestVMOWithIngresses(t *testing.T) {
 	assert.Equal(t, 4, len(ingresses), "Length of generated Ingresses")
 	assert.Equal(t, 1, len(ingresses[0].Spec.TLS), "Number of TLS elements in generated Ingress")
 	assert.Equal(t, 1, len(ingresses[0].Spec.TLS[0].Hosts), "Number of hosts in generated Ingress")
+	assert.Equal(t, "*.example.com", ingresses[0].Spec.TLS[0].Hosts[0], "Number of hosts in generated Ingress")
 	assert.True(t, strings.Contains(ingresses[0].Spec.TLS[0].SecretName, "tls"), "TLS secret")
 	assert.Equal(t, "basic", ingresses[0].Annotations["nginx.ingress.kubernetes.io/auth-type"], "Auth type")
 	assert.Equal(t, "secret", ingresses[0].Annotations["nginx.ingress.kubernetes.io/auth-secret"], "Auth secret")


### PR DESCRIPTION
This is required for upgrading cert-manager 1.6.1