### PR TITLE
Recreate Kibana on upgrade

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package deployments
@@ -176,12 +176,6 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, kubeclientset kuberne
 		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TimeoutSeconds = 3
 		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds = 20
 		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.FailureThreshold = 5
-
-		// Kibana/OSD should not have concurrent replicas with separate versions
-		// this can lead to race conditions and result in data corruption
-		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
-			Type: appsv1.RecreateDeploymentStrategyType,
-		}
 
 		// add the required istio annotations to allow inter-es component communication
 		if deployment.Spec.Template.Annotations == nil {

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -6,6 +6,7 @@ package deployments
 import (
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"strconv"
 	"strings"
 
@@ -85,6 +86,18 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, kubeclientset kuberne
 		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds = 20
 
 		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe = deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+
+		// Kibana/OSD should not have concurrent replicas with separate versions
+		// this can lead to race conditions and result in data corruption
+		maxUnavailable := intstr.FromString("100%")
+		maxSurge := intstr.FromInt(0)
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+			RollingUpdate: &appsv1.RollingUpdateDeployment{
+				MaxUnavailable: &maxUnavailable,
+				MaxSurge:       &maxSurge,
+			},
+		}
 
 		// dashboard volume
 		volumes := []corev1.Volume{

--- a/pkg/vmo/deployment_test.go
+++ b/pkg/vmo/deployment_test.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package vmo
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestGetUpdateStrategy(t *testing.T) {
+	var tests = []struct {
+		name     string
+		old      string
+		new      string
+		expected appsv1.DeploymentStrategyType
+	}{
+		{
+			"recreate update",
+			"foo",
+			"bar",
+			appsv1.RecreateDeploymentStrategyType,
+		},
+		{
+			"rolling update",
+			"foo",
+			"foo",
+			appsv1.RollingUpdateDeploymentStrategyType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			strategyType := getUpdateStrategy(tt.new, tt.old)
+			assert.Equal(t, tt.expected, strategyType)
+		})
+	}
+}
+
+func TestAddKibanaUpgradeStrategy(t *testing.T) {
+	newDeploy := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  config.Kibana.Name,
+							Image: "foo",
+						},
+					},
+				},
+			},
+		},
+	}
+	oldDeploy := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  config.Kibana.Name,
+							Image: "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+	addKibanaUpgradeStrategy(newDeploy, oldDeploy)
+	assert.Equal(t, appsv1.RecreateDeploymentStrategyType, newDeploy.Spec.Strategy.Type)
+}


### PR DESCRIPTION
We recreate kibana on upgrade, since kibana does not support a rolling upgrade. If multiple kibana versions are running you may have a data race and subsequent data corruption.