### PR TITLE
ISM Update

### DIFF
--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -237,7 +237,7 @@ func (o *OSClient) deletePolicy(opensearchEndpoint, policyName string) error {
 
 func isEligibleForDeletion(policy ISMPolicy, expectedPolicyMap map[string]bool) bool {
 	return policy.Policy.Description == vmiManagedPolicy &&
-		expectedPolicyMap[*policy.ID] == false
+		!expectedPolicyMap[*policy.ID]
 }
 
 //policyNeedsUpdate returns true if the policy document has changed

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -134,12 +134,11 @@ func TestConfigureIndexManagementPluginHappyPath(t *testing.T) {
 					StatusCode: http.StatusNotFound,
 					Body:       io.NopCloser(strings.NewReader(testPolicyNotFound)),
 				}, nil
-			} else {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(testPolicyList)),
-				}, nil
 			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(testPolicyList)),
+			}, nil
 
 		case "PUT":
 			return &http.Response{
@@ -373,7 +372,7 @@ func TestCleanupPolicies(t *testing.T) {
 			*p2ISM,
 		},
 	}
-	existingPolicyJson, err := json.Marshal(existingPolicies)
+	existingPolicyJSON, err := json.Marshal(existingPolicies)
 	assert.NoError(t, err)
 
 	var getCalls, deleteCalls int
@@ -383,7 +382,7 @@ func TestCleanupPolicies(t *testing.T) {
 			getCalls++
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader(existingPolicyJson)),
+				Body:       io.NopCloser(bytes.NewReader(existingPolicyJSON)),
 			}, nil
 		default:
 			deleteCalls++

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -58,7 +58,8 @@ func (o *OSClient) ConfigureISM(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance
 				return
 			}
 		}
-		ch <- nil
+
+		ch <- o.cleanupPolicies(opensearchEndpoint, vmi.Spec.Elasticsearch.Policies)
 	}()
 
 	return ch


### PR DESCRIPTION
- ISM policies are deleted once they are removed from the CR
- If a managed policy is overwritten outside the VMO, the VMO corrects it back to the expected state.