### PR TITLE
VZ-5361: Change service port names for use with Kiali

### DIFF
--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -78,7 +78,7 @@ func GetSpecID(vmoName string, componentName string) map[string]string {
 
 // GetServicePort returns service port
 func GetServicePort(componentDetails config.ComponentDetails) corev1.ServicePort {
-	return corev1.ServicePort{Name: componentDetails.Name, Port: int32(componentDetails.Port)}
+	return corev1.ServicePort{Name: "http-" + componentDetails.Name, Port: int32(componentDetails.Port)}
 }
 
 // GetOwnerReferences returns owner references

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -49,7 +49,7 @@ func createElasticsearchDataServiceElements(vmo *vmcontrollerv1.VerrazzanoMonito
 func createMasterServiceHTTP(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *corev1.Service {
 	masterHTTPService := createServiceElement(vmo, config.ElasticsearchMaster)
 	masterHTTPService.Name = masterHTTPService.Name + "-http"
-	masterHTTPService.Spec.Ports[0].Name = config.ElasticsearchMaster.Name + "-http"
+	masterHTTPService.Spec.Ports[0].Name = "http-" + config.ElasticsearchMaster.Name
 	masterHTTPService.Spec.Ports[0].Port = constants.OSHTTPPort
 	masterHTTPService.Spec.Ports[0].TargetPort = intstr.FromInt(constants.OSHTTPPort)
 	return masterHTTPService


### PR DESCRIPTION
This pull request changes the service port names for VMI services to include the protocol as a prefix.  This is required by Kiali.