### PR TITLE
VZ-3844: replace extensions/v1beta1 with networking.k8s.io/v1 to support k8s 1.22

### DIFF
--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -23,6 +23,7 @@ func createIngressRuleElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, 
 		endpointName = componentDetails.Name
 	}
 	fqdn := fmt.Sprintf("%s.%s", endpointName, vmo.Spec.URI)
+	pathType := netv1.PathTypeImplementationSpecific
 
 	return netv1.IngressRule{
 		Host: fqdn,
@@ -30,7 +31,8 @@ func createIngressRuleElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, 
 			HTTP: &netv1.HTTPIngressRuleValue{
 				Paths: []netv1.HTTPIngressPath{
 					{
-						Path: "/",
+						Path:     "/",
+						PathType: &pathType,
 						Backend: netv1.IngressBackend{
 							Service: &netv1.IngressServiceBackend{
 								Name: serviceName,
@@ -229,13 +231,15 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 	}
 	serviceName := resources.AuthProxyMetaName()
 	ingressHost := resources.OidcProxyIngressHost(vmo, component)
+	pathType := netv1.PathTypeImplementationSpecific
 	ingressRule := netv1.IngressRule{
 		Host: ingressHost,
 		IngressRuleValue: netv1.IngressRuleValue{
 			HTTP: &netv1.HTTPIngressRuleValue{
 				Paths: []netv1.HTTPIngressPath{
 					{
-						Path: "/()(.*)",
+						Path:     "/()(.*)",
+						PathType: &pathType,
 						Backend: netv1.IngressBackend{
 							Service: &netv1.IngressServiceBackend{
 								Name: serviceName,

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -12,12 +12,11 @@ import (
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	"go.uber.org/zap"
-	extensions_v1beta1 "k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func createIngressRuleElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, componentDetails config.ComponentDetails) extensions_v1beta1.IngressRule {
+func createIngressRuleElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, componentDetails config.ComponentDetails) netv1.IngressRule {
 	serviceName := resources.GetMetaName(vmo.Name, componentDetails.Name)
 	endpointName := componentDetails.EndpointName
 	if endpointName == "" {
@@ -25,16 +24,20 @@ func createIngressRuleElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, 
 	}
 	fqdn := fmt.Sprintf("%s.%s", endpointName, vmo.Spec.URI)
 
-	return extensions_v1beta1.IngressRule{
+	return netv1.IngressRule{
 		Host: fqdn,
-		IngressRuleValue: extensions_v1beta1.IngressRuleValue{
-			HTTP: &extensions_v1beta1.HTTPIngressRuleValue{
-				Paths: []extensions_v1beta1.HTTPIngressPath{
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
 					{
 						Path: "/",
-						Backend: extensions_v1beta1.IngressBackend{
-							ServiceName: serviceName,
-							ServicePort: intstr.FromInt(componentDetails.Port),
+						Backend: netv1.IngressBackend{
+							Service: &netv1.IngressServiceBackend{
+								Name: serviceName,
+								Port: netv1.ServiceBackendPort{
+									Number: int32(componentDetails.Port),
+								},
+							},
 						},
 					},
 				},
@@ -43,9 +46,9 @@ func createIngressRuleElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, 
 	}
 }
 
-func createIngressElementNoBasicAuth(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, hostName string, componentDetails config.ComponentDetails, ingressRule extensions_v1beta1.IngressRule) (*extensions_v1beta1.Ingress, error) {
+func createIngressElementNoBasicAuth(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, hostName string, componentDetails config.ComponentDetails, ingressRule netv1.IngressRule) (*netv1.Ingress, error) {
 	var hosts = []string{hostName}
-	ingress := &extensions_v1beta1.Ingress{
+	ingress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations:     map[string]string{},
 			Labels:          resources.GetMetaLabels(vmo),
@@ -53,14 +56,14 @@ func createIngressElementNoBasicAuth(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 			Namespace:       vmo.Namespace,
 			OwnerReferences: resources.GetOwnerReferences(vmo),
 		},
-		Spec: extensions_v1beta1.IngressSpec{
-			TLS: []extensions_v1beta1.IngressTLS{
+		Spec: netv1.IngressSpec{
+			TLS: []netv1.IngressTLS{
 				{
 					Hosts:      hosts,
 					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, componentDetails.Name),
 				},
 			},
-			Rules: []extensions_v1beta1.IngressRule{ingressRule},
+			Rules: []netv1.IngressRule{ingressRule},
 		},
 	}
 
@@ -80,7 +83,7 @@ func createIngressElementNoBasicAuth(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 	return ingress, nil
 }
 
-func addBasicAuthIngressAnnotations(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, ingress *extensions_v1beta1.Ingress, healthLocations string) {
+func addBasicAuthIngressAnnotations(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, ingress *netv1.Ingress, healthLocations string) {
 	ingress.Annotations["nginx.ingress.kubernetes.io/auth-type"] = "basic"
 	ingress.Annotations["nginx.ingress.kubernetes.io/auth-secret"] = vmo.Spec.SecretName
 	ingress.Annotations["nginx.ingress.kubernetes.io/auth-realm"] = vmo.Spec.URI + " auth"
@@ -89,7 +92,7 @@ func addBasicAuthIngressAnnotations(vmo *vmcontrollerv1.VerrazzanoMonitoringInst
 	ingress.Annotations["nginx.ingress.kubernetes.io/server-snippet"] = healthLocations
 }
 
-func createIngressElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, hostName string, componentDetails config.ComponentDetails, ingressRule extensions_v1beta1.IngressRule, healthLocations string) (*extensions_v1beta1.Ingress, error) {
+func createIngressElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, hostName string, componentDetails config.ComponentDetails, ingressRule netv1.IngressRule, healthLocations string) (*netv1.Ingress, error) {
 	ingress, err := createIngressElementNoBasicAuth(vmo, hostName, componentDetails, ingressRule)
 	if err != nil {
 		return ingress, err
@@ -99,8 +102,8 @@ func createIngressElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, host
 }
 
 // New will return a new Service for VMO that needs to executed for on Complete
-func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*extensions_v1beta1.Ingress, error) {
-	var ingresses []*extensions_v1beta1.Ingress
+func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, error) {
+	var ingresses []*netv1.Ingress
 
 	// Only create ingress if URI and secret name specified
 	if len(vmo.Spec.URI) <= 0 {
@@ -183,7 +186,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*extensions_v1beta
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
 			ingresses = append(ingresses, ingress)
 		} else {
-			var ingress *extensions_v1beta1.Ingress
+			var ingress *netv1.Ingress
 			ingRule := createIngressRuleElement(vmo, config.ElasticsearchIngest)
 			host := config.ElasticsearchIngest.EndpointName + "." + vmo.Spec.URI
 			healthLocations := noAuthOnHealthCheckSnippet(vmo, "", config.ElasticsearchIngest)
@@ -201,7 +204,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*extensions_v1beta
 }
 
 // setNginxRoutingAnnotations adds the nginx annotations required for routing via istio envoy
-func setNginxRoutingAnnotations(ingress *extensions_v1beta1.Ingress) {
+func setNginxRoutingAnnotations(ingress *netv1.Ingress) {
 	ingress.Annotations["nginx.ingress.kubernetes.io/service-upstream"] = "true"
 	ingress.Annotations["nginx.ingress.kubernetes.io/upstream-vhost"] = "${service_name}.${namespace}.svc.cluster.local"
 }
@@ -219,30 +222,34 @@ func noAuthOnHealthCheckSnippet(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance
 }
 
 // newOidcProxyIngress creates the Ingress of the OidcProxy
-func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) *extensions_v1beta1.Ingress {
+func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) *netv1.Ingress {
 	port, err := strconv.Atoi(resources.AuthProxyPort())
 	if err != nil {
 		port = 8775
 	}
 	serviceName := resources.AuthProxyMetaName()
 	ingressHost := resources.OidcProxyIngressHost(vmo, component)
-	ingressRule := extensions_v1beta1.IngressRule{
+	ingressRule := netv1.IngressRule{
 		Host: ingressHost,
-		IngressRuleValue: extensions_v1beta1.IngressRuleValue{
-			HTTP: &extensions_v1beta1.HTTPIngressRuleValue{
-				Paths: []extensions_v1beta1.HTTPIngressPath{
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
 					{
 						Path: "/()(.*)",
-						Backend: extensions_v1beta1.IngressBackend{
-							ServiceName: serviceName,
-							ServicePort: intstr.FromInt(port),
+						Backend: netv1.IngressBackend{
+							Service: &netv1.IngressServiceBackend{
+								Name: serviceName,
+								Port: netv1.ServiceBackendPort{
+									Number: int32(port),
+								},
+							},
 						},
 					},
 				},
 			},
 		},
 	}
-	ingress := &extensions_v1beta1.Ingress{
+	ingress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations:     map[string]string{},
 			Labels:          resources.GetMetaLabels(vmo),
@@ -250,14 +257,14 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 			Namespace:       vmo.Namespace,
 			OwnerReferences: resources.GetOwnerReferences(vmo),
 		},
-		Spec: extensions_v1beta1.IngressSpec{
-			TLS: []extensions_v1beta1.IngressTLS{
+		Spec: netv1.IngressSpec{
+			TLS: []netv1.IngressTLS{
 				{
 					Hosts:      []string{ingressHost},
 					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
 				},
 			},
-			Rules: []extensions_v1beta1.IngressRule{ingressRule},
+			Rules: []netv1.IngressRule{ingressRule},
 		},
 	}
 	ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = constants.NginxClientMaxBodySize

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -223,7 +223,7 @@ func noAuthOnHealthCheckSnippet(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance
 
 // newOidcProxyIngress creates the Ingress of the OidcProxy
 func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) *netv1.Ingress {
-	port, err := strconv.Atoi(resources.AuthProxyPort())
+	port, err := strconv.ParseInt(resources.AuthProxyPort(), 10, 32)
 	if err != nil {
 		port = 8775
 	}

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -7,11 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/opensearch"
-	dashboards "github.com/verrazzano/verrazzano-monitoring-operator/pkg/opensearch_dashboards"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/upgrade"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
-	"k8s.io/apimachinery/pkg/types"
 	"reflect"
 	"time"
 
@@ -23,12 +18,17 @@ import (
 	listers "github.com/verrazzano/verrazzano-monitoring-operator/pkg/client/listers/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/opensearch"
+	dashboards "github.com/verrazzano/verrazzano-monitoring-operator/pkg/opensearch_dashboards"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/signals"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/upgrade"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeinformers "k8s.io/client-go/informers"
@@ -37,7 +37,7 @@ import (
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	appslistersv1 "k8s.io/client-go/listers/apps/v1"
 	corelistersv1 "k8s.io/client-go/listers/core/v1"
-	extensionslistersv1beta1 "k8s.io/client-go/listers/extensions/v1beta1"
+	netlistersv1 "k8s.io/client-go/listers/networking/v1"
 	rbacv1listers1 "k8s.io/client-go/listers/rbac/v1"
 	storagelisters1 "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
@@ -63,7 +63,7 @@ type Controller struct {
 	configMapsSynced     cache.InformerSynced
 	deploymentLister     appslistersv1.DeploymentLister
 	deploymentsSynced    cache.InformerSynced
-	ingressLister        extensionslistersv1beta1.IngressLister
+	ingressLister        netlistersv1.IngressLister
 	ingressesSynced      cache.InformerSynced
 	nodeLister           corelistersv1.NodeLister
 	nodesSynced          cache.InformerSynced
@@ -185,7 +185,7 @@ func NewController(namespace string, configmapName string, buildVersion string, 
 	clusterRoleInformer := kubeInformerFactory.Rbac().V1().ClusterRoles()
 	configmapInformer := kubeInformerFactory.Core().V1().ConfigMaps()
 	deploymentInformer := kubeInformerFactory.Apps().V1().Deployments()
-	ingressInformer := kubeInformerFactory.Extensions().V1beta1().Ingresses()
+	ingressInformer := kubeInformerFactory.Networking().V1().Ingresses()
 	nodeInformer := kubeInformerFactory.Core().V1().Nodes()
 	pvcInformer := kubeInformerFactory.Core().V1().PersistentVolumeClaims()
 	roleBindingInformer := kubeInformerFactory.Rbac().V1().RoleBindings()

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -48,10 +48,10 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 			specDiffs := diff.Diff(existingIngress, curIngress)
 			if specDiffs != "" {
 				controller.log.Debugf("Ingress %s : Spec differences %s", curIngress.Name, specDiffs)
-				_, err = controller.kubeclientset.ExtensionsV1beta1().Ingresses(vmo.Namespace).Update(context.TODO(), curIngress, metav1.UpdateOptions{})
+				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), curIngress, metav1.UpdateOptions{})
 			}
 		} else if k8serrors.IsNotFound(err) {
-			_, err = controller.kubeclientset.ExtensionsV1beta1().Ingresses(vmo.Namespace).Create(context.TODO(), curIngress, metav1.CreateOptions{})
+			_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Create(context.TODO(), curIngress, metav1.CreateOptions{})
 		} else {
 			controller.log.Errorf("Failed getting existing Ingress %s/%s: %v", vmo.Namespace, ingName, err)
 			return err


### PR DESCRIPTION
This pull request replaces use of extensions/v1beta1 with networking.k8s.io/v1 for ingresses.  This fix allows VMO to work on k8s 1.22+