### PR TITLE
VZ-5623: Add labels for filtering

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -245,3 +245,6 @@ const (
 
 //ComponentLabel - the label for a specific component
 const ComponentLabel = "verrazzano-component"
+
+//ComponentOpenSearchValue - the value for opensearch component
+const ComponentOpenSearchValue = "opensearch"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -242,3 +242,6 @@ const (
 	ObjectStoreCustomerKeyVarName = "OBJECT_STORE_SECRET_KEY_ID"
 	ObjectStoreCustomerKey        = "object_store_secret_key"
 )
+
+//ComponentLabel - the label for a specific component
+const ComponentLabel = "verrazzano-component"

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -302,7 +302,7 @@ func createDeploymentElementByPvcIndex(vmo *vmcontrollerv1.VerrazzanoMonitoringI
 
 	resourceLabel := resources.GetMetaLabels(vmo)
 	resourceLabel[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
-	podLabels := resources.GetSpecID(vmo.Name, componentDetails.Name)
+	podLabels := resources.DeepCopyMap(labels)
 	podLabels[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -302,7 +302,8 @@ func createDeploymentElementByPvcIndex(vmo *vmcontrollerv1.VerrazzanoMonitoringI
 
 	resourceLabel := resources.GetMetaLabels(vmo)
 	resourceLabel[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
-	labels[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
+	podLabels := resources.GetSpecID(vmo.Name, componentDetails.Name)
+	podLabels[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:          resourceLabel,
@@ -317,7 +318,7 @@ func createDeploymentElementByPvcIndex(vmo *vmcontrollerv1.VerrazzanoMonitoringI
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: podLabels,
 				},
 				Spec: corev1.PodSpec{
 					Volumes: volumes,

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -300,9 +300,12 @@ func createDeploymentElementByPvcIndex(vmo *vmcontrollerv1.VerrazzanoMonitoringI
 		labels["index"] = strconv.Itoa(pvcIndex)
 	}
 
+	resourceLabel := resources.GetMetaLabels(vmo)
+	resourceLabel[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
+	labels[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:          resources.GetMetaLabels(vmo),
+			Labels:          resourceLabel,
 			Name:            deploymentName,
 			Namespace:       vmo.Namespace,
 			OwnerReferences: resources.GetOwnerReferences(vmo),

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -76,11 +76,20 @@ func GetCompLabel(componentName string) string {
 	var componentLabelValue string
 	switch componentName {
 	case config.ElasticsearchMaster.Name, config.ElasticsearchData.Name, config.ElasticsearchIngest.Name:
-		componentLabelValue = "opensearch"
+		componentLabelValue = constants.ComponentOpenSearchValue
 	default:
 		componentLabelValue = componentName
 	}
 	return componentLabelValue
+}
+
+// DeepCopyMap performs a deepcopy of a map
+func DeepCopyMap(srcMap map[string]string) map[string]string {
+	result := make(map[string]string, len(srcMap))
+	for k, v := range srcMap {
+		result[k] = v
+	}
+	return result
 }
 
 // GetSpecID returns app label

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -63,12 +63,25 @@ func GetNewRandomID(size int) (string, error) {
 
 // GetMetaName returns name
 func GetMetaName(vmoName string, componentName string) string {
+	// adding component specific labels
 	return constants.VMOServiceNamePrefix + vmoName + "-" + componentName
 }
 
 // GetMetaLabels returns k8s-app and vmo lables
 func GetMetaLabels(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) map[string]string {
 	return map[string]string{constants.K8SAppLabel: constants.VMOGroup, constants.VMOLabel: vmo.Name}
+}
+
+// GetCompLabel returns a component value for opensearch
+func GetCompLabel(componentName string) string {
+	var componentLabelValue string
+	switch componentName {
+	case "es-master", "es-data", "es-ingest":
+		componentLabelValue = "opensearch"
+	default:
+		componentLabelValue = componentName
+	}
+	return componentLabelValue
 }
 
 // GetSpecID returns app label

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -75,7 +75,7 @@ func GetMetaLabels(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) map[string]
 func GetCompLabel(componentName string) string {
 	var componentLabelValue string
 	switch componentName {
-	case "es-master", "es-data", "es-ingest":
+	case config.ElasticsearchMaster.Name, config.ElasticsearchData.Name, config.ElasticsearchIngest.Name:
 		componentLabelValue = "opensearch"
 	default:
 		componentLabelValue = componentName

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -63,7 +63,6 @@ func GetNewRandomID(size int) (string, error) {
 
 // GetMetaName returns name
 func GetMetaName(vmoName string, componentName string) string {
-	// adding component specific labels
 	return constants.VMOServiceNamePrefix + vmoName + "-" + componentName
 }
 

--- a/pkg/resources/helper_test.go
+++ b/pkg/resources/helper_test.go
@@ -249,3 +249,22 @@ func TestGetCompLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestDeepCopyMap(t *testing.T) {
+	var tests = []struct {
+		srcMap map[string]string
+		dstMap map[string]string
+	}{
+		{
+			map[string]string{"foo": "bar"},
+			map[string]string{"foo": "bar"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("basic deepcopy test", func(t *testing.T) {
+			r := DeepCopyMap(tt.srcMap)
+			assert.Equal(t, tt.dstMap, r)
+		})
+	}
+}

--- a/pkg/resources/helper_test.go
+++ b/pkg/resources/helper_test.go
@@ -218,3 +218,34 @@ func TestConvertToRegexp(t *testing.T) {
 		})
 	}
 }
+
+func TestGetCompLabel(t *testing.T) {
+	var tests = []struct {
+		compName     string
+		expectedName string
+	}{
+		{
+			"es-master",
+			"opensearch",
+		},
+		{
+			"es-data",
+			"opensearch",
+		},
+		{
+			"es-ingest",
+			"opensearch",
+		},
+		{
+			"foo",
+			"foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("component name '%s' to expectedName '%s'", tt.compName, tt.expectedName), func(t *testing.T) {
+			r := GetCompLabel(tt.compName)
+			assert.Equal(t, tt.expectedName, r)
+		})
+	}
+}

--- a/pkg/resources/services/service.go
+++ b/pkg/resources/services/service.go
@@ -6,6 +6,7 @@ package services
 import (
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,9 +50,11 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*corev1.Service, e
 	return services, nil
 }
 func createServiceElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, componentDetails config.ComponentDetails) *corev1.Service {
+	resourceLabel := resources.GetMetaLabels(vmo)
+	resourceLabel[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:          resources.GetMetaLabels(vmo),
+			Labels:          resourceLabel,
 			Name:            resources.GetMetaName(vmo.Name, componentDetails.Name),
 			Namespace:       vmo.Namespace,
 			OwnerReferences: resources.GetOwnerReferences(vmo),

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -365,7 +365,8 @@ func createStatefulSetElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, 
 	}
 	resourceLabel := resources.GetMetaLabels(vmo)
 	resourceLabel[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
-	labels[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
+	podLabels := resources.GetSpecID(vmo.Name, componentDetails.Name)
+	podLabels[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:          resourceLabel,
@@ -384,7 +385,7 @@ func createStatefulSetElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, 
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: podLabels,
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -363,10 +363,12 @@ func createStatefulSetElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, 
 	if serviceName == "" {
 		serviceName = statefulSetName
 	}
-
+	resourceLabel := resources.GetMetaLabels(vmo)
+	resourceLabel[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
+	labels[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:          resources.GetMetaLabels(vmo),
+			Labels:          resourceLabel,
 			Name:            statefulSetName,
 			Namespace:       vmo.Namespace,
 			OwnerReferences: resources.GetOwnerReferences(vmo),

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -365,7 +365,7 @@ func createStatefulSetElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, 
 	}
 	resourceLabel := resources.GetMetaLabels(vmo)
 	resourceLabel[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
-	podLabels := resources.GetSpecID(vmo.Name, componentDetails.Name)
+	podLabels := resources.DeepCopyMap(labels)
 	podLabels[constants.ComponentLabel] = resources.GetCompLabel(componentDetails.Name)
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Adding component specific labels for filtering 

Today under verrazzano-system , there is no way to filter objects based on the component 
This change will add those filters 

```
kubectl get pod -n verrazzano-system -l verrazzano-component
NAME                                       READY   STATUS    RESTARTS   AGE
vmi-system-es-data-0-7b5cccc464-mlfxn      2/2     Running   0          15h
vmi-system-es-data-1-7bfd8b7b8c-ttl5h      2/2     Running   0          15h
vmi-system-es-data-2-778bd48c48-726l9      2/2     Running   0          15h
vmi-system-es-ingest-76f9cf577-bv9s8       2/2     Running   1          15h
vmi-system-es-master-0                     2/2     Running   0          15h
vmi-system-es-master-1                     2/2     Running   0          15h
vmi-system-es-master-2                     2/2     Running   0          15h
vmi-system-grafana-7784d444cf-t7rr9        2/2     Running   0          15h
vmi-system-kibana-7d66ddbd89-pbs4z         2/2     Running   0          15h
vmi-system-prometheus-0-6bfd76bd46-vqs96   3/3     Running   0          15h

kubectl get pod -n verrazzano-system -l verrazzano-component=opensearch
NAME                                    READY   STATUS    RESTARTS   AGE
vmi-system-es-data-0-7b5cccc464-mlfxn   2/2     Running   0          15h
vmi-system-es-data-1-7bfd8b7b8c-ttl5h   2/2     Running   0          15h
vmi-system-es-data-2-778bd48c48-726l9   2/2     Running   0          15h
vmi-system-es-ingest-76f9cf577-bv9s8    2/2     Running   1          15h
vmi-system-es-master-0                  2/2     Running   0          15h
vmi-system-es-master-1                  2/2     Running   0          15h
vmi-system-es-master-2                  2/2     Running   0          15h


kubectl get pod -n verrazzano-system -l verrazzano-component=grafana
NAME                                  READY   STATUS    RESTARTS   AGE
vmi-system-grafana-7784d444cf-t7rr9   2/2     Running   0          15h

kubectl get pod -n verrazzano-system -l verrazzano-component=kibana
NAME                                 READY   STATUS    RESTARTS   AGE
vmi-system-kibana-7d66ddbd89-pbs4z   2/2     Running   0          15h

kubectl get pod -n verrazzano-system -l verrazzano-component=prometheus
NAME                                       READY   STATUS    RESTARTS   AGE
vmi-system-prometheus-0-6bfd76bd46-vqs96   3/3     Running   0          15h
```