### PR TITLE
Bounce single node on update

### DIFF
--- a/pkg/resources/statefulsets/plan.go
+++ b/pkg/resources/statefulsets/plan.go
@@ -45,7 +45,7 @@ func CreatePlan(log vzlog.VerrazzanoLogger, existingList, expectedList []*appsv1
 		ExistingCluster: mapping.existingSize > 0,
 		// Bounce the master node if it's a single node cluster and we're scaling up to a healthy size.
 		// This removes of the single node property in the pod environment.
-		BounceNodes: mapping.existingSize == 1 && mapping.expectedSize > 2,
+		BounceNodes: mapping.existingSize == 1 && mapping.expectedSize >= minClusterSize,
 	}
 	for name, expected := range mapping.expected {
 		existing, ok := mapping.existing[name]

--- a/pkg/resources/statefulsets/plan.go
+++ b/pkg/resources/statefulsets/plan.go
@@ -43,9 +43,9 @@ func CreatePlan(log vzlog.VerrazzanoLogger, existingList, expectedList []*appsv1
 	plan := &StatefulSetPlan{
 		// There is no running cluster if the existing size is 0
 		ExistingCluster: mapping.existingSize > 0,
-		// Bounce the master node if it's a single node cluster and we're scaling up.
+		// Bounce the master node if it's a single node cluster and we're scaling up to a healthy size.
 		// This removes of the single node property in the pod environment.
-		BounceNodes: mapping.existingSize == 1 && mapping.expectedSize > 1,
+		BounceNodes: mapping.existingSize == 1 && mapping.expectedSize > 2,
 	}
 	for name, expected := range mapping.expected {
 		existing, ok := mapping.existing[name]

--- a/pkg/resources/statefulsets/plan_test.go
+++ b/pkg/resources/statefulsets/plan_test.go
@@ -38,6 +38,22 @@ func TestCreatePlan(t *testing.T) {
 		plan         *StatefulSetPlan
 	}{
 		{
+			"should bounce nodes when scaling up single node cluster",
+			[]*appsv1.StatefulSet{
+				createTestSTS("foo", 1),
+			},
+			[]*appsv1.StatefulSet{
+				createTestSTS("foo", 3),
+			},
+			&StatefulSetPlan{
+				ExistingCluster: true,
+				BounceNodes:     true,
+				Update: []*appsv1.StatefulSet{
+					createTestSTS("foo", 3),
+				},
+			},
+		},
+		{
 			"do nothing when expected and existing are the same",
 			[]*appsv1.StatefulSet{
 				createTestSTS("foo", 1),
@@ -164,6 +180,7 @@ func TestCreatePlan(t *testing.T) {
 			assert.Equal(t, len(tt.plan.Update), len(actualPlan.Update))
 			assert.Equal(t, len(tt.plan.Delete), len(actualPlan.Delete))
 			assert.Equal(t, tt.plan.ExistingCluster, actualPlan.ExistingCluster)
+			assert.Equal(t, tt.plan.BounceNodes, actualPlan.BounceNodes)
 		})
 	}
 }


### PR DESCRIPTION
To scale up a single node cluster, the node must be bounced to pick up the new cluster properties. This is necessary because clusters set to single node discovery cannot add nodes.