### PR TITLE
VZ-5719: Change a couple of Grafana settings when Auth Proxy is disabled

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -91,7 +91,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, kubeclientset kuberne
 				{Name: "GF_AUTH_BASIC_ENABLED", Value: "true"},
 				{Name: "GF_USERS_ALLOW_SIGN_UP", Value: "false"},
 				{Name: "GF_USERS_AUTO_ASSIGN_ORG", Value: "true"},
-				{Name: "GF_USERS_AUTO_ASSIGN_ORG_ROLE", Value: "Admin"},
+				{Name: "GF_USERS_AUTO_ASSIGN_ORG_ROLE", Value: "Editor"},
 				{Name: "GF_AUTH_DISABLE_LOGIN_FORM", Value: "false"},
 				{Name: "GF_AUTH_DISABLE_SIGNOUT_MENU", Value: "false"},
 			}...)

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -89,7 +89,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, kubeclientset kuberne
 				},
 				{Name: "GF_AUTH_ANONYMOUS_ENABLED", Value: "false"},
 				{Name: "GF_AUTH_BASIC_ENABLED", Value: "true"},
-				{Name: "GF_USERS_ALLOW_SIGN_UP", Value: "true"},
+				{Name: "GF_USERS_ALLOW_SIGN_UP", Value: "false"},
 				{Name: "GF_USERS_AUTO_ASSIGN_ORG", Value: "true"},
 				{Name: "GF_USERS_AUTO_ASSIGN_ORG_ROLE", Value: "Admin"},
 				{Name: "GF_AUTH_DISABLE_LOGIN_FORM", Value: "false"},


### PR DESCRIPTION
When Auth Proxy is disabled, users will access the Grafana web UI directly using HTTP basic auth. This PR disables allowing user sign up (the admin user can create users) and changes the default org role from Admin to Editor. The second change is probably not necessary since the admin will assign the role when creating users, but better to downgrade the role from a security standpoint.