### PR TITLE
Reorder conditional to prevent array out of bounds

### DIFF
--- a/pkg/resources/statefulsets/plan.go
+++ b/pkg/resources/statefulsets/plan.go
@@ -98,7 +98,7 @@ func createStatefulSetMapping(existingList, expectedList []*appsv1.StatefulSet) 
 
 	// if expected size is one, we have a single node cluster. By definition these are
 	// less resilient, so updates/restarts are allowed (otherwise they would never be possible).
-	if (existingSize == 1 && expectedList[0].Name == existingList[0].Name) || expectedSize == 0 {
+	if expectedSize == 0 || (existingSize == 1 && expectedList[0].Name == existingList[0].Name) {
 		// if we have a single node cluster, or the desired outcome is to scale everything down to 0,
 		// scale down is allowed
 		mapping.isScaleDownAllowed = true

--- a/pkg/resources/statefulsets/plan_test.go
+++ b/pkg/resources/statefulsets/plan_test.go
@@ -38,6 +38,19 @@ func TestCreatePlan(t *testing.T) {
 		plan         *StatefulSetPlan
 	}{
 		{
+			"should delete nodes when expected is empty",
+			[]*appsv1.StatefulSet{
+				createTestSTS("foo", 1),
+			},
+			[]*appsv1.StatefulSet{},
+			&StatefulSetPlan{
+				ExistingCluster: true,
+				Delete: []*appsv1.StatefulSet{
+					createTestSTS("foo", 1),
+				},
+			},
+		},
+		{
 			"should bounce nodes when scaling up single node cluster",
 			[]*appsv1.StatefulSet{
 				createTestSTS("foo", 1),


### PR DESCRIPTION
Array out of bounds could happen in some circumstances. Reordering the conditional prevents this.