### PR TITLE
Scale in Statefulset/Deployment

### DIFF
--- a/pkg/resources/statefulsets/plan.go
+++ b/pkg/resources/statefulsets/plan.go
@@ -55,7 +55,7 @@ func CreatePlan(log vzlog.VerrazzanoLogger, existingList, expectedList []*appsv1
 		} else if mapping.isScaleDownAllowed || !plan.ExistingCluster {
 			// The cluster is in a state that allows updates, so we check if the STS has changed
 			CopyFromExisting(expected, existing)
-			specDiffs := diff.Diff(expected, existing)
+			specDiffs := diff.Diff(existing, expected)
 			if specDiffs != "" || *existing.Spec.Replicas != *expected.Spec.Replicas {
 				log.Oncef("Statefulset %s/%s has spec differences %s", expected.Namespace, expected.Name, specDiffs)
 				plan.Update = append(plan.Update, expected)

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -127,7 +127,7 @@ func CreateDeployments(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMon
 	}
 	for _, deployment := range existingDeploymentsList {
 		if !contains(deploymentNames, deployment.Name) {
-			if deployments.IsOpenSearchDataDeployment(vmo.Name, deployment) && (expected.OpenSearchDataDeployments > 0 || deployment.Status.ReadyReplicas < 1) {
+			if deployments.IsOpenSearchDataDeployment(vmo.Name, deployment) && (expected.OpenSearchDataDeployments > 0 || deployment.Status.ReadyReplicas > 0) {
 				if err := controller.osClient.IsGreen(vmo); err != nil {
 					controller.log.Oncef("Scale down of deployment %s not allowed: cluster health is not green", deployment.Name)
 					continue

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -127,6 +127,8 @@ func CreateDeployments(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMon
 	}
 	for _, deployment := range existingDeploymentsList {
 		if !contains(deploymentNames, deployment.Name) {
+			// if processing an OpenSearch data node, and the data node is expected and running
+			// An OpenSearch health check should be made to prevent unexpected shard allocation
 			if deployments.IsOpenSearchDataDeployment(vmo.Name, deployment) && (expected.OpenSearchDataDeployments > 0 || deployment.Status.ReadyReplicas > 0) {
 				if err := controller.osClient.IsGreen(vmo); err != nil {
 					controller.log.Oncef("Scale down of deployment %s not allowed: cluster health is not green", deployment.Name)

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -127,7 +127,7 @@ func CreateDeployments(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMon
 	}
 	for _, deployment := range existingDeploymentsList {
 		if !contains(deploymentNames, deployment.Name) {
-			if deployments.IsOpenSearchDataDeployment(vmo.Name, deployment) && expected.OpenSearchDataDeployments > 0 {
+			if deployments.IsOpenSearchDataDeployment(vmo.Name, deployment) && (expected.OpenSearchDataDeployments > 0 || deployment.Status.ReadyReplicas < 1) {
 				if err := controller.osClient.IsGreen(vmo); err != nil {
 					controller.log.Oncef("Scale down of deployment %s not allowed: cluster health is not green", deployment.Name)
 					continue


### PR DESCRIPTION
If the Statefulset or Deployment is down (no ready replicas), allow the resource to be updated or deleted.
This allows the use case where the user may want to scale-in or update a resource, but the cluster is not in a healthy state.
If the nodes are running, a safe scale down will be issued, to re-allocate any shards on the node.  