### PR TITLE
VZ 5927: Scale up single node dev profile

### DIFF
--- a/pkg/resources/statefulsets/plan.go
+++ b/pkg/resources/statefulsets/plan.go
@@ -117,5 +117,5 @@ func CopyFromExisting(expected, existing *appsv1.StatefulSet) {
 	expected.Spec.VolumeClaimTemplates = existing.Spec.VolumeClaimTemplates
 	// Changes to selector are forbidden
 	expected.Spec.Selector = existing.Spec.Selector
-	resources.CopyInitialMasterNodes(expected.Spec.Template.Spec.Containers, existing.Spec.Template.Spec.Containers, config.ElasticsearchMaster.Name)
+	resources.CopyImmutableEnvVars(expected.Spec.Template.Spec.Containers, existing.Spec.Template.Spec.Containers, config.ElasticsearchMaster.Name)
 }

--- a/pkg/resources/statefulsets/plan_test.go
+++ b/pkg/resources/statefulsets/plan_test.go
@@ -204,6 +204,7 @@ func TestCreatePlan(t *testing.T) {
 }
 
 func TestCopyFromContainers(t *testing.T) {
+	nodeRoleVar := "node.roles"
 	existing := createTestSTS("foo", 1)
 	existing.Spec = appsv1.StatefulSetSpec{
 		VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
@@ -223,6 +224,10 @@ func TestCopyFromContainers(t *testing.T) {
 								Name:  constants.ClusterInitialMasterNodes,
 								Value: "z",
 							},
+							{
+								Name:  nodeRoleVar,
+								Value: "a",
+							},
 						},
 					},
 				},
@@ -241,6 +246,10 @@ func TestCopyFromContainers(t *testing.T) {
 								Name:  "x",
 								Value: "y",
 							},
+							{
+								Name:  nodeRoleVar,
+								Value: "b",
+							},
 						},
 					},
 				},
@@ -252,10 +261,16 @@ func TestCopyFromContainers(t *testing.T) {
 	existingInitialClusterMasters := resources.GetEnvVar(&existing.Spec.Template.Spec.Containers[0], constants.ClusterInitialMasterNodes)
 	expectedInitialClusterMasters := resources.GetEnvVar(&expected.Spec.Template.Spec.Containers[0], constants.ClusterInitialMasterNodes)
 	assert.NotEqualValues(t, existingInitialClusterMasters, expectedInitialClusterMasters)
+	existingNodeRoles := resources.GetEnvVar(&existing.Spec.Template.Spec.Containers[0], nodeRoleVar)
+	expectedNodeRoles := resources.GetEnvVar(&expected.Spec.Template.Spec.Containers[0], nodeRoleVar)
+	assert.NotEqualValues(t, existingNodeRoles, expectedNodeRoles)
 	CopyFromExisting(expected, existing)
 
 	assert.EqualValues(t, existing.Spec.VolumeClaimTemplates, expected.Spec.VolumeClaimTemplates)
 	existingInitialClusterMasters = resources.GetEnvVar(&existing.Spec.Template.Spec.Containers[0], constants.ClusterInitialMasterNodes)
 	expectedInitialClusterMasters = resources.GetEnvVar(&expected.Spec.Template.Spec.Containers[0], constants.ClusterInitialMasterNodes)
 	assert.EqualValues(t, existingInitialClusterMasters, expectedInitialClusterMasters)
+	existingNodeRoles = resources.GetEnvVar(&existing.Spec.Template.Spec.Containers[0], nodeRoleVar)
+	expectedNodeRoles = resources.GetEnvVar(&expected.Spec.Template.Spec.Containers[0], nodeRoleVar)
+	assert.EqualValues(t, existingNodeRoles, expectedNodeRoles)
 }


### PR DESCRIPTION
In addition to allowing InstallArg profiles to scale up, this prevents a few nasty scenarios that lose cluster state:
- removing master roles dumps cluster state
- removing data roles causes shard allocation issues

There are ways to repurpose nodes, but the use of a CLI tool is required, run from within the node. It's recommended to create new nodes instead, and decommission old nodes with the undesired roles.