### PR TITLE
VZ-6150 (Backport to release-1.3) VMO expects a default storage class even when emptyDir is configured

### DIFF
--- a/pkg/vmo/pvc.go
+++ b/pkg/vmo/pvc.go
@@ -178,7 +178,12 @@ func determineStorageClass(controller *Controller, className *string) (*storagev
 	if err != nil {
 		return nil, err
 	}
-	return getDefaultStorageClass(storageClasses)
+	emptyStorageClass := &storagev1.StorageClass{}
+	defaultStorageClass := getDefaultStorageClass(storageClasses)
+	if defaultStorageClass == emptyStorageClass {
+		controller.log.Info("Failed to find a default storage class. Returning an empty storage class.")
+	}
+	return defaultStorageClass, nil
 }
 
 func getStorageClassOverride(controller *Controller, className *string) (*storagev1.StorageClass, error) {
@@ -235,12 +240,12 @@ func getZoneFromExistingPvc(storageClassInfo StorageClassInfo, existingPvc *core
 }
 
 // Determines the "default" storage class from a list of storage classes.
-func getDefaultStorageClass(storageClasses []*storagev1.StorageClass) (*storagev1.StorageClass, error) {
+func getDefaultStorageClass(storageClasses []*storagev1.StorageClass) *storagev1.StorageClass {
 	for _, storageClass := range storageClasses {
 		if storageClass.ObjectMeta.Annotations[constants.K8sDefaultStorageClassAnnotation] == "true" ||
 			storageClass.ObjectMeta.Annotations[constants.K8sDefaultStorageClassBetaAnnotation] == "true" {
-			return storageClass, nil
+			return storageClass
 		}
 	}
-	return nil, fmt.Errorf("Failed to find a default storage class")
+	return &storagev1.StorageClass{}
 }

--- a/pkg/vmo/pvc.go
+++ b/pkg/vmo/pvc.go
@@ -34,7 +34,7 @@ func CreatePersistentVolumeClaims(controller *Controller, vmo *vmcontrollerv1.Ve
 	}
 	emptyStorageClass := &storagev1.StorageClass{}
 	if storageClass == emptyStorageClass {
-		return nil, fmt.Errorf("Found an empty storage class")
+		return nil, fmt.Errorf("found an empty storage class")
 	}
 	storageClassInfo := parseStorageClassInfo(storageClass, controller.operatorConfig)
 

--- a/pkg/vmo/pvc.go
+++ b/pkg/vmo/pvc.go
@@ -33,26 +33,26 @@ func CreatePersistentVolumeClaims(controller *Controller, vmo *vmcontrollerv1.Ve
 		return nil, err
 	}
 	storageClassInfo := parseStorageClassInfo(storageClass, controller.operatorConfig)
-	
+
 	expectedPVCs, err := pvcs.New(vmo, storageClass.Name)
 	if err != nil {
 		controller.log.Errorf("Failed to create PVC specs for VMI %s: %v", vmo.Name, err)
 		return nil, err
 	}
 	pvcToAdMap := map[string]string{}
-	
+
 	controller.log.Oncef("Creating/updating PVCs for VMI %s", vmo.Name)
-	
+
 	// Get total list of all possible schedulable ADs
 	schedulableADs, err := getSchedulableADs(controller)
 	if err != nil {
 		return pvcToAdMap, err
 	}
-	
+
 	// Keep track of ADs for Prometheus and Elasticsearch PVCs, to ensure they land on all different ADs
 	prometheusAdCounter := NewAdPvcCounter(schedulableADs)
 	elasticsearchAdCounter := NewAdPvcCounter(schedulableADs)
-	
+
 	emptyStorageClass := &storagev1.StorageClass{}
 	if len(expectedPVCs) > 0 && storageClass == emptyStorageClass {
 		return nil, fmt.Errorf("cannot create PVCs when the cluster has no storage class")

--- a/pkg/vmo/pvc.go
+++ b/pkg/vmo/pvc.go
@@ -53,8 +53,7 @@ func CreatePersistentVolumeClaims(controller *Controller, vmo *vmcontrollerv1.Ve
 	prometheusAdCounter := NewAdPvcCounter(schedulableADs)
 	elasticsearchAdCounter := NewAdPvcCounter(schedulableADs)
 
-	emptyStorageClass := &storagev1.StorageClass{}
-	if len(expectedPVCs) > 0 && storageClass == emptyStorageClass {
+	if len(expectedPVCs) > 0 && storageClassInfo.Name == "" {
 		return nil, fmt.Errorf("cannot create PVCs when the cluster has no storage class")
 	}
 	for _, expectedPVC := range expectedPVCs {

--- a/pkg/vmo/pvc.go
+++ b/pkg/vmo/pvc.go
@@ -56,6 +56,7 @@ func CreatePersistentVolumeClaims(controller *Controller, vmo *vmcontrollerv1.Ve
 	// Keep track of ADs for Prometheus and Elasticsearch PVCs, to ensure they land on all different ADs
 	prometheusAdCounter := NewAdPvcCounter(schedulableADs)
 	elasticsearchAdCounter := NewAdPvcCounter(schedulableADs)
+
 	for _, expectedPVC := range expectedPVCs {
 		pvcName := expectedPVC.Name
 		if pvcName == "" {

--- a/pkg/vmo/pvc_test.go
+++ b/pkg/vmo/pvc_test.go
@@ -172,10 +172,10 @@ func TestGetDefaultStorageClass3(t *testing.T) {
 	storageClass2 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass2"}}
 	storageClass3 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass3"}}
 	result := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
-	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect storage class to be empty")
+	assert.Equal(t, result.Name, "", "Expect storage class name to be empty")
 }
 
 func TestGetDefaultStorageClass4(t *testing.T) {
 	result := getDefaultStorageClass([]*storagev1.StorageClass{})
-	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect storage class to be empty")
+	assert.Equal(t, result.Name, "", "Expect storage class name to be empty")
 }

--- a/pkg/vmo/pvc_test.go
+++ b/pkg/vmo/pvc_test.go
@@ -155,7 +155,7 @@ func TestGetDefaultStorageClass1(t *testing.T) {
 	storageClass1 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass1"}}
 	storageClass2 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass2", Annotations: map[string]string{constants.K8sDefaultStorageClassAnnotation: "true"}}}
 	storageClass3 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass3"}}
-	result, _ := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
+	result := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
 	assert.Equal(t, result, &storageClass2, "Default storage class found based on standard label")
 }
 
@@ -163,7 +163,7 @@ func TestGetDefaultStorageClass2(t *testing.T) {
 	storageClass1 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass1"}}
 	storageClass2 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass2"}}
 	storageClass3 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass3", Annotations: map[string]string{constants.K8sDefaultStorageClassBetaAnnotation: "true"}}}
-	result, _ := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
+	result := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
 	assert.Equal(t, result, &storageClass3, "Default storage class found based on beta label")
 }
 
@@ -171,15 +171,11 @@ func TestGetDefaultStorageClass3(t *testing.T) {
 	storageClass1 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass1"}}
 	storageClass2 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass2"}}
 	storageClass3 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass3"}}
-	result, err := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
-	var expectedStorageClass *storagev1.StorageClass
-	assert.Equal(t, expectedStorageClass, result, "No default storage class")
-	assert.NotEqual(t, nil, err, "Error from no default storage class")
+	result := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
+	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect name to be same")
 }
 
 func TestGetDefaultStorageClass4(t *testing.T) {
-	result, err := getDefaultStorageClass([]*storagev1.StorageClass{})
-	var expectedStorageClass *storagev1.StorageClass
-	assert.Equal(t, expectedStorageClass, result, "No storage classes")
-	assert.NotEqual(t, nil, err, "Error from no storage classes")
+	result := getDefaultStorageClass([]*storagev1.StorageClass{})
+	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect name to be same")
 }

--- a/pkg/vmo/pvc_test.go
+++ b/pkg/vmo/pvc_test.go
@@ -172,10 +172,10 @@ func TestGetDefaultStorageClass3(t *testing.T) {
 	storageClass2 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass2"}}
 	storageClass3 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass3"}}
 	result := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
-	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect name to be same")
+	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect storage class to be empty")
 }
 
 func TestGetDefaultStorageClass4(t *testing.T) {
 	result := getDefaultStorageClass([]*storagev1.StorageClass{})
-	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect name to be same")
+	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect storage class to be empty")
 }


### PR DESCRIPTION
# Description

- Fixes VZ-6150
- Updated the getDefaultStorage function to return an empty StorageClass object when emptyDir is configured
- Updated pvc tests