### PR TITLE
VZ-6150 VMO expects a default storage class even when emptyDir is configured

### DIFF
--- a/pkg/vmo/pvc.go
+++ b/pkg/vmo/pvc.go
@@ -242,7 +242,6 @@ func getDefaultStorageClass(storageClasses []*storagev1.StorageClass) (*storagev
 			return storageClass, nil
 		}
 	}
-	fmt.Printf("Failed to find a default storage class. Returning an empty storage class.")
-	var defaultStorageClass = storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass-default", Annotations: map[string]string{constants.K8sDefaultStorageClassAnnotation: "true"}}}
-	return &defaultStorageClass, nil
+	fmt.Println("Failed to find a default storage class. Returning an empty storage class.")
+	return &storagev1.StorageClass{}, nil
 }

--- a/pkg/vmo/pvc.go
+++ b/pkg/vmo/pvc.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -16,93 +14,17 @@ import (
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/pvcs"
-	v1alpha1 "github.com/verrazzano/verrazzano/platform-operator/apis/verrazzano/v1alpha1"
-	vpoClient "github.com/verrazzano/verrazzano/platform-operator/clients/verrazzano/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 )
-
-// EnvVarKubeConfig Name of Environment Variable for KUBECONFIG
-const EnvVarKubeConfig = "KUBECONFIG"
-
-// EnvVarTestKubeConfig Name of Environment Variable for test KUBECONFIG
-const EnvVarTestKubeConfig = "TEST_KUBECONFIG"
-
-// GetKubeConfigLocation Helper function to obtain the default kubeConfig location
-func GetKubeConfigLocation() (string, error) {
-	if testKubeConfig := os.Getenv(EnvVarTestKubeConfig); len(testKubeConfig) > 0 {
-		return testKubeConfig, nil
-	}
-
-	if kubeConfig := os.Getenv(EnvVarKubeConfig); len(kubeConfig) > 0 {
-		return kubeConfig, nil
-	}
-
-	if home := homedir.HomeDir(); home != "" {
-		return filepath.Join(home, ".kube", "config"), nil
-	}
-
-	return "", errors.New("unable to find kubeconfig")
-}
-
-// GetKubeConfigGivenPath GetKubeConfig will get the kubeconfig from the given kubeconfigPath
-func GetKubeConfig() (*restclient.Config, error) {
-	kubeconfigPath, err := GetKubeConfigLocation()
-	if err != nil {
-		return nil, err
-	}
-
-	return clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-}
-
-// GetVerrazzanoCR returns the installed Verrazzano CR in the given cluster
-// (there should only be 1 per cluster)
-func GetVerrazzanoCR() (*v1alpha1.Verrazzano, error) {
-	config, err := GetKubeConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := vpoClient.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	vzClient := client.VerrazzanoV1alpha1().Verrazzanos("")
-	vzList, err := vzClient.List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("error listing out Verrazzano instances: %v", err)
-	}
-
-	numVzs := len(vzList.Items)
-	if numVzs == 0 {
-		return nil, fmt.Errorf("did not find installed Verrazzano instance")
-	}
-
-	vz := vzList.Items[0]
-	return &vz, nil
-}
 
 //CreatePersistentVolumeClaims Creates PVCs for the given VMO instance.  Returns a pvc->AD map, which is populated *only if* AD information
 // can be specified for new PVCs or determined from existing PVCs.  A pvc-AD map with empty AD values instructs the
 // subsequent deployment processing logic to do the job of choosing ADs.
 func CreatePersistentVolumeClaims(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) (map[string]string, error) {
-	// Get Verrazzano CR
-	cr, err := GetVerrazzanoCR()
-	if err != nil {
-		return nil, err
-	}
-	// Exit if Verrazzano uses EmptyDir as VolumeSource
-	if cr.Spec.DefaultVolumeSource == nil || cr.Spec.DefaultVolumeSource.EmptyDir != nil {
-		controller.log.Info("Verrazzano is using EmptyDir as VolumeSource. Discarding PVC creation.")
-		return map[string]string{}, nil
-	}
 	// Update storage with the new API
 	setPerNodeStorage(vmo)
 	// Inspect the Storage Class to use
@@ -320,5 +242,6 @@ func getDefaultStorageClass(storageClasses []*storagev1.StorageClass) (*storagev
 			return storageClass, nil
 		}
 	}
-	return nil, fmt.Errorf("Failed to find a default storage class")
+	fmt.Printf("Failed to find a default storage class. Returning empty storage class")
+	return &storagev1.StorageClass{}, nil
 }

--- a/pkg/vmo/pvc.go
+++ b/pkg/vmo/pvc.go
@@ -32,6 +32,10 @@ func CreatePersistentVolumeClaims(controller *Controller, vmo *vmcontrollerv1.Ve
 	if err != nil {
 		return nil, err
 	}
+	emptyStorageClass := &storagev1.StorageClass{}
+	if storageClass == emptyStorageClass {
+		controller.log.Info("Failed to find a default storage class. Returning an empty storage class.")
+	}
 	storageClassInfo := parseStorageClassInfo(storageClass, controller.operatorConfig)
 
 	expectedPVCs, err := pvcs.New(vmo, storageClass.Name)
@@ -178,12 +182,7 @@ func determineStorageClass(controller *Controller, className *string) (*storagev
 	if err != nil {
 		return nil, err
 	}
-	emptyStorageClass := &storagev1.StorageClass{}
-	defaultStorageClass := getDefaultStorageClass(storageClasses)
-	if defaultStorageClass == emptyStorageClass {
-		controller.log.Info("Failed to find a default storage class. Returning an empty storage class.")
-	}
-	return defaultStorageClass, nil
+	return getDefaultStorageClass(storageClasses), nil
 }
 
 func getStorageClassOverride(controller *Controller, className *string) (*storagev1.StorageClass, error) {

--- a/pkg/vmo/pvc.go
+++ b/pkg/vmo/pvc.go
@@ -242,6 +242,7 @@ func getDefaultStorageClass(storageClasses []*storagev1.StorageClass) (*storagev
 			return storageClass, nil
 		}
 	}
-	fmt.Printf("Failed to find a default storage class. Returning empty storage class")
-	return &storagev1.StorageClass{}, nil
+	fmt.Printf("Failed to find a default storage class. Returning an empty storage class.")
+	var defaultStorageClass = storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass-default", Annotations: map[string]string{constants.K8sDefaultStorageClassAnnotation: "true"}}}
+	return &defaultStorageClass, nil
 }

--- a/pkg/vmo/pvc_test.go
+++ b/pkg/vmo/pvc_test.go
@@ -172,14 +172,18 @@ func TestGetDefaultStorageClass3(t *testing.T) {
 	storageClass2 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass2"}}
 	storageClass3 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass3"}}
 	result, err := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
-	var expectedStorageClass *storagev1.StorageClass = &storagev1.StorageClass{}
-	assert.Equal(t, *expectedStorageClass, *result, "Expect an empty storage class")
-	assert.NotEqual(t, nil, err, "Error from no default storage class")
+	var expectedStorageClassName string = "storageclass-default"
+	var expectedStorageClassAnnotation = map[string]string{constants.K8sDefaultStorageClassAnnotation: "true"}
+	assert.Equal(t, expectedStorageClassName, result.ObjectMeta.Name, "Expect name to be same")
+	assert.Equal(t, expectedStorageClassAnnotation, result.ObjectMeta.Annotations, "Expect annotations to be same")
+	assert.NotEqual(t, nil, err, "Error fetching default storage class")
 }
 
 func TestGetDefaultStorageClass4(t *testing.T) {
 	result, err := getDefaultStorageClass([]*storagev1.StorageClass{})
-	var expectedStorageClass *storagev1.StorageClass = &storagev1.StorageClass{}
-	assert.Equal(t, *expectedStorageClass, *result, "No storage classes")
-	assert.NotEqual(t, nil, err, "Error from no storage classes")
+	var expectedStorageClassName string = "storageclass-default"
+	var expectedStorageClassAnnotations = map[string]string{constants.K8sDefaultStorageClassAnnotation: "true"}
+	assert.Equal(t, expectedStorageClassName, result.ObjectMeta.Name, "Expect name to be same")
+	assert.Equal(t, expectedStorageClassAnnotations, result.ObjectMeta.Annotations, "Expect annotations to be same")
+	assert.NotEqual(t, nil, err, "Error fetching default storage classes")
 }

--- a/pkg/vmo/pvc_test.go
+++ b/pkg/vmo/pvc_test.go
@@ -155,7 +155,7 @@ func TestGetDefaultStorageClass1(t *testing.T) {
 	storageClass1 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass1"}}
 	storageClass2 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass2", Annotations: map[string]string{constants.K8sDefaultStorageClassAnnotation: "true"}}}
 	storageClass3 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass3"}}
-	result, _ := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
+	result := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
 	assert.Equal(t, result, &storageClass2, "Default storage class found based on standard label")
 }
 
@@ -163,7 +163,7 @@ func TestGetDefaultStorageClass2(t *testing.T) {
 	storageClass1 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass1"}}
 	storageClass2 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass2"}}
 	storageClass3 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass3", Annotations: map[string]string{constants.K8sDefaultStorageClassBetaAnnotation: "true"}}}
-	result, _ := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
+	result := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
 	assert.Equal(t, result, &storageClass3, "Default storage class found based on beta label")
 }
 
@@ -171,13 +171,11 @@ func TestGetDefaultStorageClass3(t *testing.T) {
 	storageClass1 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass1"}}
 	storageClass2 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass2"}}
 	storageClass3 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass3"}}
-	result, err := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
+	result := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
 	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect name to be same")
-	assert.Equal(t, nil, err, "Error fetching default storage class")
 }
 
 func TestGetDefaultStorageClass4(t *testing.T) {
-	result, err := getDefaultStorageClass([]*storagev1.StorageClass{})
+	result := getDefaultStorageClass([]*storagev1.StorageClass{})
 	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect name to be same")
-	assert.Equal(t, nil, err, "Error fetching default storage class")
 }

--- a/pkg/vmo/pvc_test.go
+++ b/pkg/vmo/pvc_test.go
@@ -172,14 +172,14 @@ func TestGetDefaultStorageClass3(t *testing.T) {
 	storageClass2 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass2"}}
 	storageClass3 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass3"}}
 	result, err := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
-	var expectedStorageClass *storagev1.StorageClass
-	assert.Equal(t, expectedStorageClass, result, "No default storage class")
+	var expectedStorageClass *storagev1.StorageClass = &storagev1.StorageClass{}
+	assert.Equal(t, *expectedStorageClass, *result, "Expect an empty storage class")
 	assert.NotEqual(t, nil, err, "Error from no default storage class")
 }
 
 func TestGetDefaultStorageClass4(t *testing.T) {
 	result, err := getDefaultStorageClass([]*storagev1.StorageClass{})
-	var expectedStorageClass *storagev1.StorageClass
-	assert.Equal(t, expectedStorageClass, result, "No storage classes")
+	var expectedStorageClass *storagev1.StorageClass = &storagev1.StorageClass{}
+	assert.Equal(t, *expectedStorageClass, *result, "No storage classes")
 	assert.NotEqual(t, nil, err, "Error from no storage classes")
 }

--- a/pkg/vmo/pvc_test.go
+++ b/pkg/vmo/pvc_test.go
@@ -172,18 +172,12 @@ func TestGetDefaultStorageClass3(t *testing.T) {
 	storageClass2 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass2"}}
 	storageClass3 := storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "storageclass3"}}
 	result, err := getDefaultStorageClass([]*storagev1.StorageClass{&storageClass1, &storageClass2, &storageClass3})
-	var expectedStorageClassName string = "storageclass-default"
-	var expectedStorageClassAnnotation = map[string]string{constants.K8sDefaultStorageClassAnnotation: "true"}
-	assert.Equal(t, expectedStorageClassName, result.ObjectMeta.Name, "Expect name to be same")
-	assert.Equal(t, expectedStorageClassAnnotation, result.ObjectMeta.Annotations, "Expect annotations to be same")
-	assert.NotEqual(t, nil, err, "Error fetching default storage class")
+	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect name to be same")
+	assert.Equal(t, nil, err, "Error fetching default storage class")
 }
 
 func TestGetDefaultStorageClass4(t *testing.T) {
 	result, err := getDefaultStorageClass([]*storagev1.StorageClass{})
-	var expectedStorageClassName string = "storageclass-default"
-	var expectedStorageClassAnnotations = map[string]string{constants.K8sDefaultStorageClassAnnotation: "true"}
-	assert.Equal(t, expectedStorageClassName, result.ObjectMeta.Name, "Expect name to be same")
-	assert.Equal(t, expectedStorageClassAnnotations, result.ObjectMeta.Annotations, "Expect annotations to be same")
-	assert.NotEqual(t, nil, err, "Error fetching default storage classes")
+	assert.Equal(t, &storagev1.StorageClass{}, result, "Expect name to be same")
+	assert.Equal(t, nil, err, "Error fetching default storage class")
 }


### PR DESCRIPTION
# Description

- Fixes VZ-6150
- Updated the VMO to throw error in case a StorageClass is not configured