### PR TITLE
VZ-6437: Namespace change

### DIFF
--- a/verrazzano-backup-hook/constants/constants.go
+++ b/verrazzano-backup-hook/constants/constants.go
@@ -9,7 +9,7 @@ const (
 	VerrazzanoSystemNamespace = "verrazzano-system"
 
 	// VerrazzanoNameSpaceName Namespace where Velero components are installed
-	VeleroNameSpace = "velero"
+	VeleroNameSpace = "verrazzano-backup"
 
 	// BackupOperation backup operation expected value
 	BackupOperation = "backup"


### PR DESCRIPTION
Today velero install happens in a namespace called velero. This could collide with another install of velero if its been installed out of band. 

We will be installing velero in verrazzano-backup namespace. 