### PR TITLE
VZ-6378: VZ-6385: remove remnants of config reloader

### DIFF
--- a/pkg/config/components.go
+++ b/pkg/config/components.go
@@ -32,7 +32,7 @@ type ComponentDetails struct {
 }
 
 // AllComponentDetails is array of all ComponentDetails
-var AllComponentDetails = []*ComponentDetails{&Grafana, &Kibana, &ElasticsearchIngest, &ElasticsearchMaster, &ElasticsearchData, &ElasticsearchInit, &API, &ConfigReloader, &OidcProxy}
+var AllComponentDetails = []*ComponentDetails{&Grafana, &Kibana, &ElasticsearchIngest, &ElasticsearchMaster, &ElasticsearchData, &ElasticsearchInit, &API, &OidcProxy}
 
 // StorageEnableComponents is storage operation-related stuff
 var StorageEnableComponents = []*ComponentDetails{&Grafana}
@@ -159,14 +159,6 @@ var API = ComponentDetails{
 	ReadinessHTTPPath: "/healthcheck",
 	Privileged:        false,
 	Optional:          true,
-}
-
-// ConfigReloader is the default config-reloader configuration
-var ConfigReloader = ComponentDetails{
-	Name:            "config-reloader",
-	EnvName:         "CONFIG_RELOADER_IMAGE",
-	ImagePullPolicy: constants.DefaultImagePullPolicy,
-	Privileged:      false,
 }
 
 const (

--- a/run-vmo.sh
+++ b/run-vmo.sh
@@ -48,7 +48,6 @@ export KIBANA_IMAGE=$(grep kibanaImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml 
 export ELASTICSEARCH_IMAGE=$(grep esImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
 export ELASTICSEARCH_INIT_IMAGE=$(grep esInitImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
 export VERRAZZANO_MONITORING_INSTANCE_API_IMAGE=$(grep monitoringInstanceApiImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
-export CONFIG_RELOADER_IMAGE=$(grep configReloaderImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
 export OIDC_PROXY_IMAGE=$(grep oidcProxyImage ${VERRAZZANO_INSTALLER_REPO}/values.yaml | head -1 | cut -d':' -f2,3 | sed -e 's/^[[:space:]]*//')
 
 # Extract the API server realm from values.yaml.
@@ -71,7 +70,6 @@ KIBANA_IMAGE=${KIBANA_IMAGE}
 ELASTICSEARCH_IMAGE=${ELASTICSEARCH_IMAGE}
 ELASTICSEARCH_INIT_IMAGE=${ELASTICSEARCH_INIT_IMAGE}
 VERRAZZANO_MONITORING_INSTANCE_API_IMAGE=${VERRAZZANO_MONITORING_INSTANCE_API_IMAGE}
-CONFIG_RELOADER_IMAGE=${CONFIG_RELOADER_IMAGE}
 OIDC_PROXY_IMAGE=${OIDC_PROXY_IMAGE}
 
 WATCH_VMI=${WATCH_VMI}


### PR DESCRIPTION
This removes remnants the config-reloader which is no longer used by VMO.