### PR TITLE
Fix for OS cluster going to yellow state in dev profile when ISM polices are enabled in VZ CR

### DIFF
--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -81,6 +81,46 @@ func (o *OSClient) createISMPolicy(opensearchEndpoint string, policy vmcontrolle
 	return o.addPolicyToExistingIndices(opensearchEndpoint, &policy, updatedPolicy)
 }
 
+// updateDefaultIndexSettings updates the default index settings to be used
+func (o *OSClient) updateDefaultIndexSettings(opensearchEndpoint string) error {
+	settingsUrl := fmt.Sprintf("%s/_settings", opensearchEndpoint)
+	payload, err := json.Marshal(getDefaultIndexSettings())
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("PUT", settingsUrl, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := o.DoHTTP(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("got status code %d when updating default settings of index, expected %d", resp.StatusCode, http.StatusOK)
+	}
+	var updatedIndexSettings map[string]bool
+	err = json.NewDecoder(resp.Body).Decode(updatedIndexSettings)
+	if err != nil {
+		return err
+	}
+	if !updatedIndexSettings["acknowledged"] {
+		return fmt.Errorf("expected acknowldegement for index settings update but did not get. Actual response  %v", updatedIndexSettings)
+	}
+	return nil
+}
+
+//getDefaultIndexSettings returns the default index settings to be used for all indices
+func getDefaultIndexSettings() map[string]interface{} {
+	indexSettings := map[string]interface{}{
+		"index": map[string]string{
+			"auto_expand_replicas": "0-1",
+		},
+	}
+	return indexSettings
+}
+
 func (o *OSClient) getPolicyByName(policyURL string) (*ISMPolicy, error) {
 	req, err := http.NewRequest("GET", policyURL, nil)
 	if err != nil {

--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -133,7 +133,7 @@ func (o *OSClient) putUpdatedPolicy(opensearchEndpoint string, policy *vmcontrol
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add(contentTypeHeader, applicationJson)
+	req.Header.Add(contentTypeHeader, applicationJSON)
 	resp, err := o.DoHTTP(req)
 	if err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func (o *OSClient) addPolicyToExistingIndices(opensearchEndpoint string, policy 
 	if err != nil {
 		return err
 	}
-	req.Header.Add(contentTypeHeader, applicationJson)
+	req.Header.Add(contentTypeHeader, applicationJSON)
 	resp, err := o.DoHTTP(req)
 	if err != nil {
 		return err

--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -83,12 +83,12 @@ func (o *OSClient) createISMPolicy(opensearchEndpoint string, policy vmcontrolle
 
 // updateDefaultIndexSettings updates the default index settings to be used
 func (o *OSClient) updateDefaultIndexSettings(opensearchEndpoint string) error {
-	settingsUrl := fmt.Sprintf("%s/_settings", opensearchEndpoint)
+	settingsURL := fmt.Sprintf("%s/_settings", opensearchEndpoint)
 	payload, err := json.Marshal(getDefaultIndexSettings())
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("PUT", settingsUrl, bytes.NewReader(payload))
+	req, err := http.NewRequest("PUT", settingsURL, bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (o *OSClient) updateDefaultIndexSettings(opensearchEndpoint string) error {
 		return fmt.Errorf("got status code %d when updating default settings of index, expected %d", resp.StatusCode, http.StatusOK)
 	}
 	var updatedIndexSettings map[string]bool
-	err = json.NewDecoder(resp.Body).Decode(updatedIndexSettings)
+	err = json.NewDecoder(resp.Body).Decode(&updatedIndexSettings)
 	if err != nil {
 		return err
 	}

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	testPolicyNotFound = `{"error":{"root_cause":[{"type":"status_exception","reason":"Policy not found"}],"type":"status_exception","reason":"Policy not found"},"status":404}`
+	testSettingsCreated = `{"acknowledged":true}`
 	testSystemPolicy   = `
 {
     "_id" : "verrazzano-system",
@@ -141,6 +142,12 @@ func TestConfigureIndexManagementPluginHappyPath(t *testing.T) {
 			}, nil
 
 		case "PUT":
+			if strings.HasSuffix(request.URL.Path, "/_settings") {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(testSettingsCreated)),
+				}, nil
+			}
 			return &http.Response{
 				StatusCode: http.StatusCreated,
 				Body:       io.NopCloser(strings.NewReader(testSystemPolicy)),

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -18,9 +18,8 @@ import (
 )
 
 const (
-	testPolicyNotFound  = `{"error":{"root_cause":[{"type":"status_exception","reason":"Policy not found"}],"type":"status_exception","reason":"Policy not found"},"status":404}`
-	testSettingsCreated = `{"acknowledged":true}`
-	testSystemPolicy    = `
+	testPolicyNotFound = `{"error":{"root_cause":[{"type":"status_exception","reason":"Policy not found"}],"type":"status_exception","reason":"Policy not found"},"status":404}`
+	testSystemPolicy   = `
 {
     "_id" : "verrazzano-system",
     "_seq_no" : 0,

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	testPolicyNotFound = `{"error":{"root_cause":[{"type":"status_exception","reason":"Policy not found"}],"type":"status_exception","reason":"Policy not found"},"status":404}`
+	testPolicyNotFound  = `{"error":{"root_cause":[{"type":"status_exception","reason":"Policy not found"}],"type":"status_exception","reason":"Policy not found"},"status":404}`
 	testSettingsCreated = `{"acknowledged":true}`
-	testSystemPolicy   = `
+	testSystemPolicy    = `
 {
     "_id" : "verrazzano-system",
     "_seq_no" : 0,

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -142,12 +142,6 @@ func TestConfigureIndexManagementPluginHappyPath(t *testing.T) {
 			}, nil
 
 		case "PUT":
-			if strings.HasSuffix(request.URL.Path, "/_settings") {
-				return &http.Response{
-					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(testSettingsCreated)),
-				}, nil
-			}
 			return &http.Response{
 				StatusCode: http.StatusCreated,
 				Body:       io.NopCloser(strings.NewReader(testSystemPolicy)),

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -21,7 +21,7 @@ type (
 
 const (
 	indexSettings     = `{"index":{"auto_expand_replicas": "0-1"}}`
-	applicationJson   = "application/json"
+	applicationJSON   = "application/json"
 	contentTypeHeader = "Content-Type"
 )
 
@@ -100,7 +100,7 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 			ch <- err
 			return
 		}
-		req.Header.Add(contentTypeHeader, applicationJson)
+		req.Header.Add(contentTypeHeader, applicationJSON)
 		resp, err := o.DoHTTP(req)
 		if err != nil {
 			ch <- err

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -63,6 +63,10 @@ func (o *OSClient) ConfigureISM(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance
 		}
 
 		opensearchEndpoint := resources.GetOpenSearchHTTPEndpoint(vmi)
+		if err := o.updateDefaultIndexSettings(opensearchEndpoint); err != nil {
+			ch <- err
+			return
+		}
 		for _, policy := range vmi.Spec.Elasticsearch.Policies {
 			if err := o.createISMPolicy(opensearchEndpoint, policy); err != nil {
 				ch <- err

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/nodes"
 	"net/http"
 )
 
@@ -90,6 +91,10 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 	// configuration is done asynchronously, as this does not need to be blocking
 	go func() {
 		if !vmi.Spec.Elasticsearch.Enabled {
+			ch <- nil
+			return
+		}
+		if !nodes.IsSingleNodeCluster(vmi) {
 			ch <- nil
 			return
 		}

--- a/pkg/opensearch/opensearch_upgrade.go
+++ b/pkg/opensearch/opensearch_upgrade.go
@@ -226,7 +226,7 @@ func (o *OSClient) reindexToDataStream(log vzlog.VerrazzanoLogger, openSearchEnd
 	if err != nil {
 		return err
 	}
-	req.Header.Add(contentTypeHeader, applicationJson)
+	req.Header.Add(contentTypeHeader, applicationJSON)
 	resp, err := o.DoHTTP(req)
 	if err != nil {
 		log.Errorf("Reindex from %s to %s failed", sourceName, destName)

--- a/pkg/opensearch/opensearch_upgrade.go
+++ b/pkg/opensearch/opensearch_upgrade.go
@@ -226,7 +226,7 @@ func (o *OSClient) reindexToDataStream(log vzlog.VerrazzanoLogger, openSearchEnd
 	if err != nil {
 		return err
 	}
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add(contentTypeHeader, applicationJson)
 	resp, err := o.DoHTTP(req)
 	if err != nil {
 		log.Errorf("Reindex from %s to %s failed", sourceName, destName)

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -454,7 +454,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	/***************************************
 	 * Configure Index AutoExpand settings
 	 ****************************************/
-	autoExpandIndexChannel := c.osClient.SetAutoExpandIndices(vmo);
+	autoExpandIndexChannel := c.osClient.SetAutoExpandIndices(vmo)
 
 	/*********************
 	 * Configure ISM
@@ -547,7 +547,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 			errorObserved = true
 		}
 	}
-	
+
 	autExpandIndexErr := <-autoExpandIndexChannel
 	if autExpandIndexErr != nil {
 		c.log.Errorf("Failed to update auto expand settings for indices: %v", err)

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -451,6 +451,11 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 
 	errorObserved := false
 
+	/***************************************
+	 * Configure Index AutoExpand settings
+	 ****************************************/
+	autoExpandIndexChannel := c.osClient.SetAutoExpandIndices(vmo);
+
 	/*********************
 	 * Configure ISM
 	 **********************/
@@ -541,6 +546,12 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 			c.log.Errorf("Failed to update status for VMI %s: %v", vmo.Name, err)
 			errorObserved = true
 		}
+	}
+	
+	autExpandIndexErr := <-autoExpandIndexChannel
+	if autExpandIndexErr != nil {
+		c.log.Errorf("Failed to update auto expand settings for indices: %v", err)
+		errorObserved = true
 	}
 
 	ismErr := <-ismChannel


### PR DESCRIPTION
Fixes VZ-6538 OS cluster goes to yellow state when the hidden indices created by ISM plugin creates with replica=1 as the dev profile has a single node OS cluster. This causes one secondary node to remain assigned causing the cluster to go into yellow state.