### PR TITLE
VZ-6538 Use index templates to set the 'auto_expand_replicas' to '0-1' for ISM and Jaeger indices in dev profile. 

### DIFF
--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -125,6 +125,7 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 			ch <- fmt.Errorf("expected acknowldegement for index settings update but did not get. Actual response  %v", updatedIndexSettings)
 			return
 		}
+                ch <- nil
 	}()
 
 	return ch

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -21,7 +21,7 @@ type (
 )
 
 const (
-	indexSettings     = `{"index_patterns": [".opendistro*", "verrazzano-jaeger-*"],"priority": 0,"template": {"settings": {"auto_expand_replicas": "0-1"}}}`
+	indexSettings     = `{"index_patterns": [".opendistro*"],"priority": 0,"template": {"settings": {"auto_expand_replicas": "0-1"}}}`
 	applicationJSON   = "application/json"
 	contentTypeHeader = "Content-Type"
 )
@@ -99,7 +99,7 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 			return
 		}
 		opensearchEndpoint := resources.GetOpenSearchHTTPEndpoint(vmi)
-		settingsURL := fmt.Sprintf("%s/_index_template/vz-template", opensearchEndpoint)
+		settingsURL := fmt.Sprintf("%s/_index_template/ism-plugin-template", opensearchEndpoint)
 		req, err := http.NewRequest("PUT", settingsURL, bytes.NewReader([]byte(indexSettings)))
 		if err != nil {
 			ch <- err

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -125,7 +125,7 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 			ch <- fmt.Errorf("expected acknowldegement for index settings update but did not get. Actual response  %v", updatedIndexSettings)
 			return
 		}
-                ch <- nil
+		ch <- nil
 	}()
 
 	return ch

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -21,7 +21,7 @@ type (
 )
 
 const (
-	indexSettings     = `{"index":{"auto_expand_replicas": "0-1"}}`
+	indexSettings     = `{"index_patterns": [".opendistro*", "verrazzano-jaeger-*"],"priority": 0,"template": {"settings": {"auto_expand_replicas": "0-1"}}}`
 	applicationJSON   = "application/json"
 	contentTypeHeader = "Content-Type"
 )
@@ -99,7 +99,7 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 			return
 		}
 		opensearchEndpoint := resources.GetOpenSearchHTTPEndpoint(vmi)
-		settingsURL := fmt.Sprintf("%s/_settings", opensearchEndpoint)
+		settingsURL := fmt.Sprintf("%s/_index_template/vz-template", opensearchEndpoint)
 		req, err := http.NewRequest("PUT", settingsURL, bytes.NewReader([]byte(indexSettings)))
 		if err != nil {
 			ch <- err

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -465,11 +465,6 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	 * Configure Index AutoExpand settings
 	 ****************************************/
 	autoExpandIndexChannel := c.osClient.SetAutoExpandIndices(vmo)
-	autExpandIndexErr := <-autoExpandIndexChannel
-	if autExpandIndexErr != nil {
-		c.log.Errorf("Failed to update auto expand settings for indices: %v", err)
-		errorObserved = true
-	}
 
 	/*********************
 	 * Configure ISM
@@ -569,7 +564,11 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 		}
 	}
 
-
+	autExpandIndexErr := <-autoExpandIndexChannel
+	if autExpandIndexErr != nil {
+		c.log.Errorf("Failed to update auto expand settings for indices: %v", err)
+		errorObserved = true
+	}
 
 	ismErr := <-ismChannel
 	if ismErr != nil {

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -465,11 +465,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	 * Configure Index AutoExpand settings
 	 ****************************************/
 	autoExpandIndexChannel := c.osClient.SetAutoExpandIndices(vmo)
-	autExpandIndexErr := <-autoExpandIndexChannel
-	if autExpandIndexErr != nil {
-		c.log.Errorf("Failed to update auto expand settings for indices: %v", err)
-		errorObserved = true
-	}
+
 	/*********************
 	 * Configure ISM
 	 **********************/
@@ -566,6 +562,12 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 			c.log.Errorf("Failed to update status for VMI %s: %v", vmo.Name, err)
 			errorObserved = true
 		}
+	}
+
+	autExpandIndexErr := <-autoExpandIndexChannel
+	if autExpandIndexErr != nil {
+		c.log.Errorf("Failed to update auto expand settings for indices: %v", err)
+		errorObserved = true
 	}
 
 	ismErr := <-ismChannel

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -465,6 +465,11 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	 * Configure Index AutoExpand settings
 	 ****************************************/
 	autoExpandIndexChannel := c.osClient.SetAutoExpandIndices(vmo)
+	autExpandIndexErr := <-autoExpandIndexChannel
+	if autExpandIndexErr != nil {
+		c.log.Errorf("Failed to update auto expand settings for indices: %v", err)
+		errorObserved = true
+	}
 
 	/*********************
 	 * Configure ISM
@@ -564,11 +569,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 		}
 	}
 
-	autExpandIndexErr := <-autoExpandIndexChannel
-	if autExpandIndexErr != nil {
-		c.log.Errorf("Failed to update auto expand settings for indices: %v", err)
-		errorObserved = true
-	}
+
 
 	ismErr := <-ismChannel
 	if ismErr != nil {

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -465,7 +465,11 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	 * Configure Index AutoExpand settings
 	 ****************************************/
 	autoExpandIndexChannel := c.osClient.SetAutoExpandIndices(vmo)
-
+	autExpandIndexErr := <-autoExpandIndexChannel
+	if autExpandIndexErr != nil {
+		c.log.Errorf("Failed to update auto expand settings for indices: %v", err)
+		errorObserved = true
+	}
 	/*********************
 	 * Configure ISM
 	 **********************/
@@ -562,12 +566,6 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 			c.log.Errorf("Failed to update status for VMI %s: %v", vmo.Name, err)
 			errorObserved = true
 		}
-	}
-
-	autExpandIndexErr := <-autoExpandIndexChannel
-	if autExpandIndexErr != nil {
-		c.log.Errorf("Failed to update auto expand settings for indices: %v", err)
-		errorObserved = true
 	}
 
 	ismErr := <-ismChannel


### PR DESCRIPTION
The earlier fix of using `/_settings` endpoint worked only if the indices were already present. Since it cannot be guaranteed always that the ISM policies are created prior to the VMO initialization, using the index template approach to update the `auto_expand_replicas` of the ISM plugin index `.opendistro_job_scheduler_lock`  to `0-1`

Background of the issue.
-------------------------
In dev profile, with a single node OpenSearch cluster, when an ISM policy is created, the ISM plugin creates an hidden index `.opendistro_job_scheduler_lock` with `replica=1`. This condition cannot be met on a single node cluster and the secondary shard remains un-assigned causing the cluster health to go to yellow (unstable) state. With `auto_expand_replicas` setting, the replica count can be made to 0 for single node clusters and the replica count increments to 1 when additional nodes are added.