### PR TITLE
VZ-6699: Revert "VZ-6699: Have all OpenSearch components use a common node antiaffinity rule"

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -56,7 +56,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, kubeclientset kuberne
 		deployment := createDeploymentElement(vmo, &vmo.Spec.Grafana.Storage, &vmo.Spec.Grafana.Resources, config.Grafana, config.Grafana.Name)
 		deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = config.Grafana.ImagePullPolicy
 		deployment.Spec.Replicas = resources.NewVal(vmo.Spec.Grafana.Replicas)
-		deployment.Spec.Template.Spec.Affinity = resources.CreateNodeAntiAffinityElement(vmo.Name, config.Grafana.Name)
+		deployment.Spec.Template.Spec.Affinity = resources.CreateZoneAntiAffinityElement(vmo.Name, config.Grafana.Name)
 
 		deployment.Spec.Strategy.Type = "Recreate"
 		deployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -262,7 +262,7 @@ func NewOpenSearchDashboardsDeployment(vmo *vmcontrollerv1.VerrazzanoMonitoringI
 			Type: appsv1.RecreateDeploymentStrategyType,
 		}
 		deployment.Spec.Replicas = resources.NewVal(vmo.Spec.Kibana.Replicas)
-		deployment.Spec.Template.Spec.Affinity = resources.CreateNodeAntiAffinityElement(vmo.Name, config.Kibana.Name)
+		deployment.Spec.Template.Spec.Affinity = resources.CreateZoneAntiAffinityElement(vmo.Name, config.Kibana.Name)
 		deployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
 			{Name: "OPENSEARCH_HOSTS", Value: elasticsearchURL},
 		}

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -317,25 +317,6 @@ func CreateZoneAntiAffinityElement(vmoName string, component string) *corev1.Aff
 	}
 }
 
-// CreateNodeAntiAffinityElement return an Affinity resource for a given VMO instance and component
-func CreateNodeAntiAffinityElement(vmoName string, component string) *corev1.Affinity {
-	return &corev1.Affinity{
-		PodAntiAffinity: &corev1.PodAntiAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-				{
-					Weight: 100,
-					PodAffinityTerm: corev1.PodAffinityTerm{
-						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: GetSpecID(vmoName, component),
-						},
-						TopologyKey: "kubernetes.io/hostname",
-					},
-				},
-			},
-		},
-	}
-}
-
 // GetElasticsearchMasterInitContainer return an Elasticsearch Init container for the master.  This changes ownership of
 // the ES directory permissions needed to access PV volume data.  Also set the max map count.
 func GetElasticsearchMasterInitContainer() *corev1.Container {

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -56,7 +56,7 @@ func createOpenSearchStatefulSet(log vzlog.VerrazzanoLogger, vmo *vmcontrollerv1
 	statefulSet.Spec.Template.Labels[constants.NodeGroupLabel] = node.Name
 
 	statefulSet.Spec.Replicas = resources.NewVal(node.Replicas)
-	statefulSet.Spec.Template.Spec.Affinity = resources.CreateNodeAntiAffinityElement(vmo.Name, config.ElasticsearchMaster.Name)
+	statefulSet.Spec.Template.Spec.Affinity = resources.CreateZoneAntiAffinityElement(vmo.Name, config.ElasticsearchMaster.Name)
 
 	var elasticsearchUID int64 = 1000
 	esMasterContainer := &statefulSet.Spec.Template.Spec.Containers[0]

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -6,18 +6,20 @@ package statefulsets
 import (
 	"testing"
 
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/nodes"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/stretchr/testify/assert"
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/nodes"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const defaultStorageClass = "default"
@@ -185,7 +187,7 @@ func verifyElasticSearch(t *testing.T, vmo *vmcontrollerv1.VerrazzanoMonitoringI
 	const esMasterData = "/usr/share/opensearch/data"
 
 	assert.Equal(*resources.NewVal(replicas), *sts.Spec.Replicas, "Incorrect Elasticsearch MasterNodes replicas count")
-	affin := resources.CreateNodeAntiAffinityElement(vmo.Name, config.ElasticsearchMaster.Name)
+	affin := resources.CreateZoneAntiAffinityElement(vmo.Name, config.ElasticsearchMaster.Name)
 	assert.Equal(affin, sts.Spec.Template.Spec.Affinity, "Incorrect Elasticsearch affinity")
 	var elasticsearchUID int64 = 1000
 	assert.Equal(elasticsearchUID, *sts.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser,
@@ -275,7 +277,7 @@ func verifyElasticSearchDevProfile(t *testing.T, vmo *vmcontrollerv1.VerrazzanoM
 	assert.Equal(nodes.RoleAssigned, sts.Spec.Template.ObjectMeta.Labels[nodes.RoleIngest])
 
 	assert.Equal(*resources.NewVal(int32(replicas)), *sts.Spec.Replicas, "Incorrect Elasticsearch MasterNodes replicas count")
-	affin := resources.CreateNodeAntiAffinityElement(vmo.Name, config.ElasticsearchMaster.Name)
+	affin := resources.CreateZoneAntiAffinityElement(vmo.Name, config.ElasticsearchMaster.Name)
 	assert.Equal(affin, sts.Spec.Template.Spec.Affinity, "Incorrect Elasticsearch affinity")
 	var elasticsearchUID int64 = 1000
 	assert.Equal(elasticsearchUID, *sts.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser,


### PR DESCRIPTION
Reverts verrazzano/verrazzano-monitoring-operator#231