### PR TITLE
WIP: VZ-6691: Deploy opensearch dashboards after ES is green

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -252,41 +252,6 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, kubeclientset kuberne
 	return expected, err
 }
 
-func NewOpenSearchDashboardsDeployment(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *appsv1.Deployment {
-	var deployment *appsv1.Deployment
-	if vmo.Spec.Kibana.Enabled {
-		elasticsearchURL := fmt.Sprintf("http://%s%s-%s:%d/", constants.VMOServiceNamePrefix, vmo.Name, config.ElasticsearchIngest.Name, config.ElasticsearchIngest.Port)
-		deployment = createDeploymentElement(vmo, nil, &vmo.Spec.Kibana.Resources, config.Kibana, config.Kibana.Name)
-
-		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
-			Type: appsv1.RecreateDeploymentStrategyType,
-		}
-		deployment.Spec.Replicas = resources.NewVal(vmo.Spec.Kibana.Replicas)
-		deployment.Spec.Template.Spec.Affinity = resources.CreateZoneAntiAffinityElement(vmo.Name, config.Kibana.Name)
-		deployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
-			{Name: "OPENSEARCH_HOSTS", Value: elasticsearchURL},
-		}
-
-		deployment.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds = 120
-		deployment.Spec.Template.Spec.Containers[0].LivenessProbe.TimeoutSeconds = 3
-		deployment.Spec.Template.Spec.Containers[0].LivenessProbe.PeriodSeconds = 20
-		deployment.Spec.Template.Spec.Containers[0].LivenessProbe.FailureThreshold = 10
-
-		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds = 15
-		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.TimeoutSeconds = 3
-		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.PeriodSeconds = 20
-		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe.FailureThreshold = 5
-
-		// add the required istio annotations to allow inter-es component communication
-		if deployment.Spec.Template.Annotations == nil {
-			deployment.Spec.Template.Annotations = make(map[string]string)
-		}
-		deployment.Spec.Template.Annotations["traffic.sidecar.istio.io/includeOutboundPorts"] = fmt.Sprintf("%d", constants.OSHTTPPort)
-	}
-
-	return deployment
-}
-
 func createVolumeElement(pvcName string) corev1.Volume {
 	return corev1.Volume{
 		Name: constants.StorageVolumeName,

--- a/pkg/resources/deployments/deployment_test.go
+++ b/pkg/resources/deployments/deployment_test.go
@@ -54,8 +54,7 @@ func TestVMOFullDeploymentSize(t *testing.T) {
 		t.Error(err)
 	}
 	deployments := expected.Deployments
-	deployments = append(deployments, NewOpenSearchDashboardsDeployment(vmo))
-	assert.Equal(t, 5, len(deployments), "Length of generated deployments")
+	assert.Equal(t, 3, len(deployments), "Length of generated deployments")
 	assert.Equal(t, constants.VMOKind, deployments[0].ObjectMeta.OwnerReferences[0].Kind, "OwnerReferences is not set by default")
 }
 
@@ -91,7 +90,6 @@ func TestVMODevProfileFullDeploymentSize(t *testing.T) {
 		t.Error(err)
 	}
 	deployments := expected.Deployments
-	deployments = append(deployments, NewOpenSearchDashboardsDeployment(vmo))
 	assert.Equal(t, 3, len(deployments), "Length of generated deployments")
 	assert.Equal(t, constants.VMOKind, deployments[0].ObjectMeta.OwnerReferences[0].Kind, "OwnerReferences is not set by default")
 }
@@ -260,8 +258,7 @@ func TestVMOWithReplicas(t *testing.T) {
 		t.Error(err)
 	}
 	deployments := expected.Deployments
-	deployments = append(deployments, NewOpenSearchDashboardsDeployment(vmo))
-	assert.Equal(t, 2, len(deployments), "Length of generated deployments")
+	assert.Equal(t, 1, len(deployments), "Length of generated deployments")
 	for _, deployment := range deployments {
 		if deployment.Name == resources.GetMetaName(vmo.Name, config.API.Name) {
 			assert.Equal(t, *resources.NewVal(2), *deployment.Spec.Replicas, "Api replicas")

--- a/pkg/resources/deployments/deployment_test.go
+++ b/pkg/resources/deployments/deployment_test.go
@@ -54,7 +54,7 @@ func TestVMOFullDeploymentSize(t *testing.T) {
 		t.Error(err)
 	}
 	deployments := expected.Deployments
-	assert.Equal(t, 3, len(deployments), "Length of generated deployments")
+	assert.Equal(t, 4, len(deployments), "Length of generated deployments")
 	assert.Equal(t, constants.VMOKind, deployments[0].ObjectMeta.OwnerReferences[0].Kind, "OwnerReferences is not set by default")
 }
 
@@ -90,7 +90,7 @@ func TestVMODevProfileFullDeploymentSize(t *testing.T) {
 		t.Error(err)
 	}
 	deployments := expected.Deployments
-	assert.Equal(t, 3, len(deployments), "Length of generated deployments")
+	assert.Equal(t, 2, len(deployments), "Length of generated deployments")
 	assert.Equal(t, constants.VMOKind, deployments[0].ObjectMeta.OwnerReferences[0].Kind, "OwnerReferences is not set by default")
 }
 

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -281,7 +281,7 @@ fi`,
 	return statefulSet
 }
 
-// Creates a statefulset element for the given VMO and component
+// Creates a StatefulSet element for the given VMO and component
 func createStatefulSetElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, vmoResources *vmcontrollerv1.Resources,
 	componentDetails config.ComponentDetails, serviceName, statefulSetName string) *appsv1.StatefulSet {
 	labels := resources.GetSpecID(vmo.Name, componentDetails.Name)
@@ -298,8 +298,8 @@ func createStatefulSetElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, 
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: resources.NewVal(1),
-			// The default PodManagementPolicy (OrderedReady) has known issues where a statefulset with
-			// a crashing pod is never updated on further statefulset changes, so use Parallel here
+			// The default PodManagementPolicy (OrderedReady) has known issues where a StatefulSet with
+			// a crashing pod is never updated on further StatefulSet changes, so use Parallel here
 			PodManagementPolicy: appsv1.ParallelPodManagement,
 			ServiceName:         serviceName,
 			Selector: &metav1.LabelSelector{
@@ -329,7 +329,7 @@ func NewOpenSearchDashboardsStatefulSet(vmo *vmcontrollerv1.VerrazzanoMonitoring
 	statefulSetName := resources.GetMetaName(vmo.Name, config.Kibana.Name)
 
 	if vmo.Spec.Kibana.Enabled {
-		elasticsearchURL := fmt.Sprintf("http://%s%s-%s:%d/", constants.VMOServiceNamePrefix, vmo.Name, config.ElasticsearchIngest.Name, config.ElasticsearchIngest.Port)
+		openSearchURL := fmt.Sprintf("http://%s%s-%s:%d/", constants.VMOServiceNamePrefix, vmo.Name, config.ElasticsearchIngest.Name, config.ElasticsearchIngest.Port)
 		statefulSet = createStatefulSetElement(vmo, &vmo.Spec.Kibana.Resources, config.Kibana, headlessService, statefulSetName)
 
 		statefulSet.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
@@ -339,7 +339,7 @@ func NewOpenSearchDashboardsStatefulSet(vmo *vmcontrollerv1.VerrazzanoMonitoring
 		statefulSet.Spec.Replicas = resources.NewVal(vmo.Spec.Kibana.Replicas)
 		statefulSet.Spec.Template.Spec.Affinity = resources.CreateZoneAntiAffinityElement(vmo.Name, config.Kibana.Name)
 		statefulSet.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
-			{Name: "OPENSEARCH_HOSTS", Value: elasticsearchURL},
+			{Name: "OPENSEARCH_HOSTS", Value: openSearchURL},
 		}
 
 		statefulSet.Spec.Template.Spec.Containers[0].LivenessProbe.InitialDelaySeconds = 120

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -6,20 +6,18 @@ package statefulsets
 import (
 	"testing"
 
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/nodes"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
-	storagev1 "k8s.io/api/storage/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-
 	"github.com/stretchr/testify/assert"
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/nodes"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const defaultStorageClass = "default"
@@ -28,6 +26,39 @@ var storageClass = storagev1.StorageClass{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: defaultStorageClass,
 	},
+}
+
+// TestNewOpenSearchDashboardsStatefulSet tests the creation of OpenSearch-Dashboard StatefulSets
+// GIVEN a VMI spec with an Kibana spec having 'enabled' set to true
+//  WHEN I call NewOpenSearchDashboardsStatefulSet
+//  THEN there should be a StatefulSet created
+func TestNewOpenSearchDashboardsStatefulSet(t *testing.T) {
+	vmo := &vmcontrollerv1.VerrazzanoMonitoringInstance{
+		Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
+			Kibana: vmcontrollerv1.Kibana{
+				Enabled: true,
+			},
+		},
+	}
+	statefulSet := NewOpenSearchDashboardsStatefulSet(vmo)
+	assert.Equal(t, appsv1.RollingUpdateStatefulSetStrategyType, statefulSet.Spec.UpdateStrategy.Type)
+	assert.NotNil(t, statefulSet)
+}
+
+// TestNewOpenSearchDashboardsStatefulSetDisabled tests the creation of OpenSearch-Dashboard StatefulSets
+// GIVEN a VMI spec with an Kibana spec having 'enabled' set to false
+//  WHEN I call NewOpenSearchDashboardsStatefulSet
+//  THEN there should be no StatefulSets created
+func TestNewOpenSearchDashboardsStatefulSetDisabled(t *testing.T) {
+	vmo := &vmcontrollerv1.VerrazzanoMonitoringInstance{
+		Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
+			Kibana: vmcontrollerv1.Kibana{
+				Enabled: false,
+			},
+		},
+	}
+	statefulSet := NewOpenSearchDashboardsStatefulSet(vmo)
+	assert.Nil(t, statefulSet)
 }
 
 // TestVMOEmptyStatefulSetSize tests the creation of a VMI without StatefulSets

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -26,6 +26,10 @@ func updateOpenSearchDashboardsDeployment(osd *appsv1.Deployment, controller *Co
 		return nil
 	}
 
+	if err := controller.osClient.IsGreen(vmo); err != nil {
+		return err
+	}
+
 	var err error
 	existingDeployment, err := controller.deploymentLister.Deployments(vmo.Namespace).Get(osd.Name)
 	if err != nil {

--- a/pkg/vmo/statefulset.go
+++ b/pkg/vmo/statefulset.go
@@ -47,11 +47,10 @@ func CreateStatefulSets(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMo
 	if vmo.Spec.Kibana.Enabled {
 		if err := controller.osClient.IsGreen(vmo); err != nil {
 			return false, err
-		} else {
-			if osd := statefulsets.NewOpenSearchDashboardsStatefulSet(vmo); osd != nil {
-				if err = updateOpenSearchDashboardsStatefulSet(osd, controller, vmo); err != nil {
-					return false, err
-				}
+		}
+		if osd := statefulsets.NewOpenSearchDashboardsStatefulSet(vmo); osd != nil {
+			if err = updateOpenSearchDashboardsStatefulSet(osd, controller, vmo); err != nil {
+				return false, err
 			}
 		}
 	}
@@ -229,7 +228,9 @@ func updateOpenSearchDashboardsStatefulSet(osd *appsv1.StatefulSet, controller *
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			controller.log.Oncef("Creating StatefulSet %s/%s", osd.Namespace, osd.Name)
-			_, err = controller.kubeclientset.AppsV1().StatefulSets(vmo.Namespace).Create(context.TODO(), osd, metav1.CreateOptions{})
+			if _, err = controller.kubeclientset.AppsV1().StatefulSets(vmo.Namespace).Create(context.TODO(), osd, metav1.CreateOptions{}); err != nil {
+				return err
+			}
 		} else {
 			return err
 		}

--- a/pkg/vmo/statefulset.go
+++ b/pkg/vmo/statefulset.go
@@ -5,7 +5,6 @@ package vmo
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
@@ -234,7 +233,7 @@ func updateOpenSearchDashboardsStatefulSet(osd *appsv1.StatefulSet, controller *
 			return err
 		}
 		// Return a temporary error to give some time for the "delete" to start processing
-		return errors.New(fmt.Sprintf("waiting for delete of deployment %s in namespace %s to start processing", osd.Name, vmo.Namespace))
+		return fmt.Errorf("waiting for delete of deployment %s in namespace %s to start processing", osd.Name, vmo.Namespace)
 	} else if !k8serrors.IsNotFound(err) {
 		return err
 	}

--- a/pkg/vmo/statefulset.go
+++ b/pkg/vmo/statefulset.go
@@ -5,15 +5,56 @@ package vmo
 
 import (
 	"context"
+
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/metricsexporter"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/nodes"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/statefulsets"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
 	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
+
+func updateOpenSearchDashboardsStatefulSet(osd *appsv1.StatefulSet, controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, plan *statefulsets.StatefulSetPlan) error {
+	if osd == nil {
+		return nil
+	}
+
+	if err := controller.osClient.IsGreen(vmo); err != nil {
+		return err
+	}
+
+	var err error
+	existingStatefulSet, err := controller.statefulSetLister.StatefulSets(vmo.Namespace).Get(osd.Name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			controller.log.Oncef("Creating StatefulSet %s/%s", osd.Namespace, osd.Name)
+			_, err = controller.kubeclientset.AppsV1().StatefulSets(vmo.Namespace).Create(context.TODO(), osd, metav1.CreateOptions{})
+		} else {
+			return err
+		}
+	} else {
+		err = controller.osClient.IsUpdated(vmo)
+		if err != nil {
+			return err
+		}
+		err = updateStatefulSet(controller, existingStatefulSet, vmo, plan)
+	}
+	if err != nil {
+		if metric, metricErr := metricsexporter.GetErrorMetrics(metricsexporter.NamesDeploymentUpdateError); metricErr != nil {
+			controller.log.Errorf("Failed to get error metric %s: %v", metricsexporter.NamesDeploymentUpdateError, metricErr)
+		} else {
+			metric.Inc()
+		}
+		controller.log.Errorf("Failed to update StatefulSet %s/%s: %v", osd.Namespace, osd.Name, err)
+		return err
+	}
+
+	return nil
+}
 
 // CreateStatefulSets creates/updates/deletes VMO statefulset k8s resources
 func CreateStatefulSets(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) (bool, error) {
@@ -59,6 +100,17 @@ func CreateStatefulSets(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMo
 	for _, sts := range plan.Update {
 		if err := updateStatefulSet(controller, sts, vmo, plan); err != nil {
 			return plan.ExistingCluster, logReturnError(controller.log, sts, err)
+		}
+	}
+
+	// Create the OSD StatefulSet
+	if vmo.Spec.Kibana.Enabled {
+		osd := statefulsets.NewOpenSearchDashboardsStatefulSet(vmo)
+		if osd != nil {
+			err = updateOpenSearchDashboardsStatefulSet(osd, controller, vmo, plan)
+			if err != nil {
+				return false, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Defer the deployment of the OpenSearch dashboards until after ES is green.  This is to resolve the issue of a fresh install failing due to indexes being migrated.