### PR TITLE
VZ-6735 Set auto_expand_replicas to 0-1 for system indices when OS is a single node cluster

### DIFF
--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -21,7 +21,7 @@ type (
 )
 
 const (
-	indexSettings     = `{"index_patterns": [".opendistro*"],"priority": 0,"template": {"settings": {"auto_expand_replicas": "0-1"}}}`
+	indexSettings     = `{"index_patterns": ["*"],"priority": 0,"template": {"settings": {"auto_expand_replicas": "0-1"}}}`
 	applicationJSON   = "application/json"
 	contentTypeHeader = "Content-Type"
 )
@@ -99,7 +99,7 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 			return
 		}
 		opensearchEndpoint := resources.GetOpenSearchHTTPEndpoint(vmi)
-		settingsURL := fmt.Sprintf("%s/_index_template/ism-plugin-template", opensearchEndpoint)
+		settingsURL := fmt.Sprintf("%s/_index_template/global-index-template", opensearchEndpoint)
 		req, err := http.NewRequest("PUT", settingsURL, bytes.NewReader([]byte(indexSettings)))
 		if err != nil {
 			ch <- err

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -21,7 +21,7 @@ type (
 )
 
 const (
-	indexSettings     = `{"index_patterns": ["*"],"priority": 0,"template": {"settings": {"auto_expand_replicas": "0-1"}}}`
+	indexSettings     = `{"index_patterns": [".opendistro*", "verrazzano-jaeger*"],"priority": 0,"template": {"settings": {"auto_expand_replicas": "0-1"}}}`
 	applicationJSON   = "application/json"
 	contentTypeHeader = "Content-Type"
 )
@@ -99,7 +99,7 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 			return
 		}
 		opensearchEndpoint := resources.GetOpenSearchHTTPEndpoint(vmi)
-		settingsURL := fmt.Sprintf("%s/_index_template/global-index-template", opensearchEndpoint)
+		settingsURL := fmt.Sprintf("%s/_index_template/system-index-template", opensearchEndpoint)
 		req, err := http.NewRequest("PUT", settingsURL, bytes.NewReader([]byte(indexSettings)))
 		if err != nil {
 			ch <- err


### PR DESCRIPTION
VZ-6735 - This bug is for system indices not reaching Jaeger during bootstrap. When the issue is fixed, traces starts reaching OS and the index created automatically is with replica count = 1. This causes the OS cluster to become unstable and go into yellow state during startup. The current solution is to set `auto_expand_replica=0-1` for all indices `*` present in the OS cluster.