### PR TITLE
VZ-6157 - Deploy OpenSearch Dashboard pods one at a time

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -261,9 +261,7 @@ func NewOpenSearchDashboardsDeployment(vmo *vmcontrollerv1.VerrazzanoMonitoringI
 		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
 		}
-		// Always start with one replica, then scale up one at a time
-		// deployment.Spec.Replicas = resources.NewVal(vmo.Spec.Kibana.Replicas)
-		deployment.Spec.Replicas = resources.NewVal(int32(1))
+		deployment.Spec.Replicas = resources.NewVal(vmo.Spec.Kibana.Replicas)
 		deployment.Spec.Template.Spec.Affinity = resources.CreateZoneAntiAffinityElement(vmo.Name, config.Kibana.Name)
 		deployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
 			{Name: "OPENSEARCH_HOSTS", Value: elasticsearchURL},

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -261,7 +261,9 @@ func NewOpenSearchDashboardsDeployment(vmo *vmcontrollerv1.VerrazzanoMonitoringI
 		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
 			Type: appsv1.RecreateDeploymentStrategyType,
 		}
-		deployment.Spec.Replicas = resources.NewVal(vmo.Spec.Kibana.Replicas)
+		// Always start with one replica, then scale up one at a time
+		// deployment.Spec.Replicas = resources.NewVal(vmo.Spec.Kibana.Replicas)
+		deployment.Spec.Replicas = resources.NewVal(int32(1))
 		deployment.Spec.Template.Spec.Affinity = resources.CreateZoneAntiAffinityElement(vmo.Name, config.Kibana.Name)
 		deployment.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
 			{Name: "OPENSEARCH_HOSTS", Value: elasticsearchURL},

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -55,7 +55,7 @@ func updateOpenSearchDashboardsDeployment(osd *appsv1.Deployment, controller *Co
 			*resources.NewVal(vmo.Spec.Kibana.Replicas) > *existingDeployment.Spec.Replicas {
 			// Ok to scale up
 			*osd.Spec.Replicas = *existingDeployment.Spec.Replicas + 1
-			controller.log.Oncef("Incrementing replica count of deployment %s/%s to %d", osd.Namespace, osd.Name, *existingDeployment.Spec.Replicas)
+			controller.log.Oncef("Incrementing replica count of deployment %s/%s to %d", osd.Namespace, osd.Name, *osd.Spec.Replicas)
 		}
 		if err = updateDeployment(controller, vmo, existingDeployment, osd); err == nil {
 			// Return a temporary error if not finished scaling up to the desired replica count

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -67,6 +67,7 @@ func updateOpenSearchDashboardsDeployment(osd *appsv1.Deployment, controller *Co
 		if existingDeployment.Status.ReadyReplicas == *existingDeployment.Spec.Replicas {
 			// Ok to scale up
 			*existingDeployment.Spec.Replicas++
+			controller.log.Oncef("Incrementing replica count of deployment %s/%s to %d", osd.Namespace, osd.Name, *existingDeployment.Spec.Replicas)
 			if _, err = controller.kubeclientset.AppsV1().Deployments(vmo.Namespace).Update(context.TODO(), existingDeployment, metav1.UpdateOptions{}); err != nil {
 				return err
 			}

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -60,7 +60,7 @@ func updateOpenSearchDashboardsDeployment(osd *appsv1.Deployment, controller *Co
 
 	// Determine if the deployment needs to be scaled up. The OS Dashboard pods are being rolled out one at a time.
 	// First re-fetch the deployment
-	if existingDeployment, err = controller.deploymentLister.Deployments(vmo.Namespace).Get(osd.Name); err != nil {
+	if existingDeployment, err = controller.kubeclientset.AppsV1().Deployments(vmo.Namespace).Get(context.TODO(), osd.Name, metav1.GetOptions{}); err != nil {
 		return err
 	}
 	if *resources.NewVal(vmo.Spec.Kibana.Replicas) > *existingDeployment.Spec.Replicas {

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -54,7 +54,7 @@ func updateOpenSearchDashboardsDeployment(osd *appsv1.Deployment, controller *Co
 		if existingDeployment.Status.ReadyReplicas == *existingDeployment.Spec.Replicas &&
 			*resources.NewVal(vmo.Spec.Kibana.Replicas) > *existingDeployment.Spec.Replicas {
 			// Ok to scale up
-			*existingDeployment.Spec.Replicas++
+			*osd.Spec.Replicas = *existingDeployment.Spec.Replicas + 1
 			controller.log.Oncef("Incrementing replica count of deployment %s/%s to %d", osd.Namespace, osd.Name, *existingDeployment.Spec.Replicas)
 		}
 		if err = updateDeployment(controller, vmo, existingDeployment, osd); err == nil {


### PR DESCRIPTION
Change install and upgrade of OpenSearch Dashboards to deploy a single pod at a time, to avoid getting errors about indices needing to be migrated.