### PR TITLE
VZ-6757: Wait for available replica count instead of ready count for OS Dashboards

### DIFF
--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -51,7 +51,7 @@ func updateOpenSearchDashboardsDeployment(osd *appsv1.Deployment, controller *Co
 		if err = controller.osClient.IsUpdated(vmo); err != nil {
 			return err
 		}
-		if existingDeployment.Status.ReadyReplicas == *existingDeployment.Spec.Replicas &&
+		if existingDeployment.Status.AvailableReplicas == *existingDeployment.Spec.Replicas &&
 			*resources.NewVal(vmo.Spec.Kibana.Replicas) > *existingDeployment.Spec.Replicas {
 			// Ok to scale up
 			*osd.Spec.Replicas = *existingDeployment.Spec.Replicas + 1


### PR DESCRIPTION
Modify check for being ready to use available replica count instead of ready count.  Available count ensures the pod has been ready for min seconds.