### PR TITLE
VZ-7002: Prevent logging of error messages due to Opensearch not being ready

### DIFF
--- a/pkg/opensearch/health_test.go
+++ b/pkg/opensearch/health_test.go
@@ -4,6 +4,7 @@
 package opensearch
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -14,9 +15,14 @@ import (
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	fake "k8s.io/client-go/kubernetes/fake"
+	appslistersv1 "k8s.io/client-go/listers/apps/v1"
 )
 
 const (
@@ -222,4 +228,162 @@ func TestIsOpenSearchResizable(t *testing.T) {
 	}
 	o := NewOSClient(statefulSetLister)
 	assert.Error(t, o.IsDataResizable(&notEnoughNodesVMO))
+}
+
+// simple StatefulsetLister implementation
+type simpleStatefulSetLister struct {
+	kubeClient kubernetes.Interface
+}
+
+// lists all StatefulSets
+func (s *simpleStatefulSetLister) List(selector labels.Selector) ([]*appsv1.StatefulSet, error) {
+	namespaces, err := s.kubeClient.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var statefulSets []*appsv1.StatefulSet
+	for _, namespace := range namespaces.Items {
+
+		list, err := s.StatefulSets(namespace.Name).List(selector)
+		if err != nil {
+			return nil, err
+		}
+		statefulSets = append(statefulSets, list...)
+	}
+	return statefulSets, nil
+}
+
+// StatefulSets returns an object that can list and get StatefulSets.
+func (s *simpleStatefulSetLister) StatefulSets(namespace string) appslistersv1.StatefulSetNamespaceLister {
+	return simpleStatefulSetNamespaceLister{
+		namespace:  namespace,
+		kubeClient: s.kubeClient,
+	}
+}
+
+// GetPodStatefulSets is a fake implementation for StatefulSetLister.GetPodStatefulSets
+func (s *simpleStatefulSetLister) GetPodStatefulSets(pod *v1.Pod) ([]*appsv1.StatefulSet, error) {
+	return nil, nil
+}
+
+// simpleStatefulSetNamespaceLister implements the StatefulSetNamespaceLister
+// interface.
+type simpleStatefulSetNamespaceLister struct {
+	namespace  string
+	kubeClient kubernetes.Interface
+}
+
+// List lists all StatefulSets for a given namespace.
+func (s simpleStatefulSetNamespaceLister) List(selector labels.Selector) ([]*appsv1.StatefulSet, error) {
+	var statefulSets []*appsv1.StatefulSet
+
+	list, err := s.kubeClient.AppsV1().StatefulSets(s.namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range list.Items {
+		if selector.Matches(labels.Set(list.Items[i].Labels)) {
+			statefulSets = append(statefulSets, &list.Items[i])
+		}
+	}
+	return statefulSets, nil
+}
+
+// GetPodStatefulSets is a fake implementation for StatefulSetNamespaceLister.GetPodStatefulSets
+func (s *simpleStatefulSetNamespaceLister) GetPodStatefulSets(pod *v1.Pod) ([]*appsv1.StatefulSet, error) {
+	return nil, nil
+}
+
+// Get is a fake implementation for StatefulSetNamespaceLister.Get
+func (s simpleStatefulSetNamespaceLister) Get(name string) (*appsv1.StatefulSet, error) {
+	return nil, nil
+}
+
+// TestIsOpenSearchReady Tests the value returned by  IsOpenSearchReady in few scenarios
+// GIVEN a default VMI instance
+// WHEN I call IsOpenSearchReady
+// THEN the IsOpenSearchReady returns true only when the Opensearch StatefulSet pods are ready, false otherwise
+func TestIsOpenSearchReady(t *testing.T) {
+	var tests = []struct {
+		name      string
+		clientSet *fake.Clientset
+		isReady   bool
+	}{
+		{
+			"not ready when no stateful set is found",
+			fake.NewSimpleClientset(),
+			false,
+		},
+		{
+			"not ready when opensearch statefulset is not found",
+			fake.NewSimpleClientset(&appsv1.StatefulSet{}),
+			false,
+		},
+		{
+			"not ready when opensearch statefulset set is not ready",
+			fake.NewSimpleClientset(&appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						constants.VMOLabel: constants.VMODefaultName, constants.ComponentLabel: constants.ComponentOpenSearchValue,
+					},
+					Namespace: testvmo.GetNamespace(),
+				},
+				Status: appsv1.StatefulSetStatus{
+					Replicas: 1,
+				},
+			}),
+			false,
+		},
+		{
+			"ready when opensearch statefulset set is ready",
+			fake.NewSimpleClientset(&appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						constants.VMOLabel: constants.VMODefaultName, constants.ComponentLabel: constants.ComponentOpenSearchValue,
+					},
+					Namespace: testvmo.GetNamespace(),
+				},
+				Status: appsv1.StatefulSetStatus{
+					Replicas:      1,
+					ReadyReplicas: 1,
+				},
+			}),
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := NewOSClient(&simpleStatefulSetLister{kubeClient: tt.clientSet})
+			ready := o.IsOpenSearchReady(&testvmo)
+			assert.Equal(t, ready, tt.isReady)
+		})
+	}
+}
+
+// TestSetAutoExpandIndicesNoErrorWhenOSNotReady Tests the SetAutoExpandIndices does not return error when OpenSearch is not ready
+// GIVEN a default VMI instance
+// WHEN I call SetAutoExpandIndices
+// THEN the SetAutoExpandIndices does not return error when the Opensearch StatefulSet pods are not ready
+func TestSetAutoExpandIndicesNoErrorWhenOSNotReady(t *testing.T) {
+	o := NewOSClient(&simpleStatefulSetLister{kubeClient: fake.NewSimpleClientset(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.VMOLabel: constants.VMODefaultName, constants.ComponentLabel: constants.ComponentOpenSearchValue,
+			},
+			Namespace: testvmo.GetNamespace(),
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas: 1,
+		},
+	})})
+	assert.NoError(t, <-o.SetAutoExpandIndices(&vmcontrollerv1.VerrazzanoMonitoringInstance{Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
+		Elasticsearch: vmcontrollerv1.Elasticsearch{
+			Enabled: true,
+			MasterNode: vmcontrollerv1.ElasticsearchNode{
+				Replicas: 1,
+				Roles:    []vmcontrollerv1.NodeRole{vmcontrollerv1.MasterRole},
+			},
+		},
+	}}))
 }

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -8,13 +8,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"io"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -116,7 +117,7 @@ func createISMVMI(age string, enabled bool) *vmcontrollerv1.VerrazzanoMonitoring
 // WHEN I call Configure
 // THEN the ISM configuration does nothing because it is disabled
 func TestConfigureIndexManagementPluginISMDisabled(t *testing.T) {
-	o := NewOSClient()
+	o := NewOSClient(statefulSetLister)
 	assert.NoError(t, <-o.ConfigureISM(&vmcontrollerv1.VerrazzanoMonitoringInstance{}))
 }
 
@@ -125,7 +126,7 @@ func TestConfigureIndexManagementPluginISMDisabled(t *testing.T) {
 // WHEN I call Configure
 // THEN the ISM configuration is created in OpenSearch
 func TestConfigureIndexManagementPluginHappyPath(t *testing.T) {
-	o := NewOSClient()
+	o := NewOSClient(statefulSetLister)
 	o.DoHTTP = func(request *http.Request) (*http.Response, error) {
 		switch request.Method {
 		case "GET":
@@ -174,7 +175,7 @@ func TestGetPolicyByName(t *testing.T) {
 		},
 	}
 
-	o := NewOSClient()
+	o := NewOSClient(statefulSetLister)
 	o.DoHTTP = func(request *http.Request) (*http.Response, error) {
 		if strings.Contains(request.URL.Path, "verrazzano-system") {
 			return &http.Response{
@@ -251,7 +252,7 @@ func TestPutUpdatedPolicy_PolicyExists(t *testing.T) {
 		assert.NoError(t, err)
 		status := http.StatusOK
 		existingPolicy.Status = &status
-		o := NewOSClient()
+		o := NewOSClient(statefulSetLister)
 		o.DoHTTP = tt.httpFunc
 		t.Run(tt.name, func(t *testing.T) {
 			newPolicy := &vmcontrollerv1.IndexManagementPolicy{
@@ -349,7 +350,7 @@ func TestPolicyNeedsUpdate(t *testing.T) {
 // WHEN I call cleanupPolicies
 // THEN then the existing policies should be queried and any non-matching members removed
 func TestCleanupPolicies(t *testing.T) {
-	o := NewOSClient()
+	o := NewOSClient(statefulSetLister)
 
 	id1 := "myapp"
 	id2 := "anotherapp"

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -446,3 +446,16 @@ func TestIsEligibleForDeletion(t *testing.T) {
 		})
 	}
 }
+
+// TestConfigureIndexManagementPluginOpenSearchNotReady Tests that ConfigureISM does not return error when OpenSearch is not ready
+// GIVEN a default VMI instance
+// WHEN I call ConfigureISM
+// THEN the ISM configuration does nothing because OpenSearch is not ready
+func TestConfigureIndexManagementPluginOpenSearchNotReady(t *testing.T) {
+	o := NewOSClient(statefulSetLister)
+	assert.NoError(t, <-o.ConfigureISM(&vmcontrollerv1.VerrazzanoMonitoringInstance{Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
+		Elasticsearch: vmcontrollerv1.Elasticsearch{
+			Enabled: true,
+		},
+	}}))
+}

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -7,16 +7,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/nodes"
-	"net/http"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/labels"
+	appslistersv1 "k8s.io/client-go/listers/apps/v1"
 )
 
 type (
 	OSClient struct {
-		httpClient *http.Client
-		DoHTTP     func(request *http.Request) (*http.Response, error)
+		httpClient        *http.Client
+		DoHTTP            func(request *http.Request) (*http.Response, error)
+		statefulSetLister appslistersv1.StatefulSetLister
 	}
 )
 
@@ -26,9 +32,10 @@ const (
 	contentTypeHeader = "Content-Type"
 )
 
-func NewOSClient() *OSClient {
+func NewOSClient(statefulSetLister appslistersv1.StatefulSetLister) *OSClient {
 	o := &OSClient{
-		httpClient: http.DefaultClient,
+		httpClient:        http.DefaultClient,
+		statefulSetLister: statefulSetLister,
 	}
 	o.DoHTTP = func(request *http.Request) (*http.Response, error) {
 		return o.httpClient.Do(request)
@@ -71,6 +78,11 @@ func (o *OSClient) ConfigureISM(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance
 			return
 		}
 
+		if !o.IsOpenSearchReady(vmi) {
+			ch <- nil
+			return
+		}
+
 		opensearchEndpoint := resources.GetOpenSearchHTTPEndpoint(vmi)
 		for _, policy := range vmi.Spec.Elasticsearch.Policies {
 			if err := o.createISMPolicy(opensearchEndpoint, policy); err != nil {
@@ -88,6 +100,7 @@ func (o *OSClient) ConfigureISM(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance
 // SetAutoExpandIndices updates the default index settings to auto expand replicas (max 1) when nodes are added to the cluster
 func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) chan error {
 	ch := make(chan error)
+
 	// configuration is done asynchronously, as this does not need to be blocking
 	go func() {
 		if !vmi.Spec.Elasticsearch.Enabled {
@@ -98,6 +111,12 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 			ch <- nil
 			return
 		}
+
+		if !o.IsOpenSearchReady(vmi) {
+			ch <- nil
+			return
+		}
+
 		opensearchEndpoint := resources.GetOpenSearchHTTPEndpoint(vmi)
 		settingsURL := fmt.Sprintf("%s/_index_template/ism-plugin-template", opensearchEndpoint)
 		req, err := http.NewRequest("PUT", settingsURL, bytes.NewReader([]byte(indexSettings)))
@@ -129,4 +148,25 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 	}()
 
 	return ch
+}
+
+func (o *OSClient) IsOpenSearchReady(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) bool {
+	selector := labels.SelectorFromSet(map[string]string{constants.VMOLabel: vmi.Name, constants.ComponentLabel: constants.ComponentOpenSearchValue})
+	statefulSets, err := o.statefulSetLister.StatefulSets(vmi.Namespace).List(selector)
+	if err != nil {
+		zap.S().Error("Error fetching OpenSearch statefulset.")
+		return false
+	}
+
+	if len(statefulSets) == 0 {
+		zap.S().Error("OpenSearch statefulset not created.")
+		return false
+	}
+
+	if len(statefulSets) > 1 {
+		zap.S().Errorf("Invalid number of OpenSearch statefulset created %v.", len(statefulSets))
+		return false
+	}
+
+	return statefulSets[0].Status.ReadyReplicas == statefulSets[0].Status.Replicas
 }

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -155,17 +155,17 @@ func (o *OSClient) IsOpenSearchReady(vmi *vmcontrollerv1.VerrazzanoMonitoringIns
 	selector := labels.SelectorFromSet(map[string]string{constants.VMOLabel: vmi.Name, constants.ComponentLabel: constants.ComponentOpenSearchValue})
 	statefulSets, err := o.statefulSetLister.StatefulSets(vmi.Namespace).List(selector)
 	if err != nil {
-		zap.S().Error("Error fetching OpenSearch statefulset.")
+		zap.S().Errorf("error fetching OpenSearch statefulset, error: %s", err.Error())
 		return false
 	}
 
 	if len(statefulSets) == 0 {
-		zap.S().Error("OpenSearch statefulset not created.")
+		zap.S().Warn("waiting for OpenSearch statefulset to be created.")
 		return false
 	}
 
 	if len(statefulSets) > 1 {
-		zap.S().Errorf("Invalid number of OpenSearch statefulset created %v.", len(statefulSets))
+		zap.S().Errorf("invalid number of OpenSearch statefulset created %v.", len(statefulSets))
 		return false
 	}
 

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -150,6 +150,7 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 	return ch
 }
 
+//IsOpenSearchReady returns true when all OpenSearch pods are ready, false otherwise
 func (o *OSClient) IsOpenSearchReady(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) bool {
 	selector := labels.SelectorFromSet(map[string]string{constants.VMOLabel: vmi.Name, constants.ComponentLabel: constants.ComponentOpenSearchValue})
 	statefulSets, err := o.statefulSetLister.StatefulSets(vmi.Namespace).List(selector)

--- a/pkg/opensearch/opensearch_upgrade_test.go
+++ b/pkg/opensearch/opensearch_upgrade_test.go
@@ -5,14 +5,15 @@ package opensearch
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
-	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
 )
 
 const fakeIndicesResponse = `{
@@ -66,7 +67,7 @@ const openSearchEP = "http://localhost:9200/"
 // WHEN I call getIndices, getSystemIndices, and getApplicationIndices
 // THEN I get back the expected indices, system indices, and application indices
 func TestGetIndices(t *testing.T) {
-	o := NewOSClient()
+	o := NewOSClient(statefulSetLister)
 	o.DoHTTP = func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
@@ -97,7 +98,7 @@ func TestGetIndices(t *testing.T) {
 // THEN true is returned if the data stream is present
 func TestDataStreamExists(t *testing.T) {
 	a := assert.New(t)
-	o := NewOSClient()
+	o := NewOSClient(statefulSetLister)
 	o.DoHTTP = func(request *http.Request) (*http.Response, error) {
 		if strings.Contains(request.URL.Path, config.DataStreamName()) {
 			return &http.Response{
@@ -232,7 +233,7 @@ func TestReindexAndDeleteIndices(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			o := NewOSClient()
+			o := NewOSClient(statefulSetLister)
 			o.DoHTTP = tt.httpFunc
 			err := o.reindexAndDeleteIndices(vzlog.DefaultLogger(), vmi, openSearchEP, tt.indices, tt.isSystemIndex)
 			if tt.isError {
@@ -249,7 +250,7 @@ func TestReindexAndDeleteIndices(t *testing.T) {
 // WHEN I call reindexToDataStream
 // THEN the index is reindex to a data stream
 func TestReindexToDataStream(t *testing.T) {
-	o := NewOSClient()
+	o := NewOSClient(statefulSetLister)
 	o.DoHTTP = func(request *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -5,6 +5,7 @@ package upgrade
 
 import (
 	"fmt"
+
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/opensearch"
@@ -20,6 +21,10 @@ type Monitor struct {
 
 func (m *Monitor) MigrateOldIndices(log vzlog.VerrazzanoLogger, vmi *vmcontrollerv1.VerrazzanoMonitoringInstance,
 	o *opensearch.OSClient, od *dashboards.OSDashboardsClient) error {
+	if !o.IsOpenSearchReady(vmi) {
+		return nil
+	}
+
 	// if not already migrating, start migrating indices
 	if !m.running {
 		m.run(log, vmi, o, od)

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/opensearch"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
+	kubeinformers "k8s.io/client-go/informers"
+	fake "k8s.io/client-go/kubernetes/fake"
+)
+
+// TestMigrateOldIndicesNoErrorWhenOSNotReady tests that MigrateOldIndices does not return error when OpenSearch is not ready
+// GIVEN a default VMI instance
+// WHEN I call MigrateOldIndices
+// THEN the MigrateOldIndices does not return error when the Opensearch StatefulSet pods are not ready
+func TestMigrateOldIndicesNoErrorWhenOSNotReady(t *testing.T) {
+	// fake statefulSetLister that returns no StatefulSets and hence o.IsOpenSearchReady() returns false
+	statefulSetLister := kubeinformers.NewSharedInformerFactory(fake.NewSimpleClientset(), constants.ResyncPeriod).Apps().V1().StatefulSets().Lister()
+	o := opensearch.NewOSClient(statefulSetLister)
+	monitor := &Monitor{}
+	err := monitor.MigrateOldIndices(vzlog.DefaultLogger(), &vmcontrollerv1.VerrazzanoMonitoringInstance{}, o, nil)
+	assert.NoError(t, err)
+}

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -205,9 +205,10 @@ func NewController(namespace string, configmapName string, buildVersion string, 
 	eventBroadcaster.StartLogging(zap.S().Infof)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
+	statefulSetLister := statefulSetInformer.Lister()
 
 	zap.S().Infow("Creating OpenSearch client")
-	osClient := opensearch.NewOSClient()
+	osClient := opensearch.NewOSClient(statefulSetLister)
 
 	zap.S().Infow("Creating OpenSearchDashboards client")
 	osDashboardsClient := dashboards.NewOSDashboardsClient()
@@ -238,7 +239,7 @@ func NewController(namespace string, configmapName string, buildVersion string, 
 		secretsSynced:         secretsInformer.Informer().HasSynced,
 		serviceLister:         serviceInformer.Lister(),
 		servicesSynced:        serviceInformer.Informer().HasSynced,
-		statefulSetLister:     statefulSetInformer.Lister(),
+		statefulSetLister:     statefulSetLister,
 		statefulSetsSynced:    statefulSetInformer.Informer().HasSynced,
 		vmoLister:             vmoInformer.Lister(),
 		vmosSynced:            vmoInformer.Informer().HasSynced,


### PR DESCRIPTION
Check for Opensearch pods to be ready before accessing in `ConfigureISM` , `MigrateOldIndices` and `SetAutoExpandIndices` to prevent logging error message due to pods not being up yet