### PR TITLE
Add a few log statements, fix a couple of places where deleting deployments might be skipped

### DIFF
--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -521,6 +521,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	 **********************/
 	existingCluster, err := CreateStatefulSets(c, vmo)
 	if err != nil {
+		c.log.Errorf("Failed to create/update statefulsets for VMI %s: %v", vmo.Name, err)
 		errorObserved = true
 	}
 
@@ -531,6 +532,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	if !errorObserved {
 		deploymentsDirty, err = CreateDeployments(c, vmo, pvcToAdMap, existingCluster)
 		if err != nil {
+			c.log.Errorf("Failed to create/update deployments for VMI %s: %v", vmo.Name, err)
 			functionMetric.IncError()
 			errorObserved = true
 		}


### PR DESCRIPTION
This PR adds a few log statements and also fixes two places where deleting deployments might be skipped:
1. In the `deleteDeployment` function, the first thing it does is get a metric. If getting that metric failed, it would not attempt to delete the deployment.
2. In the `CreateDeployments` function, it loops over the deployments looking for deployments that should be deleted. In the case of deleting an OpenSearch deployment, it would `return` which would prevent any other deployments from being deleted.