### PR TITLE
VZ-7099: Fix bug that causes deployments to not be deleted

### DIFF
--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -536,22 +536,23 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 		c.log.Errorf("Failed to create Deployment specs for VMI %s: %v", vmo.Name, err)
 		functionMetric.IncError()
 		errorObserved = true
-	}
-	deploymentsDirty, err = CreateDeployments(c, vmo, expectedDeployments, existingCluster)
-	if err != nil {
-		c.log.Errorf("Failed to create/update deployments for VMI %s: %v", vmo.Name, err)
-		functionMetric.IncError()
-		errorObserved = true
-	}
-	// OSD is a special case, so add it to the expected deployments (if it should exist)
-	osd := deployments.NewOpenSearchDashboardsDeployment(vmo)
-	if osd != nil {
-		expectedDeployments.Deployments = append(expectedDeployments.Deployments, osd)
-	}
-	if err = DeleteDeployments(c, vmo, expectedDeployments); err != nil {
-		c.log.Errorf("Failed to delete deployments for VMI %s: %v", vmo.Name, err)
-		functionMetric.IncError()
-		errorObserved = true
+	} else {
+		deploymentsDirty, err = CreateDeployments(c, vmo, expectedDeployments, existingCluster)
+		if err != nil {
+			c.log.Errorf("Failed to create/update deployments for VMI %s: %v", vmo.Name, err)
+			functionMetric.IncError()
+			errorObserved = true
+		}
+		// OSD is a special case, so add it to the expected deployments (if it should exist)
+		osd := deployments.NewOpenSearchDashboardsDeployment(vmo)
+		if osd != nil {
+			expectedDeployments.Deployments = append(expectedDeployments.Deployments, osd)
+		}
+		if err = DeleteDeployments(c, vmo, expectedDeployments); err != nil {
+			c.log.Errorf("Failed to delete deployments for VMI %s: %v", vmo.Name, err)
+			functionMetric.IncError()
+			errorObserved = true
+		}
 	}
 
 	/*********************

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -531,14 +531,22 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	 * Create, update, and delete Deployments
 	 **********************/
 	var deploymentsDirty bool
-	var expectedDeployments *deployments.ExpectedDeployments
-	if !errorObserved {
-		deploymentsDirty, expectedDeployments, err = CreateDeployments(c, vmo, pvcToAdMap, existingCluster)
-		if err != nil {
-			c.log.Errorf("Failed to create/update deployments for VMI %s: %v", vmo.Name, err)
-			functionMetric.IncError()
-			errorObserved = true
-		}
+	expectedDeployments, err := deployments.New(vmo, c.kubeclientset, c.operatorConfig, pvcToAdMap)
+	if err != nil {
+		c.log.Errorf("Failed to create Deployment specs for VMI %s: %v", vmo.Name, err)
+		functionMetric.IncError()
+		errorObserved = true
+	}
+	deploymentsDirty, err = CreateDeployments(c, vmo, expectedDeployments, existingCluster)
+	if err != nil {
+		c.log.Errorf("Failed to create/update deployments for VMI %s: %v", vmo.Name, err)
+		functionMetric.IncError()
+		errorObserved = true
+	}
+	// OSD is a special case, so add it to the expected deployments (if it should exist)
+	osd := deployments.NewOpenSearchDashboardsDeployment(vmo)
+	if osd != nil {
+		expectedDeployments.Deployments = append(expectedDeployments.Deployments, osd)
 	}
 	if err = DeleteDeployments(c, vmo, expectedDeployments); err != nil {
 		c.log.Errorf("Failed to delete deployments for VMI %s: %v", vmo.Name, err)

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -77,8 +77,8 @@ func updateOpenSearchDashboardsDeployment(osd *appsv1.Deployment, controller *Co
 	return nil
 }
 
-// CreateDeployments create/update VMO deployment k8s resources
-func CreateDeployments(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, expectedDeployments *deployments.ExpectedDeployments, existingCluster bool) (bool, error) {
+// CreateOrUpdateDeployments create/update VMO deployment k8s resources
+func CreateOrUpdateDeployments(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, expectedDeployments *deployments.ExpectedDeployments, existingCluster bool) (bool, error) {
 	// The error count is incremented by the function which calls createDeployment
 	functionMetric, functionError := metricsexporter.GetFunctionMetrics(metricsexporter.NamesDeployment)
 	if functionError == nil {

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -145,6 +145,7 @@ func CreateDeployments(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMon
 	// Create the OSD deployment
 	osd := deployments.NewOpenSearchDashboardsDeployment(vmo)
 	if osd != nil {
+		expected.Deployments = append(expected.Deployments, osd)
 		err = updateOpenSearchDashboardsDeployment(osd, controller, vmo)
 		if err != nil {
 			return false, expected, err

--- a/pkg/vmo/metricsexporter_test.go
+++ b/pkg/vmo/metricsexporter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+// Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package vmo
@@ -19,6 +19,7 @@ import (
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/opensearch"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/configmaps"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/deployments"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/upgrade"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -245,8 +246,10 @@ func TestDeploymentMetrics(t *testing.T) {
 
 	metricsexporter.DefaultLabelFunction = func(idx int64) string { return "1" }
 	previousCount := testutil.ToFloat64(delegate.GetFunctionCounterMetric(metricsexporter.NamesDeployment))
+	expectedDeployments, err := deployments.New(vmo, controller.kubeclientset, controller.operatorConfig, map[string]string{})
+	assert.NoError(t, err)
 
-	CreateDeployments(controller, vmo, map[string]string{}, true)
+	CreateDeployments(controller, vmo, expectedDeployments, true)
 
 	newTimeStamp := testutil.ToFloat64(delegate.GetFunctionTimestampMetric(metricsexporter.NamesDeployment).WithLabelValues("1"))
 	newCount := testutil.ToFloat64(delegate.GetFunctionCounterMetric(metricsexporter.NamesDeployment))

--- a/pkg/vmo/metricsexporter_test.go
+++ b/pkg/vmo/metricsexporter_test.go
@@ -249,7 +249,7 @@ func TestDeploymentMetrics(t *testing.T) {
 	expectedDeployments, err := deployments.New(vmo, controller.kubeclientset, controller.operatorConfig, map[string]string{})
 	assert.NoError(t, err)
 
-	CreateDeployments(controller, vmo, expectedDeployments, true)
+	CreateOrUpdateDeployments(controller, vmo, expectedDeployments, true)
 
 	newTimeStamp := testutil.ToFloat64(delegate.GetFunctionTimestampMetric(metricsexporter.NamesDeployment).WithLabelValues("1"))
 	newCount := testutil.ToFloat64(delegate.GetFunctionCounterMetric(metricsexporter.NamesDeployment))


### PR DESCRIPTION
This PR fixes a bug that occurs in the following scenario:
1. User upgrades Verrazzano installation to 1.4
2. After the VMO is upgraded, attempting to create/update deployments fails because the OpenSearch status is yellow
3. Because create/update deployments fails, it never gets to the point of processing deployment deletions

As a result, the old VMI system prometheus deployment does not always get deleted when it should. To fix the problem, I separated out the delete portion of the CreateDeployments function into a new function. The controller calls this new function whether CreateDeployments fails or not.

I have no idea why the OpenSearch health does not report green in some cases, but this fixes the problem of deployments not being deleted.