### PR TITLE
VZ-5615 Update the Verrazzano user to Admin in Grafana

### DIFF
--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -215,7 +215,7 @@ func determineGrafanaState(controller *Controller, deployment *appsv1.Deployment
 	grafanaURL.RawQuery = "loginOrEmail=verrazzano"
 	grafanaURL.User = url.UserPassword(vzUser, vzPass)
 	grafanaResponse, err := http.Get(grafanaURL.String())
-	if err != nil {
+	if err != nil && grafanaResponse.StatusCode != 404 {
 		controller.log.Errorf("Failed to get Verrazzano user information from Grafana with request %s: %v", grafanaURL.String(), err)
 		return 0, err
 	}

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -253,7 +253,7 @@ func requestGrafanaAdmin(controller *Controller, grafanaURL url.URL) error {
 	}
 
 	// Request that the Verrazzano user be Grafana Admin
-	grafanaURL.Path = fmt.Sprintf("api/admin/users/%s/permissions", vzUserInfo.Id)
+	grafanaURL.Path = fmt.Sprintf("api/admin/users/%d/permissions", vzUserInfo.ID)
 	grafanaURL.RawQuery = ""
 	requestData, err := json.Marshal(&grafanaAdminRequest{IsGrafanaAdmin: true})
 	if err != nil {

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -350,7 +350,6 @@ func CreateDeployments(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMon
 
 	var openSearchDeployments []*appsv1.Deployment
 	var deploymentNames []string
-	var grafanaDirty bool
 	controller.log.Oncef("Creating/updating ExpectedDeployments for VMI %s", vmo.Name)
 	for _, curDeployment := range deployList {
 		deploymentName := curDeployment.Name
@@ -438,7 +437,7 @@ func CreateDeployments(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMon
 		}
 	}
 
-	return openSearchDirty || grafanaDirty, nil
+	return openSearchDirty, nil
 }
 
 func deleteDeployment(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, deployment *appsv1.Deployment) error {

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -182,11 +182,17 @@ func updateGrafanaAdminUser(controller *Controller, vmo *vmcontrollerv1.Verrazza
 			return false, err
 		}
 		// we need to add a completed label to the pod, so that the reconciliation does not continue infinitely
+		if len(curDeployment.Annotations) == 0 {
+			curDeployment.Annotations = make(map[string]string)
+		}
 		curDeployment.Annotations[grafanaAdminAnnotation] = completeVal
 		return false, updateDeployment(controller, vmo, grafanaDeployment, curDeployment)
 	case Complete:
 		controller.log.Oncef("The Verrazzano user admin update for Grafana has completed successfully")
 		// this will maintain the completed state
+		if len(curDeployment.Annotations) == 0 {
+			curDeployment.Annotations = make(map[string]string)
+		}
 		curDeployment.Annotations[grafanaAdminAnnotation] = completeVal
 		return false, updateDeployment(controller, vmo, grafanaDeployment, curDeployment)
 	}

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -143,7 +143,7 @@ func updateGrafanaAdminUser(controller *Controller, vmo *vmcontrollerv1.Verrazza
 	}
 	grafanaURL.User = url.UserPassword("admin", "admin")
 
-	grafanaState, err := determineGrafanaState(controller, grafanaDeployment, grafanaURL)
+	grafanaState, err := determineGrafanaState(controller, grafanaDeployment)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -33,8 +33,6 @@ const (
 	grafanaAdminAnnotation = "grafana-admin-update"
 	authProxyEnvName       = "GF_AUTH_PROXY_ENABLED"
 	basicAuthEnvName       = "GF_AUTH_BASIC_ENABLED"
-	vzUserEnvName          = "GF_SECURITY_ADMIN_USER"
-	vzPassEnvName          = "GF_SECURITY_ADMIN_PASSWORD" //nolint:gosec
 )
 
 // GrafanaAdminState Grafana Admin Update state enum

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -6,7 +6,6 @@ package vmo
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -198,18 +197,8 @@ func determineGrafanaState(controller *Controller, deployment *appsv1.Deployment
 		controller.log.Errorf("Failed to get the Grafana Verrazzano credential secret %s: %v", vzUserSecretName, err)
 		return 0, err
 	}
-	vzUserByte, err := base64.URLEncoding.DecodeString(string(vzUserSecret.Data["username"]))
-	if err != nil {
-		controller.log.Errorf("Failed to decode the Verrazzano username data: %v", err)
-		return 0, err
-	}
-	vzPassByte, err := base64.URLEncoding.DecodeString(string(vzUserSecret.Data["password"]))
-	if err != nil {
-		controller.log.Errorf("Failed to decode the Verrazzano password data: %v", err)
-		return 0, err
-	}
-	vzUser := string(vzUserByte)
-	vzPass := string(vzPassByte)
+	vzUser := string(vzUserSecret.Data["username"])
+	vzPass := string(vzUserSecret.Data["password"])
 
 	// Always check that the Verrazzano is not the admin user first
 	// This prevents the pod from continually getting recycled and updated
@@ -235,7 +224,7 @@ func determineGrafanaState(controller *Controller, deployment *appsv1.Deployment
 	return Setup, nil
 }
 
-// reuqestGrafanaAdmin handles the request to Grafana to grant the Verrazzano user admin permissions
+// requestGrafanaAdmin handles the request to Grafana to grant the Verrazzano user admin permissions
 func requestGrafanaAdmin(controller *Controller, grafanaURL url.URL) error {
 	// Get the Verrazzano user ID for the admin request
 	grafanaURL.Path = "api/users/lookup"

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -201,7 +201,7 @@ func updateGrafanaAdminUser(controller *Controller, vmo *vmcontrollerv1.Verrazza
 }
 
 // determineGrafanaState returns a Grafana Admin State based on the status of the Grafana deployment
-func determineGrafanaState(controller *Controller, deployment *appsv1.Deployment, grafanaURL url.URL) (grafanaAdminState, error) {
+func determineGrafanaState(controller *Controller, deployment *appsv1.Deployment) (grafanaAdminState, error) {
 	// to prevent continually reconciling, we first should check the completed annotation
 	if val, ok := deployment.Annotations[grafanaAdminAnnotation]; ok && val == completeVal {
 		return Complete, nil

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -213,16 +213,16 @@ func determineGrafanaState(controller *Controller, deployment *appsv1.Deployment
 	}
 	if grafanaResponse.StatusCode == 200 {
 		return Complete, nil
-	} else {
-		// We expect a message response for a
-		var messageResponse grafanaMessageResponse
-		err = json.NewDecoder(grafanaResponse.Body).Decode(&messageResponse)
-		if err != nil {
-			controller.log.Errorf("Failed to decode the response body of the incomplete request with status %d: %v", grafanaResponse.StatusCode, err)
-			return 0, err
-		}
-		controller.log.Progressf("Request to get Verrazzano user info from from the Grafana pod was unsuccessful status: %d message: %s", grafanaResponse.StatusCode, messageResponse.Message)
 	}
+
+	// Give a progress message for the unsuccessful request
+	var messageResponse grafanaMessageResponse
+	err = json.NewDecoder(grafanaResponse.Body).Decode(&messageResponse)
+	if err != nil {
+		controller.log.Errorf("Failed to decode the response body of the incomplete request with status %d: %v", grafanaResponse.StatusCode, err)
+		return 0, err
+	}
+	controller.log.Progressf("Request to get Verrazzano user info from from the Grafana pod was unsuccessful status: %d, message: %s", grafanaResponse.StatusCode, messageResponse.Message)
 
 	// Check the deployment pod env vars to determine if basic auth is enabled
 	// If so, we should enter the request state
@@ -391,7 +391,7 @@ func CreateDeployments(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMon
 		}
 	}
 
-	return openSearchDirty && grafanaDirty, nil
+	return openSearchDirty || grafanaDirty, nil
 }
 
 func deleteDeployment(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, deployment *appsv1.Deployment) error {


### PR DESCRIPTION
This PR enables the Verrazzano user to become a Grafana admin if requested. To request the verrazzano admin user, the controller looks for this annotation on the VMO:
`grafana-admin-update: true`

This process acts as a state machine that is determined based on the status of the Grafana deployment. The state should be directed (but not acyclic) and can be entered at any stage (this is required if the Grafana deployment or the VMO were to crash in the middle of this process):

- **Setup**
  - If basic auth is disabled and the authproxy is enabled _without_ the `grafana-admin-update: completed` annotation on the Grafana deployment, we enter setup mode
  - This mode will enable basic authentication to enable us to use the Grafana Admin API which we will use in the next step
  - This requires a pod restart for Grafana
  - if successful, transition to the **Request** state
- **Request**
  - the request state does either both or the second of these two items
  - if the verrazzano user does not exist (the console was not accessed before upgrade and the user was never created)
    - create the user and maintain the **Request** stage
  - if the verrazzano user exists, we request that user have Grafana admin permissions
  - if this is successful, we transition to the **Complete** stage by labeling the Grafana deployment with `grafana-admin-update: completed`
- **Complete**
  - if the `grafana-admin-update: completed` is set on the Grafana deployment
    - we return to the original Grafan configuration (authproxy enabled, basic auth disabled)
  - we maintain this state by keeping the annotation `grafana-admin-update: completed`

This is all done in one process (it's pretty quick, less than a minute). I fear that continually reconciling (which would be ideal) would cause cascading changes in the VMO and make this change much larger than it needs to be. I think that because this is a one-time process (it should only run once in the lifecycle of Verrazzano) that we can get away with running this continuously.