### PR TITLE
VZ 7330:Successful wrongly spelt

### DIFF
--- a/.verrazzano-development-version
+++ b/.verrazzano-development-version
@@ -1,4 +1,4 @@
 # Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-verrazzano-development-version=1.4.0
+verrazzano-development-version=1.5.0

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,6 @@ integ-test: go-install
 .PHONY: golangci-lint
 golangci-lint:
 ifeq (, $(shell command -v golangci-lint))
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.42.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.49.0
 endif
 	golangci-lint run

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1,66 +1,48 @@
+=== Public License Template ===
 github.com/verrazzano/verrazzano-monitoring-operator
 -------- Copyrights
-Copyright (c) 2020 Oracle America, Inc. and its affiliates. 
+Copyright (c) 2020 Oracle America, Inc. and its affiliates.
 Copyright (C) 2020, 2022, Oracle and/or its affiliates.
-Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 Copyright (C) 2020, Oracle and/or its affiliates.
 Copyright 2019 The Kubernetes Authors.
+Copyright (c) 2020, 2022, Oracle and/or its affiliates.
 Copyright (C) 2022, Oracle and/or its affiliates.
 Copyright (c) 2022, Oracle and/or its affiliates.
-Copyright (C) 2021, Oracle and/or its affiliates.
 Copyright (C) 2021, 2022, Oracle and/or its affiliates.
+Copyright (C) 2021, Oracle and/or its affiliates.
 Copyright (c) 2020, 2021, Oracle and/or its affiliates.
 Copyright (C) 2020, 2021, Oracle and/or its affiliates.
 
 -------- License
-Copyright (c) 2020 Oracle America, Inc. and its affiliates. 
+The Universal Permissive License (UPL), Version 1.0
+
+Copyright (c) <year> <copyright holders>
 
 The Universal Permissive License (UPL), Version 1.0
 
-Subject to the condition set forth below, permission is hereby granted to any 
-person obtaining a copy of this software, associated documentation and/or data 
-(collectively the "Software"), free of charge and under any and all copyright 
-rights in the Software, and any and all patent rights owned or freely licensable 
-by each licensor hereunder covering either (i) the unmodified Software as 
-contributed to or provided by such licensor, or (ii) the Larger Works (as 
-defined below), to deal in both
+Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software, associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
 
 (a) the Software, and
 
-(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if 
-one is included with the Software (each a ¿Larger Work¿ to which the Software 
-is contributed by such licensors),
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a “Larger Work” to which the Software is contributed by such licensors),
 
-without restriction, including without limitation the rights to copy, create 
-derivative works of, display, perform, and distribute the Software and make, 
-use, sell, offer for sale, import, export, have made, and have sold the 
-Software and the Larger Work(s), and to sublicense the foregoing rights on 
-either these or other terms.
+without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
 
 This license is subject to the following condition:
 
-The above copyright notice and either this complete permission notice or at a 
-minimum a reference to the UPL must be included in all copies or substantial 
-portions of the Software.
+The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------------- Dependencies Grouped by License ------------
 -------- Dependency
 gopkg.in/yaml.v3
 -------- Copyrights
-Copyright 2011-2016 Canonical Ltd.
-copyright staring in 2011 when the project was ported over:
 Copyright (c) 2006-2010 Kirill Simonov
 Copyright (c) 2006-2011 Kirill Simonov
 Copyright (c) 2011-2019 Canonical Ltd
+Copyright 2011-2016 Canonical Ltd.
 -------- Notices
 Copyright 2011-2016 Canonical Ltd.
 
@@ -135,12 +117,521 @@ limitations under the License.
 
 ----------------------- Dependencies Grouped by License ------------
 -------- Dependency
+github.com/go-logr/logr
+-------- Copyrights
+Copyright 2020 The logr Authors.
+Copyright 2021 The logr Authors.
+Copyright 2019 The logr Authors.
+
+-------- Dependency
+github.com/go-logr/zapr
+-------- Copyrights
+Copyright 2019 The logr Authors.
+Copyright 2021 The logr Authors.
+Copyright 2018 Solly Ross
+Copyright 2020 The Kubernetes Authors.
+
+-------- Dependency
+github.com/golang/groupcache
+-------- Copyrights
+Copyright 2012 Google Inc.
+Copyright 2013 Google Inc.
+
+-------- Dependency
+github.com/google/gofuzz
+-------- Copyrights
+Copyright 2014 Google Inc. All rights reserved.
+
+-------- Dependency
+github.com/googleapis/gnostic
+-------- Copyrights
+Copyright 2017-2020, Google LLC.
+Copyright 2019 Google LLC. All Rights Reserved.
+Copyright 2017 Google LLC. All Rights Reserved.
+Copyright 2020 Google LLC. All Rights Reserved.
+Copyright 2018 Google LLC. All Rights Reserved.
+Copyright 2020 Google LLC. All Rights Reserved.\n" +
+
+-------- Dependency
+github.com/matttproud/golang_protobuf_extensions
+-------- Copyrights
+Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+Copyright 2013 Matt T. Proud
+Copyright 2016 Matt T. Proud
+-------- Notices
+Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
+
+
+-------- Dependency
+github.com/moby/spdystream
+-------- Copyrights
+Copyright 2013-2021 Docker, inc. Released under the [Apache 2.0 license](LICENSE).
+Copyright 2014-2021 Docker Inc.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+-------- Notices
+SpdyStream
+Copyright 2014-2021 Docker Inc.
+
+This product includes software developed at
+Docker Inc. (https://www.docker.com/).
+
+
+-------- Dependency
+github.com/modern-go/concurrent
+-------- Copyrights
+  (no copyright notices found)
+
+-------- Dependency
+github.com/modern-go/reflect2
+-------- Copyrights
+  (no copyright notices found)
+
+-------- Dependency
+github.com/prometheus/client_golang
+-------- Copyrights
+Copyright 2018 The Prometheus Authors
+Copyright 2012-2015 The Prometheus Authors
+Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
+Copyright 2010 The Go Authors
+Copyright 2013 Matt T. Proud
+Copyright 2015 The Prometheus Authors
+Copyright 2019 The Prometheus Authors
+Copyright 2017 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2014 The Prometheus Authors
+Copyright 2016 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
+Copyright 2022 The Prometheus Authors
+Copyright (c) 2013, The Prometheus Authors
+-------- Notices
+Prometheus instrumentation library for Go applications
+Copyright 2012-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+The following components are included in this product:
+
+perks - a fork of https://github.com/bmizerany/perks
+https://github.com/beorn7/perks
+Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
+See https://github.com/beorn7/perks/blob/master/README.md for license details.
+
+Go support for Protocol Buffers - Google's data interchange format
+http://github.com/golang/protobuf/
+Copyright 2010 The Go Authors
+See source code for license details.
+
+Support for streaming Protocol Buffer messages for the Go language (golang).
+https://github.com/matttproud/golang_protobuf_extensions
+Copyright 2013 Matt T. Proud
+Licensed under the Apache License, Version 2.0
+
+
+-------- Dependency
+github.com/prometheus/client_model
+-------- Copyrights
+Copyright 2013 Prometheus Team
+Copyright 2012-2015 The Prometheus Authors
+-------- Notices
+Data model artifacts for Prometheus.
+Copyright 2012-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+-------- Dependency
+github.com/prometheus/common
+-------- Copyrights
+Copyright 2015 The Prometheus Authors
+Copyright 2018 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2016 The Prometheus Authors
+Copyright 2014 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
+Copyright (c) 2011, Open Knowledge Foundation Ltd.
+Copyright 2013 The Prometheus Authors
+Copyright 2019 The Prometheus Authors
+Copyright 2017 The Prometheus Authors
+-------- Notices
+Common libraries shared by Prometheus Go components.
+Copyright 2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+-------- Dependency
+github.com/prometheus/procfs
+-------- Copyrights
+Copyright 2018 The Prometheus Authors
+Copyright 2019 The Prometheus Authors
+Copyright 2014-2015 The Prometheus Authors
+Copyright 2017 The Prometheus Authors
+Copyright 2021 The Prometheus Authors
+Copyright 2020 The Prometheus Authors
+Copyright 2014 Prometheus Team
+Copyright 2017 Prometheus Team
+-------- Notices
+procfs provides functions to retrieve system, kernel and process
+metrics from the pseudo-filesystem proc.
+
+Copyright 2014-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+-------- Dependency
+github.com/spf13/afero
+-------- Copyrights
+Copyright © 2014 Steve Francia <spf@spf13.com>.
+Copyright 2013 tsuru authors. All rights reserved.
+Copyright © 2016 Steve Francia <spf@spf13.com>.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright © 2018 Steve Francia <spf@spf13.com>.
+Copyright © 2015 Steve Francia <spf@spf13.com>.
+Copyright © 2015 Jerry Jacobs <jerry.jacobs@xor-gate.org>.
+Copyright 2016-present Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
+
+-------- Dependency
+gomodules.xyz/jsonpatch/v2
+-------- Copyrights
+  (no copyright notices found)
+
+-------- Dependency
+gopkg.in/ini.v1
+-------- Copyrights
+Copyright 2019 Unknwon
+Copyright 2017 Unknwon
+Copyright 2014 Unknwon
+Copyright 2016 Unknwon
+Copyright 2015 Unknwon
+
+-------- Dependency
+gopkg.in/yaml.v2
+-------- Copyrights
+Copyright (c) 2006 Kirill Simonov
+Copyright 2011-2016 Canonical Ltd.
+-------- Notices
+Copyright 2011-2016 Canonical Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+-------- Dependency
+k8s.io/api
+-------- Copyrights
+Copyright 2019 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+
+-------- Dependency
+k8s.io/apiextensions-apiserver
+-------- Copyrights
+Copyright 2019 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2020 Google LLC
+
+-------- Dependency
+k8s.io/apimachinery
+-------- Copyrights
+Copyright 2021 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+
+-------- Dependency
+k8s.io/client-go
+-------- Copyrights
+Copyright 2021 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+-------- Dependency
+k8s.io/component-base
+-------- Copyrights
+Copyright 2017 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+
+-------- Dependency
+k8s.io/klog/v2
+-------- Copyrights
+Copyright 2020 The Kubernetes Authors.
+Copyright 2013 Google Inc. All Rights Reserved.
+
+-------- Dependency
+k8s.io/kube-openapi
+-------- Copyrights
+Copyright 2018 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2015 go-swagger maintainers
+Copyright 2017 go-swagger maintainers
+
+-------- Dependency
+k8s.io/utils
+-------- Copyrights
+Copyright 2018 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2015 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright 2013 Google Inc.
+Copyright 2009 The Go Authors. All rights reserved.
+
+-------- Dependency
+sigs.k8s.io/controller-runtime
+-------- Copyrights
+Copyright 2020 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
+Copyright 2018 The Kubernetes authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2021 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
+Copyright 2014 The Kubernetes Authors.
+
+-------- Dependency
+sigs.k8s.io/structured-merge-diff/v4
+-------- Copyrights
+Copyright 2018 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
+
+-------- Dependencies Summary
+github.com/go-logr/logr
+github.com/go-logr/zapr
+github.com/golang/groupcache
+github.com/google/gofuzz
+github.com/googleapis/gnostic
+github.com/matttproud/golang_protobuf_extensions
+github.com/moby/spdystream
+github.com/modern-go/concurrent
+github.com/modern-go/reflect2
+github.com/prometheus/client_golang
+github.com/prometheus/client_model
+github.com/prometheus/common
+github.com/prometheus/procfs
+github.com/spf13/afero
+gomodules.xyz/jsonpatch/v2
+gopkg.in/ini.v1
+gopkg.in/yaml.v2
+k8s.io/api
+k8s.io/apiextensions-apiserver
+k8s.io/apimachinery
+k8s.io/client-go
+k8s.io/component-base
+k8s.io/klog/v2
+k8s.io/kube-openapi
+k8s.io/utils
+sigs.k8s.io/controller-runtime
+sigs.k8s.io/structured-merge-diff/v4
+
+-------- License used by Dependencies
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions. 
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the
+copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control with
+that entity. For the purposes of this definition, "control" means (i) the
+power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty percent
+(50%) or more of the outstanding shares, or (iii) beneficial ownership of such
+entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source, and
+configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative
+Works shall not include works that remain separable from, or merely link (or
+bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the purposes
+of this definition, "submitted" means any form of electronic, verbal, or
+written communication sent to the Licensor or its representatives, including
+but not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated
+in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form. 
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed. 
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions: 
+
+(a) You must give any other recipients of the Work or Derivative Works a copy
+of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that
+You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any
+part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy of
+the attribution notices contained within such NOTICE file, excluding those
+notices that do not pertain to any part of the Derivative Works, in at least
+one of the following places: within a NOTICE text file distributed as part of
+the Derivative Works; within the Source form or documentation, if provided
+along with the Derivative Works; or, within a display generated by the
+Derivative Works, if and wherever such third-party notices normally appear.
+The contents of the NOTICE file are for informational purposes only and do not
+modify the License. You may add Your own attribution notices within Derivative
+Works that You distribute, alongside or as an addendum to the NOTICE text from
+the Work, provided that such additional attribution notices cannot be
+construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a
+whole, provided Your use, reproduction, and distribution of the Work otherwise
+complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions. 
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file. 
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License. 
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages. 
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability. 
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don&apos;t include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification
+within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+
+distributed under the License is distributed on an "AS IS" BASIS,
+
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.
+
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
 github.com/magiconair/properties
 -------- Copyrights
-Copyright 2013-2014 Frank Schroeder. All rights reserved.
-Copyright 2018 Frank Schroeder. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
 Copyright (c) 2013-2020, Frank Schroeder
+Copyright 2018 Frank Schroeder. All rights reserved.
+Copyright 2013-2014 Frank Schroeder. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
 
 -------- Dependencies Summary
 github.com/magiconair/properties
@@ -211,67 +702,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------------- Dependencies Grouped by License ------------
 -------- Dependency
-github.com/verrazzano/pkg
--------- Copyrights
-Copyright (c) 2021, Oracle and/or its affiliates.
-Copyright (c) 2021 Oracle America, Inc. and its affiliates.
-Copyright (C) 2021, Oracle and/or its affiliates.
-
--------- Dependencies Summary
-github.com/verrazzano/pkg
-
--------- License used by Dependencies
-Copyright (c) 2021 Oracle America, Inc. and its affiliates.
-
-The Universal Permissive License (UPL), Version 1.0
-
-Subject to the condition set forth below, permission is hereby granted to any 
-person obtaining a copy of this software, associated documentation and/or data 
-(collectively the "Software"), free of charge and under any and all copyright 
-rights in the Software, and any and all patent rights owned or freely licensable 
-by each licensor hereunder covering either (i) the unmodified Software as 
-contributed to or provided by such licensor, or (ii) the Larger Works (as 
-defined below), to deal in both
-
-(a) the Software, and
-
-(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if 
-one is included with the Software (each a ¿Larger Work¿ to which the Software 
-is contributed by such licensors),
-
-without restriction, including without limitation the rights to copy, create 
-derivative works of, display, perform, and distribute the Software and make, 
-use, sell, offer for sale, import, export, have made, and have sold the 
-Software and the Larger Work(s), and to sublicense the foregoing rights on 
-either these or other terms.
-
-This license is subject to the following condition:
-
-The above copyright notice and either this complete permission notice or at a 
-minimum a reference to the UPL must be included in all copies or substantial 
-portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
-THE SOFTWARE.
-
-
------------------------ Dependencies Grouped by License ------------
--------- Dependency
 sigs.k8s.io/json
 -------- Copyrights
 Copyright 2021 The Kubernetes Authors.
 Copyright (c) 2009 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
 
 -------- Dependencies Summary
 sigs.k8s.io/json
@@ -549,586 +989,447 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------------- Dependencies Grouped by License ------------
 -------- Dependency
-github.com/go-logr/logr
--------- Copyrights
-Copyright 2021 The logr Authors.
-Copyright 2020 The logr Authors.
-Copyright 2019 The logr Authors.
-
--------- Dependency
-github.com/go-logr/zapr
--------- Copyrights
-Copyright 2019 The logr Authors.
-Copyright 2021 The logr Authors.
-Copyright 2018 Solly Ross
-Copyright 2020 The Kubernetes Authors.
-
--------- Dependency
-github.com/golang/groupcache
--------- Copyrights
-Copyright 2013 Google Inc.
-Copyright 2012 Google Inc.
-
--------- Dependency
-github.com/google/gofuzz
--------- Copyrights
-Copyright 2014 Google Inc. All rights reserved.
-
--------- Dependency
-github.com/googleapis/gnostic
--------- Copyrights
-Copyright 2017-2020, Google LLC.
-Copyright 2017 Google LLC. All Rights Reserved.
-Copyright 2019 Google LLC. All Rights Reserved.
-Copyright 2020 Google LLC. All Rights Reserved.
-Copyright 2018 Google LLC. All Rights Reserved.
-Copyright 2020 Google LLC. All Rights Reserved.\n" +
-
--------- Dependency
-github.com/matttproud/golang_protobuf_extensions
--------- Copyrights
-Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
-Copyright 2013 Matt T. Proud
-Copyright 2016 Matt T. Proud
--------- Notices
-Copyright 2012 Matt T. Proud (matt.proud@gmail.com)
-
-
--------- Dependency
-github.com/moby/spdystream
--------- Copyrights
-Copyright 2013-2021 Docker, inc. Released under the [Apache 2.0 license](LICENSE).
-Copyright 2014-2021 Docker Inc.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
--------- Notices
-SpdyStream
-Copyright 2014-2021 Docker Inc.
-
-This product includes software developed at
-Docker Inc. (https://www.docker.com/).
-
-
--------- Dependency
-github.com/modern-go/concurrent
+github.com/hashicorp/hcl
 -------- Copyrights
   (no copyright notices found)
-
--------- Dependency
-github.com/modern-go/reflect2
--------- Copyrights
-  (no copyright notices found)
-
--------- Dependency
-github.com/prometheus/client_golang
--------- Copyrights
-Copyright 2012-2015 The Prometheus Authors
-Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
-Copyright 2010 The Go Authors
-Copyright 2013 Matt T. Proud
-Copyright 2018 The Prometheus Authors
-Copyright 2015 The Prometheus Authors
-Copyright 2019 The Prometheus Authors
-Copyright 2021 The Prometheus Authors
-Copyright 2014 The Prometheus Authors
-Copyright 2016 The Prometheus Authors
-Copyright 2017 The Prometheus Authors
-Copyright 2020 The Prometheus Authors
-Copyright 2022 The Prometheus Authors
-Copyright (c) 2013, The Prometheus Authors
--------- Notices
-Prometheus instrumentation library for Go applications
-Copyright 2012-2015 The Prometheus Authors
-
-This product includes software developed at
-SoundCloud Ltd. (http://soundcloud.com/).
-
-
-The following components are included in this product:
-
-perks - a fork of https://github.com/bmizerany/perks
-https://github.com/beorn7/perks
-Copyright 2013-2015 Blake Mizerany, Björn Rabenstein
-See https://github.com/beorn7/perks/blob/master/README.md for license details.
-
-Go support for Protocol Buffers - Google's data interchange format
-http://github.com/golang/protobuf/
-Copyright 2010 The Go Authors
-See source code for license details.
-
-Support for streaming Protocol Buffer messages for the Go language (golang).
-https://github.com/matttproud/golang_protobuf_extensions
-Copyright 2013 Matt T. Proud
-Licensed under the Apache License, Version 2.0
-
-
--------- Dependency
-github.com/prometheus/client_model
--------- Copyrights
-Copyright 2012-2015 The Prometheus Authors
-Copyright 2013 Prometheus Team
--------- Notices
-Data model artifacts for Prometheus.
-Copyright 2012-2015 The Prometheus Authors
-
-This product includes software developed at
-SoundCloud Ltd. (http://soundcloud.com/).
-
-
--------- Dependency
-github.com/prometheus/common
--------- Copyrights
-Copyright 2018 The Prometheus Authors
-Copyright 2021 The Prometheus Authors
-Copyright 2016 The Prometheus Authors
-Copyright 2015 The Prometheus Authors
-Copyright 2014 The Prometheus Authors
-Copyright (c) 2011, Open Knowledge Foundation Ltd.
-Copyright 2020 The Prometheus Authors
-Copyright 2013 The Prometheus Authors
-Copyright 2019 The Prometheus Authors
-Copyright 2017 The Prometheus Authors
--------- Notices
-Common libraries shared by Prometheus Go components.
-Copyright 2015 The Prometheus Authors
-
-This product includes software developed at
-SoundCloud Ltd. (http://soundcloud.com/).
-
-
--------- Dependency
-github.com/prometheus/procfs
--------- Copyrights
-Copyright 2018 The Prometheus Authors
-Copyright 2019 The Prometheus Authors
-Copyright 2014-2015 The Prometheus Authors
-Copyright 2017 The Prometheus Authors
-Copyright 2020 The Prometheus Authors
-Copyright 2021 The Prometheus Authors
-Copyright 2014 Prometheus Team
-Copyright 2017 Prometheus Team
--------- Notices
-procfs provides functions to retrieve system, kernel and process
-metrics from the pseudo-filesystem proc.
-
-Copyright 2014-2015 The Prometheus Authors
-
-This product includes software developed at
-SoundCloud Ltd. (http://soundcloud.com/).
-
-
--------- Dependency
-github.com/spf13/afero
--------- Copyrights
-Copyright © 2016 Steve Francia <spf@spf13.com>.
-Copyright © 2014 Steve Francia <spf@spf13.com>.
-Copyright 2013 tsuru authors. All rights reserved.
-Copyright ©2018 Steve Francia <spf@spf13.com>
-Copyright © 2018 Steve Francia <spf@spf13.com>.
-Copyright ©2015 Steve Francia <spf@spf13.com>
-Copyright ©2015 The Go Authors
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright © 2015 Steve Francia <spf@spf13.com>.
-Copyright © 2015 Jerry Jacobs <jerry.jacobs@xor-gate.org>.
-Portions Copyright ©2015 The Hugo Authors
-Portions Copyright 2016-present Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
-
--------- Dependency
-gomodules.xyz/jsonpatch/v2
--------- Copyrights
-  (no copyright notices found)
-
--------- Dependency
-gopkg.in/ini.v1
--------- Copyrights
-Copyright 2017 Unknwon
-Copyright 2019 Unknwon
-Copyright 2016 Unknwon
-Copyright 2014 Unknwon
-Copyright 2015 Unknwon
-
--------- Dependency
-gopkg.in/yaml.v2
--------- Copyrights
-Copyright (c) 2006 Kirill Simonov
-Copyright 2011-2016 Canonical Ltd.
--------- Notices
-Copyright 2011-2016 Canonical Ltd.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-
--------- Dependency
-k8s.io/api
--------- Copyrights
-Copyright 2019 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-
--------- Dependency
-k8s.io/apiextensions-apiserver
--------- Copyrights
-Copyright 2019 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2020 Google LLC
-
--------- Dependency
-k8s.io/apimachinery
--------- Copyrights
-Copyright 2021 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2014 The Kubernetes Authors.
-Copyright 2019 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
-Copyright The Kubernetes Authors.
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
-
--------- Dependency
-k8s.io/client-go
--------- Copyrights
-Copyright The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2019 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright 2014 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-Copyright (c) 2009 The Go Authors. All rights reserved.
-
--------- Dependency
-k8s.io/component-base
--------- Copyrights
-Copyright 2017 The Kubernetes Authors.
-Copyright 2014 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
-Copyright 2019 The Kubernetes Authors.
-Copyright The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-
--------- Dependency
-k8s.io/klog/v2
--------- Copyrights
-Copyright 2013 Google Inc. All Rights Reserved.
-Copyright 2020 The Kubernetes Authors.
-
--------- Dependency
-k8s.io/kube-openapi
--------- Copyrights
-Copyright The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-Copyright 2019 The Kubernetes Authors.
-Copyright 2015 go-swagger maintainers
-Copyright 2017 go-swagger maintainers
-Copyright (C) MongoDB, Inc. 2017-present.
-
--------- Dependency
-k8s.io/utils
--------- Copyrights
-Copyright 2018 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2014 The Kubernetes Authors.
-Copyright 2015 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
-Copyright 2019 The Kubernetes Authors.
-Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
-Copyright 2013 Google Inc.
-Copyright 2009 The Go Authors. All rights reserved.
-
--------- Dependency
-sigs.k8s.io/controller-runtime
--------- Copyrights
-Copyright 2020 The Kubernetes Authors.
-Copyright 2018 The Kubernetes Authors.
-Copyright 2018 The Kubernetes authors.
-Copyright 2019 The Kubernetes Authors.
-Copyright 2021 The Kubernetes Authors.
-Copyright 2022 The Kubernetes Authors.
-Copyright 2017 The Kubernetes Authors.
-Copyright 2016 The Kubernetes Authors.
-Copyright 2014 The Kubernetes Authors.
-
--------- Dependency
-sigs.k8s.io/structured-merge-diff/v4
--------- Copyrights
-Copyright 2018 The Kubernetes Authors.
-Copyright 2019 The Kubernetes Authors.
-Copyright 2020 The Kubernetes Authors.
 
 -------- Dependencies Summary
-github.com/go-logr/logr
-github.com/go-logr/zapr
-github.com/golang/groupcache
-github.com/google/gofuzz
-github.com/googleapis/gnostic
-github.com/matttproud/golang_protobuf_extensions
-github.com/moby/spdystream
-github.com/modern-go/concurrent
-github.com/modern-go/reflect2
-github.com/prometheus/client_golang
-github.com/prometheus/client_model
-github.com/prometheus/common
-github.com/prometheus/procfs
-github.com/spf13/afero
-gomodules.xyz/jsonpatch/v2
-gopkg.in/ini.v1
-gopkg.in/yaml.v2
-k8s.io/api
-k8s.io/apiextensions-apiserver
-k8s.io/apimachinery
-k8s.io/client-go
-k8s.io/component-base
-k8s.io/klog/v2
-k8s.io/kube-openapi
-k8s.io/utils
-sigs.k8s.io/controller-runtime
-sigs.k8s.io/structured-merge-diff/v4
+github.com/hashicorp/hcl
 
 -------- License used by Dependencies
-SPDX:Apache-2.0
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Mozilla Public License Version 2.0
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+1. Definitions 
 
-   1. Definitions.
+1.1. "Contributor" means each individual or legal entity that creates,
+contributes to the creation of, or owns Covered Software.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+1.2. "Contributor Version" means the combination of the Contributions of
+others (if any) used by a Contributor and that particular Contributor&apos;s
+Contribution.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+1.3. "Contribution" means Covered Software of a particular Contributor.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+1.4. "Covered Software" means Source Code Form to which the initial
+Contributor has attached the notice in Exhibit A, the Executable Form of such
+Source Code Form, and Modifications of such Source Code Form, in each case
+including portions thereof.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+1.5. "Incompatible With Secondary Licenses" means
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+(a) that the initial Contributor has attached the notice described in Exhibit
+B to the Covered Software; or
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+(b) that the Covered Software was made available under the terms of version
+1.1 or earlier of the License, but not also under the terms of a Secondary
+License.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+1.6. "Executable Form" means any form of the work other than Source Code Form.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+1.7. "Larger Work" means a work that combines Covered Software with other
+material, in a separate file or files, that is not Covered Software.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+1.8. "License" means this document.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+1.9. "Licensable" means having the right to grant, to the maximum extent
+possible, whether at the time of the initial grant or subsequently, any and
+all of the rights conveyed by this License.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+1.10. "Modifications" means any of the following:
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+(a) any file in Source Code Form that results from an addition to, deletion
+from, or modification of the contents of Covered Software; or
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+(b) any new file in Source Code Form that contains any Covered Software.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+1.11. "Patent Claims" of a Contributor means any patent claim(s), including
+without limitation, method, process, and apparatus claims, in any patent
+Licensable by such Contributor that would be infringed, but for the grant of
+the License, by the making, using, selling, offering for sale, having made,
+import, or transfer of either its Contributions or its Contributor Version.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+1.12. "Secondary License" means either the GNU General Public License, Version
+2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero
+General Public License, Version 3.0, or any later versions of those licenses.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+1.13. "Source Code Form" means the form of the work preferred for making
+modifications.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+1.14. "You" (or "Your") means an individual or a legal entity exercising
+rights under this License. For legal entities, "You" includes any entity that
+controls, is controlled by, or is under common control with You. For purposes
+of this definition, "control" means (a) the power, direct or indirect, to
+cause the direction or management of such entity, whether by contract or
+otherwise, or (b) ownership of more than fifty percent (50%) of the
+outstanding shares or beneficial ownership of such entity.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+2. License Grants and Conditions 
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+2.1. Grants
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive
+license:
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+(a) under intellectual property rights (other than patent or trademark)
+Licensable by such Contributor to use, reproduce, make available, modify,
+display, perform, distribute, and otherwise exploit its Contributions, either
+on an unmodified basis, with Modifications, or as part of a Larger Work; and
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+(b) under Patent Claims of such Contributor to make, use, sell, offer for
+sale, have made, import, and otherwise transfer either its Contributions or
+its Contributor Version.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution become
+effective for each Contribution on the date the Contributor first distributes
+such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under this
+License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software; or
+
+(b) for infringements caused by: (i) Your and any other third party&apos;s
+modifications of Covered Software, or (ii) the combination of its
+Contributions with other software (except as part of its Contributor Version);
+or
+
+(c) under Patent Claims infringed by Covered Software in the absence of its
+Contributions.
+
+This License does not grant any rights in the trademarks, service marks, or
+logos of any Contributor (except as may be necessary to comply with the notice
+requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this License
+(see Section 10.2) or under the terms of a Secondary License (if permitted
+under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its Contributions
+are its original creation(s) or it has sufficient rights to grant the rights
+to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under applicable
+copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+Section 2.1.
+
+3. Responsibilities 
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under the
+terms of this License. You must inform recipients that the Source Code Form of
+the Covered Software is governed by the terms of this License, and how they
+can obtain a copy of this License. You may not attempt to alter or restrict
+the recipients&apos; rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code Form, as
+described in Section 3.1, and You must inform recipients of the Executable
+Form how they can obtain a copy of such Source Code Form by reasonable means
+in a timely manner, at a charge no more than the cost of distribution to the
+recipient; and
+
+(b) You may distribute such Executable Form under the terms of this License,
+or sublicense it under different terms, provided that the license for the
+Executable Form does not attempt to limit or alter the recipients&apos; rights
+in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for the
+Covered Software. If the Larger Work is a combination of Covered Software with
+a work governed by one or more Secondary Licenses, and the Covered Software is
+not Incompatible With Secondary Licenses, this License permits You to
+additionally distribute such Covered Software under the terms of such
+Secondary License(s), so that the recipient of the Larger Work may, at their
+option, further distribute the Covered Software under the terms of either this
+License or such Secondary License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices (including
+copyright notices, patent notices, disclaimers of warranty, or limitations of
+liability) contained within the Source Code Form of the Covered Software,
+except that You may alter any license notices to the extent required to remedy
+known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support, indemnity
+or liability obligations to one or more recipients of Covered Software.
+However, You may do so only on Your own behalf, and not on behalf of any
+Contributor. You must make it absolutely clear that any such warranty,
+support, indemnity, or liability obligation is offered by You alone, and You
+hereby agree to indemnify every Contributor for any liability incurred by such
+Contributor as a result of warranty, support, indemnity or liability terms You
+offer. You may include additional disclaimers of warranty and limitations of
+liability specific to any jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation   
+If it is impossible for You to comply with any of the terms of this License
+with respect to some or all of the Covered Software due to statute, judicial
+order, or regulation then You must: (a) comply with the terms of this License
+to the maximum extent possible; and (b) describe the limitations and the code
+they affect. Such description must be placed in a text file included with all
+distributions of the Covered Software under this License. Except to the extent
+prohibited by statute or regulation, such description must be sufficiently
+detailed for a recipient of ordinary skill to be able to understand it.
+
+5. Termination 
+
+5.1. The rights granted under this License will terminate automatically if You
+fail to comply with any of its terms. However, if You become compliant, then
+the rights granted under this License from a particular Contributor are
+reinstated (a) provisionally, unless and until such Contributor explicitly and
+finally terminates Your grants, and (b) on an ongoing basis, if such
+Contributor fails to notify You of the non-compliance by some reasonable means
+prior to 60 days after You have come back into compliance. Moreover, Your
+grants from a particular Contributor are reinstated on an ongoing basis if
+such Contributor notifies You of the non-compliance by some reasonable means,
+this is the first time You have received notice of non-compliance with this
+License from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions, counter-claims,
+and cross-claims) alleging that a Contributor Version directly or indirectly
+infringes any patent, then the rights granted to You by any and all
+Contributors for the Covered Software under Section 2.1 of this License shall
+terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+license agreements (excluding distributors and resellers) which have been
+validly granted by You or Your distributors under this License prior to
+termination shall survive termination.
+
+6. Disclaimer of Warranty   
+Covered Software is provided under this License on an "as is" basis, without
+warranty of any kind, either expressed, implied, or statutory, including,
+without limitation, warranties that the Covered Software is free of defects,
+merchantable, fit for a particular purpose or non-infringing. The entire risk
+as to the quality and performance of the Covered Software is with You. Should
+any Covered Software prove defective in any respect, You (not any Contributor)
+assume the cost of any necessary servicing, repair, or correction. This
+disclaimer of warranty constitutes an essential part of this License. No use
+of any Covered Software is authorized under this License except under this
+disclaimer.
+
+7. Limitation of Liability   
+Under no circumstances and under no legal theory, whether tort (including
+negligence), contract, or otherwise, shall any Contributor, or anyone who
+distributes Covered Software as permitted above, be liable to You for any
+direct, indirect, special, incidental, or consequential damages of any
+character including, without limitation, damages for lost profits, loss of
+goodwill, work stoppage, computer failure or malfunction, or any and all other
+commercial damages or losses, even if such party shall have been informed of
+the possibility of such damages. This limitation of liability shall not apply
+to liability for death or personal injury resulting from such party&apos;s
+negligence to the extent applicable law prohibits such limitation. Some
+jurisdictions do not allow the exclusion or limitation of incidental or
+consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation   
+Any litigation relating to this License may be brought only in the courts of a
+jurisdiction where the defendant maintains its principal place of business and
+such litigation shall be governed by laws of that jurisdiction, without
+reference to its conflict-of-law provisions. Nothing in this Section shall
+prevent a party&apos;s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous   
+This License represents the complete agreement concerning the subject matter
+hereof. If any provision of this License is held to be unenforceable, such
+provision shall be reformed only to the extent necessary to make it
+enforceable. Any law or regulation which provides that the language of a
+contract shall be construed against the drafter shall not be used to construe
+this License against a Contributor.
+
+10. Versions of the License 
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section 10.3,
+no one other than the license steward has the right to modify or publish new
+versions of this License. Each version will be given a distinguishing version
+number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version of the
+License under which You originally received the Covered Software, or under the
+terms of any subsequent version published by the license steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to create a
+new license for such software, you may create and use a modified version of
+this License if you rename the license and remove any references to the name
+of the license steward (except to note that such modified license differs from
+this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the notice
+described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v. 2.0. If a copy of the MPL was not distributed with this file, You can
+obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+This Source Code Form is "Incompatible With Secondary Licenses", as defined by
+the Mozilla Public License, v. 2.0.
+
+
 
 ----------------------- Dependencies Grouped by License ------------
 -------- Dependency
-github.com/pkg/errors
+github.com/beorn7/perks
 -------- Copyrights
-Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+Copyright (C) 2013 Blake Mizerany
+
+-------- Dependency
+github.com/cespare/xxhash/v2
+-------- Copyrights
+Copyright (c) 2016 Caleb Spare
+
+-------- Dependency
+github.com/go-resty/resty/v2
+-------- Copyrights
+Copyright (c) 2015-2021 Jeevanandam M., https://myjeeva.com <jeeva@myjeeva.com>
+Copyright (c) 2015-2021 Jeevanandam M. (jeeva@myjeeva.com), All rights reserved.
+Copyright (c) 2015-2021 Jeevanandam M (jeeva@myjeeva.com)
+Copyright (c) 2015-2021 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
+
+-------- Dependency
+github.com/json-iterator/go
+-------- Copyrights
+Copyright (c) 2016 json-iterator
+
+-------- Dependency
+github.com/mitchellh/mapstructure
+-------- Copyrights
+Copyright (c) 2013 Mitchell Hashimoto
+
+-------- Dependency
+github.com/spf13/cast
+-------- Copyrights
+Copyright © 2014 Steve Francia <spf@spf13.com>.
+Copyright (c) 2014 Steve Francia
+Copyright 2011 The Go Authors. All rights reserved.
+
+-------- Dependency
+github.com/spf13/jwalterweatherman
+-------- Copyrights
+Copyright © 2016 Steve Francia <spf@spf13.com>.
+Copyright (c) 2014 Steve Francia
+
+-------- Dependency
+github.com/spf13/viper
+-------- Copyrights
+Copyright (c) 2014 Steve Francia
+Copyright (c) 2017 Canonical Ltd.
+Copyright © 2016 Steve Francia <spf@spf13.com>.
+Copyright © 2015 Steve Francia <spf@spf13.com>.
+Copyright © 2014 Steve Francia <spf@spf13.com>.
+
+-------- Dependency
+github.com/subosito/gotenv
+-------- Copyrights
+Copyright (c) 2013 Alif Rachmawadi
+
+-------- Dependency
+go.uber.org/atomic
+-------- Copyrights
+Copyright (c) 2016 Uber Technologies, Inc.
+Copyright (c) 2020 Uber Technologies, Inc.
+Copyright (c) 2016-2020 Uber Technologies, Inc.
+
+-------- Dependency
+go.uber.org/multierr
+-------- Copyrights
+Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2019 Uber Technologies, Inc.
+
+-------- Dependency
+go.uber.org/zap
+-------- Copyrights
+Copyright (c) 2016-2017 Uber Technologies, Inc.
+Copyright (c) 2016 Uber Technologies, Inc.
+Copyright (c) 2017 Uber Technologies, Inc.
+Copyright (c) 2020 Uber Technologies, Inc.
+Copyright (c) 2021 Uber Technologies, Inc.
+Copyright (c) 2016, 2017 Uber Technologies, Inc.
+Copyright (c) 2018 Uber Technologies, Inc.
 
 -------- Dependencies Summary
-github.com/pkg/errors
+github.com/beorn7/perks
+github.com/cespare/xxhash/v2
+github.com/go-resty/resty/v2
+github.com/json-iterator/go
+github.com/mitchellh/mapstructure
+github.com/spf13/cast
+github.com/spf13/jwalterweatherman
+github.com/spf13/viper
+github.com/subosito/gotenv
+go.uber.org/atomic
+go.uber.org/multierr
+go.uber.org/zap
 
 -------- License used by Dependencies
-SPDX:BSD-2-Clause
-Redistribution and use in source and binary forms, with or 
-without modification, are permitted provided that the following conditions are 
-met:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
 
 ----------------------- Dependencies Grouped by License ------------
 -------- Dependency
@@ -1138,10 +1439,10 @@ Copyright 2012 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
 Copyright (c) 2012-2019 fsnotify Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
-Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2013 The Go Authors. All rights reserved.
 
 -------- Dependency
 github.com/gogo/protobuf
@@ -1154,9 +1455,9 @@ Copyright 2010 The Go Authors.
 Copyright 2015 The Go Authors.  All rights reserved.
 Copyright 2011 The Go Authors.  All rights reserved.
 Copyright (c) 2018, The GoGo Authors. All rights reserved.
-Copyright (c) 2016, The GoGo Authors. All rights reserved.
-Copyright 2017 The Go Authors.  All rights reserved.
 Copyright 2018 The Go Authors.  All rights reserved.
+Copyright 2017 The Go Authors.  All rights reserved.
+Copyright (c) 2016, The GoGo Authors. All rights reserved.
 Copyright 2014 The Go Authors.  All rights reserved.
 Copyright 2012 The Go Authors.  All rights reserved.
 Copyright 2013 The Go Authors.  All rights reserved.
@@ -1168,15 +1469,15 @@ Copyright (c) 2015, The GoGo Authors.  rights reserved.
 github.com/golang/protobuf
 -------- Copyrights
 Copyright 2010 The Go Authors.  All rights reserved.
-Copyright 2019 The Go Authors. All rights reserved.
-Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2020 The Go Authors. All rights reserved.
+Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors.  All rights reserved.
 
 -------- Dependency
@@ -1185,15 +1486,15 @@ github.com/google/go-cmp
 Copyright (c) 2017 The Go Authors. All rights reserved.
 Copyright 2021, The Go Authors. All rights reserved.
 Copyright 2017, The Go Authors. All rights reserved.
-Copyright 2018, The Go Authors. All rights reserved.
-Copyright 2019, The Go Authors. All rights reserved.
 Copyright 2020, The Go Authors. All rights reserved.
+Copyright 2019, The Go Authors. All rights reserved.
+Copyright 2018, The Go Authors. All rights reserved.
 
 -------- Dependency
 github.com/google/uuid
 -------- Copyrights
-Copyright (c) 2009,2014 Google Inc. All rights reserved.
 Copyright 2016 Google Inc.  All rights reserved.
+Copyright (c) 2009,2014 Google Inc. All rights reserved.
 Copyright 2017 Google Inc.  All rights reserved.
 Copyright 2018 Google Inc.  All rights reserved.
 
@@ -1211,26 +1512,26 @@ github.com/spf13/pflag
 -------- Copyrights
 Copyright (c) 2012 Alex Ogier. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors.  All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
 
 -------- Dependency
 golang.org/x/crypto
 -------- Copyrights
-Copyright 2017 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
 Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2018 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
+Copyright (c) 2019 The Go Authors. All rights reserved.
 Copyright (c) 2020 The Go Authors. All rights reserved.
 Copyright (c) 2017 The Go Authors. All rights reserved.
 Copyright (c) 2021 The Go Authors. All rights reserved.
-Copyright (c) 2019 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2009 The Go Authors. All rights reserved.
@@ -1267,12 +1568,12 @@ Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2010 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
+Copyright 2010 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
-Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2013 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2011 The Go Authors. All rights reserved.
 Copyright (C) 2009 Apple Inc. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
@@ -1308,12 +1609,12 @@ golang.org/x/oauth2
 -------- Copyrights
 Copyright (c) 2009 The Go Authors. All rights reserved.
 Copyright 2017 The oauth2 Authors. All rights reserved.
-Copyright 2015 The oauth2 Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
+Copyright 2015 The oauth2 Authors. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
-Copyright 2015 The Go Authors. All rights reserved.
 Copyright 2019 The Go Authors. All rights reserved.
+Copyright 2015 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2017 The Go Authors. All rights reserved.
@@ -1327,12 +1628,12 @@ Copyright 2019 The Go Authors. All rights reserved.
 Copyright 2018 The Go Authors. All rights reserved.
 Copyright 2020 The Go Authors. All rights reserved.
 Copyright 2011 The Go Authors. All rights reserved.
-Copyright 2012 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
-Copyright 2009 The Go Authors. All rights reserved.
+Copyright 2012 The Go Authors. All rights reserved.
 Copyright 2013 The Go Authors. All rights reserved.
-Copyright 2017 The Go Authors. All rights reserved.
+Copyright 2009 The Go Authors. All rights reserved.
 Copyright 2016 The Go Authors. All rights reserved.
+Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2010 The Go Authors. All rights reserved.
 Copyright 2021 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
@@ -1400,8 +1701,8 @@ shall terminate as of the date such litigation is filed.
 golang.org/x/text
 -------- Copyrights
 Copyright (c) 2009 The Go Authors. All rights reserved.
-Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2014 The Go Authors. All rights reserved.
+Copyright 2016 The Go Authors. All rights reserved.
 Copyright 2015 The Go Authors. All rights reserved.
 Copyright 2017 The Go Authors. All rights reserved.
 Copyright 2012 The Go Authors. All rights reserved.
@@ -1525,8 +1826,7 @@ google.golang.org/protobuf
 gopkg.in/inf.v0
 
 -------- License used by Dependencies
-SPDX:BSD-3-Clause--modified-by-Google
-Redistribution and use in source and binary forms, with 
+Redistribution and use in source and binary forms, with
 or without modification, are permitted provided that the following conditions
 are met:
 
@@ -1552,504 +1852,39 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
------------------------ Dependencies Grouped by License ------------
--------- Dependency
-github.com/beorn7/perks
--------- Copyrights
-Copyright (C) 2013 Blake Mizerany
-
--------- Dependency
-github.com/cespare/xxhash/v2
--------- Copyrights
-Copyright (c) 2016 Caleb Spare
-
--------- Dependency
-github.com/go-resty/resty/v2
--------- Copyrights
-Copyright (c) 2015-2021 Jeevanandam M., https://myjeeva.com <jeeva@myjeeva.com>
-Copyright (c) 2015-2021 Jeevanandam M (jeeva@myjeeva.com), All rights reserved.
-Copyright (c) 2015-2021 Jeevanandam M (jeeva@myjeeva.com)
-Copyright (c) 2015-2021 Jeevanandam M. (jeeva@myjeeva.com), All rights reserved.
-
--------- Dependency
-github.com/json-iterator/go
--------- Copyrights
-Copyright (c) 2016 json-iterator
-
--------- Dependency
-github.com/mitchellh/mapstructure
--------- Copyrights
-Copyright (c) 2013 Mitchell Hashimoto
-
--------- Dependency
-github.com/spf13/cast
--------- Copyrights
-Copyright (c) 2014 Steve Francia
-Copyright © 2014 Steve Francia <spf@spf13.com>.
-Copyright 2011 The Go Authors. All rights reserved.
-
--------- Dependency
-github.com/spf13/jwalterweatherman
--------- Copyrights
-Copyright (c) 2014 Steve Francia
-Copyright © 2016 Steve Francia <spf@spf13.com>.
-
--------- Dependency
-github.com/spf13/viper
--------- Copyrights
-Copyright (c) 2014 Steve Francia
-Copyright © 2015 Steve Francia <spf@spf13.com>.
-Copyright (c) 2017 Canonical Ltd.
-Copyright © 2014 Steve Francia <spf@spf13.com>.
-Copyright © 2016 Steve Francia <spf@spf13.com>.
-
--------- Dependency
-github.com/subosito/gotenv
--------- Copyrights
-Copyright (c) 2013 Alif Rachmawadi
-
--------- Dependency
-go.uber.org/atomic
--------- Copyrights
-Copyright (c) 2016 Uber Technologies, Inc.
-Copyright (c) 2020 Uber Technologies, Inc.
-Copyright (c) 2016-2020 Uber Technologies, Inc.
-
--------- Dependency
-go.uber.org/multierr
--------- Copyrights
-Copyright (c) 2017 Uber Technologies, Inc.
-Copyright (c) 2019 Uber Technologies, Inc.
-
--------- Dependency
-go.uber.org/zap
--------- Copyrights
-Copyright (c) 2016-2017 Uber Technologies, Inc.
-Copyright (c) 2016 Uber Technologies, Inc.
-Copyright (c) 2020 Uber Technologies, Inc.
-Copyright (c) "*" Uber Technologies, Inc.")
-Copyright (c) 2017 Uber Technologies, Inc.
-Copyright (c) 2021 Uber Technologies, Inc.
-Copyright (c) 2016, 2017 Uber Technologies, Inc.
-Copyright (c) 2018 Uber Technologies, Inc.
-
--------- Dependencies Summary
-github.com/beorn7/perks
-github.com/cespare/xxhash/v2
-github.com/go-resty/resty/v2
-github.com/json-iterator/go
-github.com/mitchellh/mapstructure
-github.com/spf13/cast
-github.com/spf13/jwalterweatherman
-github.com/spf13/viper
-github.com/subosito/gotenv
-go.uber.org/atomic
-go.uber.org/multierr
-go.uber.org/zap
-
--------- License used by Dependencies
-SPDX:MIT
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation files
-(the "Software"), to deal in the Software without restriction, including without
-limitation the rights to use, copy, modify, merge, publish, distribute,
-sublicense, and/or sell copies of the Software, and to permit persons to whom
-the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------------- Dependencies Grouped by License ------------
 -------- Dependency
-github.com/hashicorp/hcl
+github.com/pkg/errors
 -------- Copyrights
-  (no copyright notices found)
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
 
 -------- Dependencies Summary
-github.com/hashicorp/hcl
+github.com/pkg/errors
 
 -------- License used by Dependencies
-SPDX:MPL-2.0
-Mozilla Public License Version 2.0
-==================================
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-1. Definitions
---------------
 
-1.1. "Contributor"
-    means each individual or legal entity that creates, contributes to
-    the creation of, or owns Covered Software.
-
-1.2. "Contributor Version"
-    means the combination of the Contributions of others (if any) used
-    by a Contributor and that particular Contributor's Contribution.
-
-1.3. "Contribution"
-    means Covered Software of a particular Contributor.
-
-1.4. "Covered Software"
-    means Source Code Form to which the initial Contributor has attached
-    the notice in Exhibit A, the Executable Form of such Source Code
-    Form, and Modifications of such Source Code Form, in each case
-    including portions thereof.
-
-1.5. "Incompatible With Secondary Licenses"
-    means
-
-    (a) that the initial Contributor has attached the notice described
-        in Exhibit B to the Covered Software; or
-
-    (b) that the Covered Software was made available under the terms of
-        version 1.1 or earlier of the License, but not also under the
-        terms of a Secondary License.
-
-1.6. "Executable Form"
-    means any form of the work other than Source Code Form.
-
-1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
-    a separate file or files, that is not Covered Software.
-
-1.8. "License"
-    means this document.
-
-1.9. "Licensable"
-    means having the right to grant, to the maximum extent possible,
-    whether at the time of the initial grant or subsequently, any and
-    all of the rights conveyed by this License.
-
-1.10. "Modifications"
-    means any of the following:
-
-    (a) any file in Source Code Form that results from an addition to,
-        deletion from, or modification of the contents of Covered
-        Software; or
-
-    (b) any new file in Source Code Form that contains any Covered
-        Software.
-
-1.11. "Patent Claims" of a Contributor
-    means any patent claim(s), including without limitation, method,
-    process, and apparatus claims, in any patent Licensable by such
-    Contributor that would be infringed, but for the grant of the
-    License, by the making, using, selling, offering for sale, having
-    made, import, or transfer of either its Contributions or its
-    Contributor Version.
-
-1.12. "Secondary License"
-    means either the GNU General Public License, Version 2.0, the GNU
-    Lesser General Public License, Version 2.1, the GNU Affero General
-    Public License, Version 3.0, or any later versions of those
-    licenses.
-
-1.13. "Source Code Form"
-    means the form of the work preferred for making modifications.
-
-1.14. "You" (or "Your")
-    means an individual or a legal entity exercising rights under this
-    License. For legal entities, "You" includes any entity that
-    controls, is controlled by, or is under common control with You. For
-    purposes of this definition, "control" means (a) the power, direct
-    or indirect, to cause the direction or management of such entity,
-    whether by contract or otherwise, or (b) ownership of more than
-    fifty percent (50%) of the outstanding shares or beneficial
-    ownership of such entity.
-
-2. License Grants and Conditions
---------------------------------
-
-2.1. Grants
-
-Each Contributor hereby grants You a world-wide, royalty-free,
-non-exclusive license:
-
-(a) under intellectual property rights (other than patent or trademark)
-    Licensable by such Contributor to use, reproduce, make available,
-    modify, display, perform, distribute, and otherwise exploit its
-    Contributions, either on an unmodified basis, with Modifications, or
-    as part of a Larger Work; and
-
-(b) under Patent Claims of such Contributor to make, use, sell, offer
-    for sale, have made, import, and otherwise transfer either its
-    Contributions or its Contributor Version.
-
-2.2. Effective Date
-
-The licenses granted in Section 2.1 with respect to any Contribution
-become effective for each Contribution on the date the Contributor first
-distributes such Contribution.
-
-2.3. Limitations on Grant Scope
-
-The licenses granted in this Section 2 are the only rights granted under
-this License. No additional rights or licenses will be implied from the
-distribution or licensing of Covered Software under this License.
-Notwithstanding Section 2.1(b) above, no patent license is granted by a
-Contributor:
-
-(a) for any code that a Contributor has removed from Covered Software;
-    or
-
-(b) for infringements caused by: (i) Your and any other third party's
-    modifications of Covered Software, or (ii) the combination of its
-    Contributions with other software (except as part of its Contributor
-    Version); or
-
-(c) under Patent Claims infringed by Covered Software in the absence of
-    its Contributions.
-
-This License does not grant any rights in the trademarks, service marks,
-or logos of any Contributor (except as may be necessary to comply with
-the notice requirements in Section 3.4).
-
-2.4. Subsequent Licenses
-
-No Contributor makes additional grants as a result of Your choice to
-distribute the Covered Software under a subsequent version of this
-License (see Section 10.2) or under the terms of a Secondary License (if
-permitted under the terms of Section 3.3).
-
-2.5. Representation
-
-Each Contributor represents that the Contributor believes its
-Contributions are its original creation(s) or it has sufficient rights
-to grant the rights to its Contributions conveyed by this License.
-
-2.6. Fair Use
-
-This License is not intended to limit any rights You have under
-applicable copyright doctrines of fair use, fair dealing, or other
-equivalents.
-
-2.7. Conditions
-
-Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
-in Section 2.1.
-
-3. Responsibilities
--------------------
-
-3.1. Distribution of Source Form
-
-All distribution of Covered Software in Source Code Form, including any
-Modifications that You create or to which You contribute, must be under
-the terms of this License. You must inform recipients that the Source
-Code Form of the Covered Software is governed by the terms of this
-License, and how they can obtain a copy of this License. You may not
-attempt to alter or restrict the recipients' rights in the Source Code
-Form.
-
-3.2. Distribution of Executable Form
-
-If You distribute Covered Software in Executable Form then:
-
-(a) such Covered Software must also be made available in Source Code
-    Form, as described in Section 3.1, and You must inform recipients of
-    the Executable Form how they can obtain a copy of such Source Code
-    Form by reasonable means in a timely manner, at a charge no more
-    than the cost of distribution to the recipient; and
-
-(b) You may distribute such Executable Form under the terms of this
-    License, or sublicense it under different terms, provided that the
-    license for the Executable Form does not attempt to limit or alter
-    the recipients' rights in the Source Code Form under this License.
-
-3.3. Distribution of a Larger Work
-
-You may create and distribute a Larger Work under terms of Your choice,
-provided that You also comply with the requirements of this License for
-the Covered Software. If the Larger Work is a combination of Covered
-Software with a work governed by one or more Secondary Licenses, and the
-Covered Software is not Incompatible With Secondary Licenses, this
-License permits You to additionally distribute such Covered Software
-under the terms of such Secondary License(s), so that the recipient of
-the Larger Work may, at their option, further distribute the Covered
-Software under the terms of either this License or such Secondary
-License(s).
-
-3.4. Notices
-
-You may not remove or alter the substance of any license notices
-(including copyright notices, patent notices, disclaimers of warranty,
-or limitations of liability) contained within the Source Code Form of
-the Covered Software, except that You may alter any license notices to
-the extent required to remedy known factual inaccuracies.
-
-3.5. Application of Additional Terms
-
-You may choose to offer, and to charge a fee for, warranty, support,
-indemnity or liability obligations to one or more recipients of Covered
-Software. However, You may do so only on Your own behalf, and not on
-behalf of any Contributor. You must make it absolutely clear that any
-such warranty, support, indemnity, or liability obligation is offered by
-You alone, and You hereby agree to indemnify every Contributor for any
-liability incurred by such Contributor as a result of warranty, support,
-indemnity or liability terms You offer. You may include additional
-disclaimers of warranty and limitations of liability specific to any
-jurisdiction.
-
-4. Inability to Comply Due to Statute or Regulation
----------------------------------------------------
-
-If it is impossible for You to comply with any of the terms of this
-License with respect to some or all of the Covered Software due to
-statute, judicial order, or regulation then You must: (a) comply with
-the terms of this License to the maximum extent possible; and (b)
-describe the limitations and the code they affect. Such description must
-be placed in a text file included with all distributions of the Covered
-Software under this License. Except to the extent prohibited by statute
-or regulation, such description must be sufficiently detailed for a
-recipient of ordinary skill to be able to understand it.
-
-5. Termination
---------------
-
-5.1. The rights granted under this License will terminate automatically
-if You fail to comply with any of its terms. However, if You become
-compliant, then the rights granted under this License from a particular
-Contributor are reinstated (a) provisionally, unless and until such
-Contributor explicitly and finally terminates Your grants, and (b) on an
-ongoing basis, if such Contributor fails to notify You of the
-non-compliance by some reasonable means prior to 60 days after You have
-come back into compliance. Moreover, Your grants from a particular
-Contributor are reinstated on an ongoing basis if such Contributor
-notifies You of the non-compliance by some reasonable means, this is the
-first time You have received notice of non-compliance with this License
-from such Contributor, and You become compliant prior to 30 days after
-Your receipt of the notice.
-
-5.2. If You initiate litigation against any entity by asserting a patent
-infringement claim (excluding declaratory judgment actions,
-counter-claims, and cross-claims) alleging that a Contributor Version
-directly or indirectly infringes any patent, then the rights granted to
-You by any and all Contributors for the Covered Software under Section
-2.1 of this License shall terminate.
-
-5.3. In the event of termination under Sections 5.1 or 5.2 above, all
-end user license agreements (excluding distributors and resellers) which
-have been validly granted by You or Your distributors under this License
-prior to termination shall survive termination.
-
-************************************************************************
-*                                                                      *
-*  6. Disclaimer of Warranty                                           *
-*  -------------------------                                           *
-*                                                                      *
-*  Covered Software is provided under this License on an "as is"       *
-*  basis, without warranty of any kind, either expressed, implied, or  *
-*  statutory, including, without limitation, warranties that the       *
-*  Covered Software is free of defects, merchantable, fit for a        *
-*  particular purpose or non-infringing. The entire risk as to the     *
-*  quality and performance of the Covered Software is with You.        *
-*  Should any Covered Software prove defective in any respect, You     *
-*  (not any Contributor) assume the cost of any necessary servicing,   *
-*  repair, or correction. This disclaimer of warranty constitutes an   *
-*  essential part of this License. No use of any Covered Software is   *
-*  authorized under this License except under this disclaimer.         *
-*                                                                      *
-************************************************************************
-
-************************************************************************
-*                                                                      *
-*  7. Limitation of Liability                                          *
-*  --------------------------                                          *
-*                                                                      *
-*  Under no circumstances and under no legal theory, whether tort      *
-*  (including negligence), contract, or otherwise, shall any           *
-*  Contributor, or anyone who distributes Covered Software as          *
-*  permitted above, be liable to You for any direct, indirect,         *
-*  special, incidental, or consequential damages of any character      *
-*  including, without limitation, damages for lost profits, loss of    *
-*  goodwill, work stoppage, computer failure or malfunction, or any    *
-*  and all other commercial damages or losses, even if such party      *
-*  shall have been informed of the possibility of such damages. This   *
-*  limitation of liability shall not apply to liability for death or   *
-*  personal injury resulting from such party's negligence to the       *
-*  extent applicable law prohibits such limitation. Some               *
-*  jurisdictions do not allow the exclusion or limitation of           *
-*  incidental or consequential damages, so this exclusion and          *
-*  limitation may not apply to You.                                    *
-*                                                                      *
-************************************************************************
-
-8. Litigation
--------------
-
-Any litigation relating to this License may be brought only in the
-courts of a jurisdiction where the defendant maintains its principal
-place of business and such litigation shall be governed by laws of that
-jurisdiction, without reference to its conflict-of-law provisions.
-Nothing in this Section shall prevent a party's ability to bring
-cross-claims or counter-claims.
-
-9. Miscellaneous
-----------------
-
-This License represents the complete agreement concerning the subject
-matter hereof. If any provision of this License is held to be
-unenforceable, such provision shall be reformed only to the extent
-necessary to make it enforceable. Any law or regulation which provides
-that the language of a contract shall be construed against the drafter
-shall not be used to construe this License against a Contributor.
-
-10. Versions of the License
----------------------------
-
-10.1. New Versions
-
-Mozilla Foundation is the license steward. Except as provided in Section
-10.3, no one other than the license steward has the right to modify or
-publish new versions of this License. Each version will be given a
-distinguishing version number.
-
-10.2. Effect of New Versions
-
-You may distribute the Covered Software under the terms of the version
-of the License under which You originally received the Covered Software,
-or under the terms of any subsequent version published by the license
-steward.
-
-10.3. Modified Versions
-
-If you create software not governed by this License, and you want to
-create a new license for such software, you may create and use a
-modified version of this License if you rename the license and remove
-any references to the name of the license steward (except to note that
-such modified license differs from this License).
-
-10.4. Distributing Source Code Form that is Incompatible With Secondary
-Licenses
-
-If You choose to distribute Source Code Form that is Incompatible With
-Secondary Licenses under the terms of this version of the License, the
-notice described in Exhibit B of this License must be attached.
-
-Exhibit A - Source Code Form License Notice
--------------------------------------------
-
-  This Source Code Form is subject to the terms of the Mozilla Public
-  License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-If it is not possible or desirable to put the notice in a particular
-file, then You may include the notice in a location (such as a LICENSE
-file in a relevant directory) where a recipient would be likely to look
-for such a notice.
-
-You may add additional accurate notices of copyright ownership.
-
-Exhibit B - "Incompatible With Secondary Licenses" Notice
----------------------------------------------------------
-
-  This Source Code Form is "Incompatible With Secondary Licenses", as
-  defined by the Mozilla Public License, v. 2.0.
 
 ----------------------- Dependencies Grouped by License ------------
 -------- Dependency
@@ -2113,6 +1948,40 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+----------------------- Dependencies Grouped by License ------------
+-------- Dependency
+github.com/verrazzano/pkg
+-------- Copyrights
+Copyright (c) 2021 Oracle America, Inc. and its affiliates.
+Copyright (c) 2021, Oracle and/or its affiliates.
+Copyright (C) 2021, Oracle and/or its affiliates.
+
+-------- Dependencies Summary
+github.com/verrazzano/pkg
+github.com/verrazzano/verrazzano-monitoring-operator
+
+-------- License used by Dependencies
+The Universal Permissive License (UPL), Version 1.0
+
+Copyright (c) <year> <copyright holders>
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any person obtaining a copy of this software, associated documentation and/or data (collectively the "Software"), free of charge and under any and all copyright rights in the Software, and any and all patent rights owned or freely licensable by each licensor hereunder covering either (i) the unmodified Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+
+(a) the Software, and
+
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is included with the Software (each a “Larger Work” to which the Software is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create derivative works of, display, perform, and distribute the Software and make, use, sell, offer for sale, import, export, have made, and have sold the Software and the Larger Work(s), and to sublicense the foregoing rights on either these or other terms.
+
+This license is subject to the following condition:
+
+The above copyright notice and either this complete permission notice or at a minimum a reference to the UPL must be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------------- Dependencies Grouped by License ------------
@@ -2375,5 +2244,6 @@ License:
    limitations under the License.
 
 
-ATTRIBUTION-HELPER-GENERATED:
-License file based on go.mod with md5 sum: d647fc89df8a7ee9927f116deaafbf76
+=== ATTRIBUTION-HELPER-GENERATED:
+=== Attribution helper version: {Major:0 Minor:11 GitVersion:0.10.0-40-g9a6aa67d GitCommit:9a6aa67de4e2ddcabe6387929711b0d29cb9ca0e GitTreeState:dirty BuildDate:2022-07-18T20:00:42Z GoVersion:go1.17.8 Compiler:gc Platform:darwin/amd64}
+=== License file based on go.mod with md5 sum: 4a4652d23cdd1165ff0dba9a13fe2e84

--- a/docs/development.md
+++ b/docs/development.md
@@ -61,7 +61,7 @@ The official way to run a Kubernetes operator is to run it as a pod within Kuber
 Docker image, assigning it a temporary tag based on the current timestamp:
 
 ```
-make docker-build
+make build
 ```
 
 If your `$KUBECONFIG` points to a remote cluster, you'll have to push this image to a real Docker registry:
@@ -69,7 +69,7 @@ If your `$KUBECONFIG` points to a remote cluster, you'll have to push this image
 ```
 docker login --username agent <docker repo>
 # Password is a secret!
-make docker-push
+make push
 ```
 
 Now, replace the VMO Docker image in `k8s/manifests/verrazzano-monitoring-operator.yaml` with the temporary image built
@@ -81,10 +81,21 @@ kubectl apply -f k8s/manifests/verrazzano-monitoring-operator.yaml
 
 ## Running unit and integration tests
 
+To perform static analysis:
+
+```
+make golangci-lint
+```
 To run unit tests:
 
 ```
 make unit-test
+```
+
+To perform both static analysis and run unit test in one go:
+
+```
+make check
 ```
 
 To run integration tests against a real Kubernetes cluster, first start the VMO using either the

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/verrazzano/verrazzano-monitoring-operator
 
-go 1.17
+go 1.19
 
 require (
 	github.com/go-resty/resty/v2 v2.6.0

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -24,14 +24,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -24,14 +24,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/config/components.go
+++ b/pkg/config/components.go
@@ -52,7 +52,7 @@ var Grafana = ComponentDetails{
 
 // Prometheus is the default Prometheus configuration
 // Note: Update promtool version to match any version changes here
-//    - vmo/images/cirith-server-for-operator/docker-images
+//   - vmo/images/cirith-server-for-operator/docker-images
 var Prometheus = ComponentDetails{
 	Name:              "prometheus",
 	EnvName:           "PROMETHEUS_IMAGE",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -71,7 +71,7 @@ const DefaultNamespace = "default"
 // ServiceAppLabel label name for service app
 const ServiceAppLabel = "app"
 
-//ClusterInitialMasterNodes is the parameter for the OpenSearch cluster initial master nodes
+// ClusterInitialMasterNodes is the parameter for the OpenSearch cluster initial master nodes
 const ClusterInitialMasterNodes = "cluster.initial_master_nodes"
 
 // K8SAppLabel label name for k8s app
@@ -197,11 +197,11 @@ const (
 	ObjectStoreCustomerKey        = "object_store_secret_key"
 )
 
-//ComponentLabel - the label for a specific component
+// ComponentLabel - the label for a specific component
 const ComponentLabel = "verrazzano-component"
 
-//ComponentOpenSearchValue - the value for opensearch component
+// ComponentOpenSearchValue - the value for opensearch component
 const ComponentOpenSearchValue = "opensearch"
 
-//NodeGroupLabel for specifying a node's group
+// NodeGroupLabel for specifying a node's group
 const NodeGroupLabel = "node-group"

--- a/pkg/metricsexporter/metricsexporter.go
+++ b/pkg/metricsexporter/metricsexporter.go
@@ -356,7 +356,7 @@ func (md *metricsDelegate) initializeFailedMetricsArray() {
 	}
 }
 
-// registerMetricsHandlersHelper loops through the failed metrics map and deletes metrics which have been registered succesSfully
+// registerMetricsHandlersHelper loops through the failed metrics map and deletes metrics which have been registered successfully
 func (md *metricsDelegate) registerMetricsHandlersHelper() error {
 	var errorObserved error
 	for metric := range MetricsExp.internalConfig.failedMetrics {

--- a/pkg/metricsexporter/metricsexporter.go
+++ b/pkg/metricsexporter/metricsexporter.go
@@ -305,19 +305,19 @@ func initDurationMetricMap() map[metricName]*DurationMetric {
 func initTimestampMetricMap() map[metricName]*TimestampMetric {
 	return map[metricName]*TimestampMetric{
 		NamesConfigMap: {
-			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_configmap_last_succesful_timestamp", Help: "The timestamp of the last time the configMap function completed successfully"}, []string{"configMap_index"}),
+			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_configmap_last_successful_timestamp", Help: "The timestamp of the last time the configMap function completed successfully"}, []string{"configMap_index"}),
 			labelFunction: &configMapLabelFunction,
 		},
 		NamesServices: {
-			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_services_last_succesful_timestamp", Help: "The timestamp of the last time the createService function completed successfully"}, []string{"service_index"}),
+			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_services_last_successful_timestamp", Help: "The timestamp of the last time the createService function completed successfully"}, []string{"service_index"}),
 			labelFunction: &servicesLabelFunction,
 		},
 		NamesRoleBindings: {
-			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_rolebindings_last_succesful_timestamp", Help: "The timestamp of the last time the roleBindings function completed successfully"}, []string{"rolebindings_index"}),
+			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_rolebindings_last_successful_timestamp", Help: "The timestamp of the last time the roleBindings function completed successfully"}, []string{"rolebindings_index"}),
 			labelFunction: &roleBindingLabelFunction,
 		},
 		NamesVMOUpdate: {
-			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_update_last_succesful_timestamp", Help: "The timestamp of the last time the vmo update completed successfully"}, []string{"update_index"}),
+			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_update_last_successful_timestamp", Help: "The timestamp of the last time the vmo update completed successfully"}, []string{"update_index"}),
 			labelFunction: &VMOUpdateLabelFunction,
 		},
 	}
@@ -356,7 +356,7 @@ func (md *metricsDelegate) initializeFailedMetricsArray() {
 	}
 }
 
-// registerMetricsHandlersHelper loops through the failed metrics map and deletes metrics which have been registered succesfully
+// registerMetricsHandlersHelper loops through the failed metrics map and deletes metrics which have been registered succesSfully
 func (md *metricsDelegate) registerMetricsHandlersHelper() error {
 	var errorObserved error
 	for metric := range MetricsExp.internalConfig.failedMetrics {

--- a/pkg/metricsexporter/metricsexporter_utils.go
+++ b/pkg/metricsexporter/metricsexporter_utils.go
@@ -54,7 +54,11 @@ func RegisterMetrics() {
 func StartMetricsServer() {
 	go wait.Until(func() {
 		http.Handle("/metrics", promhttp.Handler())
-		err := http.ListenAndServe(":9100", nil)
+		server := &http.Server{
+			Addr:              ":9100",
+			ReadHeaderTimeout: 3 * time.Second,
+		}
+		err := server.ListenAndServe()
 		if err != nil {
 			zap.S().Errorf("Failed to start metrics server for VMO: %v", err)
 		}

--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -66,7 +66,7 @@ const (
 	vmiManagedPolicy = "__vmi-managed__"
 )
 
-//createISMPolicy creates an ISM policy if it does not exist, else the policy will be updated.
+// createISMPolicy creates an ISM policy if it does not exist, else the policy will be updated.
 // If the policy already exsts and its spec matches the VMO policy spec, no update will be issued
 func (o *OSClient) createISMPolicy(opensearchEndpoint string, policy vmcontrollerv1.IndexManagementPolicy) error {
 	policyURL := fmt.Sprintf("%s/_plugins/_ism/policies/%s", opensearchEndpoint, policy.PolicyName)
@@ -99,7 +99,7 @@ func (o *OSClient) getPolicyByName(policyURL string) (*ISMPolicy, error) {
 	return existingPolicy, nil
 }
 
-//putUpdatedPolicy updates a policy in place, if the update is required. If no update was necessary, the returned
+// putUpdatedPolicy updates a policy in place, if the update is required. If no update was necessary, the returned
 // ISMPolicy will be nil.
 func (o *OSClient) putUpdatedPolicy(opensearchEndpoint string, policy *vmcontrollerv1.IndexManagementPolicy, existingPolicy *ISMPolicy) (*ISMPolicy, error) {
 	if !policyNeedsUpdate(policy, existingPolicy) {
@@ -150,7 +150,7 @@ func (o *OSClient) putUpdatedPolicy(opensearchEndpoint string, policy *vmcontrol
 	return updatedISMPolicy, nil
 }
 
-//addPolicyToExistingIndices updates any pre-existing cluster indices to be managed by the ISMPolicy
+// addPolicyToExistingIndices updates any pre-existing cluster indices to be managed by the ISMPolicy
 func (o *OSClient) addPolicyToExistingIndices(opensearchEndpoint string, policy *vmcontrollerv1.IndexManagementPolicy, updatedPolicy *ISMPolicy) error {
 	// If no policy was updated, then there is nothing to do
 	if updatedPolicy == nil {
@@ -240,7 +240,7 @@ func isEligibleForDeletion(policy ISMPolicy, expectedPolicyMap map[string]bool) 
 		!expectedPolicyMap[*policy.ID]
 }
 
-//policyNeedsUpdate returns true if the policy document has changed
+// policyNeedsUpdate returns true if the policy document has changed
 func policyNeedsUpdate(policy *vmcontrollerv1.IndexManagementPolicy, existingPolicy *ISMPolicy) bool {
 	newPolicyDocument := toISMPolicy(policy).Policy
 	oldPolicyDocument := existingPolicy.Policy

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -43,7 +43,7 @@ func NewOSClient(statefulSetLister appslistersv1.StatefulSetLister) *OSClient {
 	return o
 }
 
-//IsDataResizable returns an error unless these conditions of the OpenSearch cluster are met
+// IsDataResizable returns an error unless these conditions of the OpenSearch cluster are met
 // - at least 2 data nodes
 // - 'green' health
 // - all expected nodes are present in the cluster status
@@ -54,20 +54,20 @@ func (o *OSClient) IsDataResizable(vmo *vmcontrollerv1.VerrazzanoMonitoringInsta
 	return o.opensearchHealth(vmo, true, true)
 }
 
-//IsUpdated returns an error unless these conditions of the OpenSearch cluster are met
+// IsUpdated returns an error unless these conditions of the OpenSearch cluster are met
 // - 'green' health
 // - all expected nodes are present in the cluster status
 func (o *OSClient) IsUpdated(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) error {
 	return o.opensearchHealth(vmo, true, true)
 }
 
-//IsGreen returns an error unless these conditions of the OpenSearch cluster are met
+// IsGreen returns an error unless these conditions of the OpenSearch cluster are met
 // - 'green' health
 func (o *OSClient) IsGreen(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) error {
 	return o.opensearchHealth(vmo, false, false)
 }
 
-//ConfigureISM sets up the ISM Policies
+// ConfigureISM sets up the ISM Policies
 // The returned channel should be read for exactly one response, which tells whether ISM configuration succeeded.
 func (o *OSClient) ConfigureISM(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) chan error {
 	ch := make(chan error)
@@ -150,7 +150,7 @@ func (o *OSClient) SetAutoExpandIndices(vmi *vmcontrollerv1.VerrazzanoMonitoring
 	return ch
 }
 
-//IsOpenSearchReady returns true when all OpenSearch pods are ready, false otherwise
+// IsOpenSearchReady returns true when all OpenSearch pods are ready, false otherwise
 func (o *OSClient) IsOpenSearchReady(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) bool {
 	selector := labels.SelectorFromSet(map[string]string{constants.VMOLabel: vmi.Name, constants.ComponentLabel: constants.ComponentOpenSearchValue})
 	statefulSets, err := o.statefulSetLister.StatefulSets(vmi.Namespace).List(selector)

--- a/pkg/resources/deployments/elasticsearch.go
+++ b/pkg/resources/deployments/elasticsearch.go
@@ -22,7 +22,7 @@ import (
 type ElasticsearchBasic struct {
 }
 
-//IsOpenSearchDataDeployment checks template label to see if a given deployment is an OpenSearch data deployment
+// IsOpenSearchDataDeployment checks template label to see if a given deployment is an OpenSearch data deployment
 func IsOpenSearchDataDeployment(vmoName string, deployment *appsv1.Deployment) bool {
 	return deployment.Spec.Template.Labels[constants.ServiceAppLabel] == vmoName+"-"+config.ElasticsearchData.Name
 }

--- a/pkg/resources/deployments/elasticsearch.go
+++ b/pkg/resources/deployments/elasticsearch.go
@@ -5,6 +5,7 @@ package deployments
 
 import (
 	"fmt"
+
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
@@ -112,7 +113,7 @@ func (es ElasticsearchBasic) createElasticsearchIngestDeploymentElements(vmo *vm
 			corev1.EnvVar{Name: "discovery.seed_hosts", Value: resources.GetMetaName(vmo.Name, config.ElasticsearchMaster.Name)},
 			corev1.EnvVar{Name: "NETWORK_HOST", Value: "0.0.0.0"},
 			corev1.EnvVar{Name: "node.roles", Value: nodes.GetRolesString(&nodeList[i])},
-			corev1.EnvVar{Name: "ES_JAVA_OPTS", Value: javaOpts},
+			corev1.EnvVar{Name: "OPENSEARCH_JAVA_OPTS", Value: javaOpts},
 		)
 		// add the required istio annotations to allow inter-es component communication
 		if ingestDeployment.Spec.Template.Annotations == nil {
@@ -186,7 +187,7 @@ func (es ElasticsearchBasic) createElasticsearchDataDeploymentElements(vmo *vmco
 				corev1.EnvVar{Name: "discovery.seed_hosts", Value: resources.GetMetaName(vmo.Name, config.ElasticsearchMaster.Name)},
 				corev1.EnvVar{Name: "node.attr.availability_domain", Value: availabilityDomain},
 				corev1.EnvVar{Name: "node.roles", Value: nodes.GetRolesString(&nodeList[idx])},
-				corev1.EnvVar{Name: "ES_JAVA_OPTS", Value: javaOpts},
+				corev1.EnvVar{Name: "OPENSEARCH_JAVA_OPTS", Value: javaOpts},
 				corev1.EnvVar{Name: constants.ObjectStoreAccessKeyVarName,
 					ValueFrom: &corev1.EnvVarSource{
 						SecretKeyRef: &corev1.SecretKeySelector{
@@ -219,20 +220,7 @@ func (es ElasticsearchBasic) createElasticsearchDataDeploymentElements(vmo *vmco
 			dataDeployment.Spec.Template.Spec.Containers[0].Command = []string{
 				"sh",
 				"-c",
-				`#!/usr/bin/env bash -e
-
-# Updating elastic search keystore with keys
-# required for the repository-s3 plugin
-
-if [ "${OBJECT_STORE_ACCESS_KEY_ID:-}" ]; then
-    echo "Updating object store access key..."
-	echo $OBJECT_STORE_ACCESS_KEY_ID | /usr/share/opensearch/bin/opensearch-keystore add --stdin --force s3.client.default.access_key;
-fi
-if [ "${OBJECT_STORE_SECRET_KEY_ID:-}" ]; then
-    echo "Updating object store secret key..."
-	echo $OBJECT_STORE_SECRET_KEY_ID | /usr/share/opensearch/bin/opensearch-keystore add --stdin --force s3.client.default.secret_key;
-fi
-/usr/local/bin/docker-entrypoint.sh`,
+				resources.CreateOpenSearchContainerCMD(javaOpts),
 			}
 
 			// add the required istio annotations to allow inter-es component communication

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -471,9 +471,9 @@ func ConvertToRegexp(pattern string) string {
 	return result.String()
 }
 
-//CreateElasticSearchContainerCMD creates the CMD for OpenSearch containers.
-//The resulting CMD also contains command to comment java heap settings in config/jvm/options if input javaOpts is non-empty
-//and contains java min/max heap settings
+// CreateElasticSearchContainerCMD creates the CMD for OpenSearch containers.
+// The resulting CMD also contains command to comment java heap settings in config/jvm/options if input javaOpts is non-empty
+// and contains java min/max heap settings
 func CreateOpenSearchContainerCMD(javaOpts string) string {
 	if javaOpts != "" {
 		jvmOptsPair := strings.Split(javaOpts, " ")

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -54,7 +54,7 @@ const (
 	`
 )
 
-//CopyImmutableEnvVars copies the initial master node environment variable from an existing container to an expected container
+// CopyImmutableEnvVars copies the initial master node environment variable from an existing container to an expected container
 // cluster.initial_master_nodes shouldn't be changed after it's set.
 func CopyImmutableEnvVars(expected, existing []corev1.Container, containerName string) {
 	getContainer := func(containers []corev1.Container) (int, *corev1.Container) {
@@ -85,7 +85,7 @@ func CopyImmutableEnvVars(expected, existing []corev1.Container, containerName s
 	expected[idx] = *currentContainer
 }
 
-//GetEnvVar retrieves a container EnvVar if it is present
+// GetEnvVar retrieves a container EnvVar if it is present
 func GetEnvVar(container *corev1.Container, name string) *corev1.EnvVar {
 	for _, envVar := range container.Env {
 		if envVar.Name == name {
@@ -95,7 +95,7 @@ func GetEnvVar(container *corev1.Container, name string) *corev1.EnvVar {
 	return nil
 }
 
-//SetEnvVar sets a container EnvVar, overriding if it was laready present
+// SetEnvVar sets a container EnvVar, overriding if it was laready present
 func SetEnvVar(container *corev1.Container, envVar *corev1.EnvVar) {
 	for idx, env := range container.Env {
 		if env.Name == envVar.Name {
@@ -138,7 +138,7 @@ func GetOwnerLabels(owner string) map[string]string {
 	}
 }
 
-//GetNewRandomID generates a random alphanumeric string of the format [a-z0-9]{size}
+// GetNewRandomID generates a random alphanumeric string of the format [a-z0-9]{size}
 func GetNewRandomID(size int) (string, error) {
 	builder := strings.Builder{}
 	for i := 0; i < size; i++ {
@@ -406,7 +406,7 @@ func OidcProxyIngressHost(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, comp
 	return fmt.Sprintf("%s.%s", host, vmo.Spec.URI)
 }
 
-//CreateOidcProxy creates OpenID Connect (OIDC) proxy container and config Volume
+// CreateOidcProxy creates OpenID Connect (OIDC) proxy container and config Volume
 func CreateOidcProxy(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, vmoResources *vmcontrollerv1.Resources, component *config.ComponentDetails) ([]corev1.Volume, *corev1.Container) {
 	var volumes []corev1.Volume
 	configName := OidcProxyConfigName(vmo.Name, component.Name)
@@ -433,7 +433,7 @@ func CreateOidcProxy(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, vmoResour
 	return volumes, &oidcProxContainer
 }
 
-//OidcProxyService creates OidcProxy Service
+// OidcProxyService creates OidcProxy Service
 func OidcProxyService(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/helper_test.go
+++ b/pkg/resources/helper_test.go
@@ -109,3 +109,39 @@ func TestDeepCopyMap(t *testing.T) {
 		})
 	}
 }
+
+//GIVEN a string representing java options settings for an OpenSerach container
+//WHEN  CreateOpenSearchContainerCMD is invoked to get the command for the OpenSearch container
+//THEN the command contains a subcommand to disable the jvm heap settings, if input contains java heap settings
+func TestCreateOpenSearchContainerCMD(t *testing.T) {
+	containerCmdWithoutJavaOpts := fmt.Sprintf(containerCmdTmpl, "")
+	containerCmdWithJavaOpts := fmt.Sprintf(containerCmdTmpl, jvmOptsDisableCmd)
+	var tests = []struct {
+		description    string
+		javaOpts       string
+		expectedResult string
+	}{
+		{
+			"testCreateOpenSearchContainerCMD with empty jvmOpts",
+			"",
+			containerCmdWithoutJavaOpts,
+		},
+		{
+			"testCreateOpenSearchContainerCMD with jvmOpts not containing jvm memory settings",
+			"-Xsomething",
+			containerCmdWithoutJavaOpts,
+		},
+		{
+			"testCreateOpenSearchContainerCMD with jvmOpts containing jvm memory settings",
+			"-Xms1g -Xmx2g",
+			containerCmdWithJavaOpts,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			r := CreateOpenSearchContainerCMD(tt.javaOpts)
+			assert.Equal(t, tt.expectedResult, r)
+		})
+	}
+}

--- a/pkg/resources/helper_test.go
+++ b/pkg/resources/helper_test.go
@@ -110,9 +110,9 @@ func TestDeepCopyMap(t *testing.T) {
 	}
 }
 
-//GIVEN a string representing java options settings for an OpenSerach container
-//WHEN  CreateOpenSearchContainerCMD is invoked to get the command for the OpenSearch container
-//THEN the command contains a subcommand to disable the jvm heap settings, if input contains java heap settings
+// GIVEN a string representing java options settings for an OpenSerach container
+// WHEN  CreateOpenSearchContainerCMD is invoked to get the command for the OpenSearch container
+// THEN the command contains a subcommand to disable the jvm heap settings, if input contains java heap settings
 func TestCreateOpenSearchContainerCMD(t *testing.T) {
 	containerCmdWithoutJavaOpts := fmt.Sprintf(containerCmdTmpl, "")
 	containerCmdWithJavaOpts := fmt.Sprintf(containerCmdTmpl, jvmOptsDisableCmd)

--- a/pkg/resources/nodes/nodes.go
+++ b/pkg/resources/nodes/nodes.go
@@ -31,22 +31,22 @@ var (
 	RoleAssigned = "true"
 )
 
-//MasterNodes returns the list of master role containing nodes in the VMI spec. These nodes will be created as statefulsets.
+// MasterNodes returns the list of master role containing nodes in the VMI spec. These nodes will be created as statefulsets.
 func MasterNodes(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) []vmcontrollerv1.ElasticsearchNode {
 	return append([]vmcontrollerv1.ElasticsearchNode{vmo.Spec.Elasticsearch.MasterNode}, filterNodes(vmo, masterNodeMatcher)...)
 }
 
-//DataNodes returns the list of data nodes (that are not masters) in the VMI spec.
+// DataNodes returns the list of data nodes (that are not masters) in the VMI spec.
 func DataNodes(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) []vmcontrollerv1.ElasticsearchNode {
 	return append([]vmcontrollerv1.ElasticsearchNode{vmo.Spec.Elasticsearch.DataNode}, filterNodes(vmo, dataNodeMatcher)...)
 }
 
-//IngestNodes returns the list of ingest nodes in the VMI spec. These nodes will have no other role but ingest.
+// IngestNodes returns the list of ingest nodes in the VMI spec. These nodes will have no other role but ingest.
 func IngestNodes(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) []vmcontrollerv1.ElasticsearchNode {
 	return append([]vmcontrollerv1.ElasticsearchNode{vmo.Spec.Elasticsearch.IngestNode}, filterNodes(vmo, ingestNodeMatcher)...)
 }
 
-//GetRolesString turns a nodes role list into a role string
+// GetRolesString turns a nodes role list into a role string
 // roles: [master, ingest, data] => "master,ingest,data"
 // we have to use a buffer because NodeRole is a type alias
 func GetRolesString(node *vmcontrollerv1.ElasticsearchNode) string {
@@ -64,7 +64,7 @@ func GetRoleLabel(role vmcontrollerv1.NodeRole) string {
 	return fmt.Sprintf("opensearch.%s/role-%s", constants.VMOGroup, string(role))
 }
 
-//SetNodeRoleLabels adds node role labels to an existing label map
+// SetNodeRoleLabels adds node role labels to an existing label map
 // role labels follow the format: opensearch.verrazzano.io/role-<role name>=true
 func SetNodeRoleLabels(node *vmcontrollerv1.ElasticsearchNode, labels map[string]string) {
 	for _, role := range node.Roles {
@@ -78,7 +78,7 @@ func IsSingleNodeCluster(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) bool 
 	return nodeCount.MasterNodes == 1 && nodeCount.Replicas == 1
 }
 
-//GetNodeCount returns a struct containing the count of nodes of each role type, and the sum of all node replicas.
+// GetNodeCount returns a struct containing the count of nodes of each role type, and the sum of all node replicas.
 func GetNodeCount(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *NodeCount {
 	nodeCount := &NodeCount{}
 	for _, node := range AllNodes(vmo) {
@@ -97,7 +97,7 @@ func GetNodeCount(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *NodeCount {
 	return nodeCount
 }
 
-//InitialMasterNodes returns a comma separated list of master nodes for cluster bootstrapping
+// InitialMasterNodes returns a comma separated list of master nodes for cluster bootstrapping
 func InitialMasterNodes(vmoName string, masterNodes []vmcontrollerv1.ElasticsearchNode) string {
 	var j int32
 	var initialMasterNodes []string
@@ -109,7 +109,7 @@ func InitialMasterNodes(vmoName string, masterNodes []vmcontrollerv1.Elasticsear
 	return strings.Join(initialMasterNodes, ",")
 }
 
-//AllNodes returns a list of all nodes that need to be created
+// AllNodes returns a list of all nodes that need to be created
 func AllNodes(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) []vmcontrollerv1.ElasticsearchNode {
 	return append(vmo.Spec.Elasticsearch.Nodes, vmo.Spec.Elasticsearch.MasterNode, vmo.Spec.Elasticsearch.DataNode, vmo.Spec.Elasticsearch.IngestNode)
 }

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -80,7 +80,7 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 	}
 }
 
-//OpenSearchPodSelector creates a pod selector like
+// OpenSearchPodSelector creates a pod selector like
 // 'app in (system-es-master, system-es-data, system-es-ingest)'
 // to select all pods in the vmi cluster
 func OpenSearchPodSelector(vmoName string) string {
@@ -92,7 +92,7 @@ func OpenSearchPodSelector(vmoName string) string {
 	)
 }
 
-//UseNodeRoleSelector verifies if all OpenSearch pods are using node role selectors.
+// UseNodeRoleSelector verifies if all OpenSearch pods are using node role selectors.
 // If all pods are using node role selectors, this implies service selectors can be updated
 // to use node roles instead of service app labels.
 func UseNodeRoleSelector(pods *corev1.PodList) bool {

--- a/pkg/resources/statefulsets/plan.go
+++ b/pkg/resources/statefulsets/plan.go
@@ -36,7 +36,7 @@ type (
 	}
 )
 
-//CreatePlan creates a plan for sts that need to be created, updated, or deleted.
+// CreatePlan creates a plan for sts that need to be created, updated, or deleted.
 // if the cluster is not safe to scale down, updates/deletes will be rejected.
 func CreatePlan(log vzlog.VerrazzanoLogger, existingList, expectedList []*appsv1.StatefulSet) *StatefulSetPlan {
 	mapping := createStatefulSetMapping(existingList, expectedList)
@@ -77,7 +77,7 @@ func CreatePlan(log vzlog.VerrazzanoLogger, existingList, expectedList []*appsv1
 	return plan
 }
 
-//createStatefulSetMapping creates a mapping of statefulset and checks if the plan would scale the cluster to an inconsistent state.
+// createStatefulSetMapping creates a mapping of statefulset and checks if the plan would scale the cluster to an inconsistent state.
 // A cluster cannot be scaled down if:
 // - if has less than minClusterSize master replicas
 // - the scale down would remove half or more of the master replicas
@@ -111,7 +111,7 @@ func createStatefulSetMapping(existingList, expectedList []*appsv1.StatefulSet) 
 	return mapping
 }
 
-//CopyFromExisting copies fields that should not be changed from existing to expected.
+// CopyFromExisting copies fields that should not be changed from existing to expected.
 func CopyFromExisting(expected, existing *appsv1.StatefulSet) {
 	// Changes to volume claim templates are forbidden
 	expected.Spec.VolumeClaimTemplates = existing.Spec.VolumeClaimTemplates

--- a/pkg/resources/statefulsets/pvc.go
+++ b/pkg/resources/statefulsets/pvc.go
@@ -8,7 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-//GetPVCNames generates the expected PVC names of a statefulset, given its replica count
+// GetPVCNames generates the expected PVC names of a statefulset, given its replica count
 // {volumeClaimTemplate name}-{sts name}-{replica ordinal}
 func GetPVCNames(statefulSet *appsv1.StatefulSet) []string {
 	var pvcNames []string

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -203,7 +203,7 @@ func verifyElasticSearch(t *testing.T, vmo *vmcontrollerv1.VerrazzanoMonitoringI
 	assert.Equal(int32(constants.OSHTTPPort), sts.Spec.Template.Spec.Containers[0].Ports[1].ContainerPort, "Incorrect Container HostPort")
 
 	env := sts.Spec.Template.Spec.Containers[0].Env
-	assert.Len(env, 9, "Incorrect number of Env Vars")
+	assert.Len(env, 10, "Incorrect number of Env Vars")
 	assert.Equal("node.name", env[0].Name, "Incorrect Env[0].Name")
 	assert.Equal("metadata.name", env[0].ValueFrom.FieldRef.FieldPath,
 		"Incorrect Env[0].ValueFrom")
@@ -219,12 +219,14 @@ func verifyElasticSearch(t *testing.T, vmo *vmcontrollerv1.VerrazzanoMonitoringI
 	assert.Equal(constants.ObjectStoreCustomerKeyVarName, env[5].Name, "Incorrect Env[5].Name")
 	assert.Equal(constants.ObjectStoreCustomerKey, env[5].ValueFrom.SecretKeyRef.Key, "Incorrect Env[5] Secret Key name")
 	assert.Equal(constants.VerrazzanoBackupScrtName, env[5].ValueFrom.SecretKeyRef.Name, "Incorrect Env[5] Secret name")
-	assert.Equal("node.roles", env[6].Name, "Incorrect Env[6].Name")
-	assert.Equal("master,data,ingest", env[6].Value, "Incorrect Env[6].Value")
-	assert.Equal("discovery.seed_hosts", env[7].Name, "Incorrect Env[7].Name")
-	assert.Equal(resources.GetMetaName(vmo.Name, config.ElasticsearchMaster.Name), env[7].Value, "Incorrect Env[7].Value")
-	assert.Equal("cluster.initial_master_nodes", env[8].Name, "Incorrect Env[8].Name")
-	assert.Equal("vmi-system-es-master-0,vmi-system-es-master-1,vmi-system-es-master-2", env[8].Value, "Incorrect Env[8].Value")
+	assert.Equal("OPENSEARCH_JAVA_OPTS", env[6].Name, "Incorrect Env[6].Name")
+	assert.Equal("-Xms700m -Xmx700m", env[6].Value, "Incorrect Env[6].Value")
+	assert.Equal("node.roles", env[7].Name, "Incorrect Env[7].Name")
+	assert.Equal("master,data,ingest", env[7].Value, "Incorrect Env[7].Value")
+	assert.Equal("discovery.seed_hosts", env[8].Name, "Incorrect Env[8].Name")
+	assert.Equal(resources.GetMetaName(vmo.Name, config.ElasticsearchMaster.Name), env[8].Value, "Incorrect Env[7].Value")
+	assert.Equal("cluster.initial_master_nodes", env[9].Name, "Incorrect Env[9].Name")
+	assert.Equal("vmi-system-es-master-0,vmi-system-es-master-1,vmi-system-es-master-2", env[9].Value, "Incorrect Env[9].Value")
 
 	assert.Equal(int32(90), sts.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds,
 		"Incorrect Readiness Probe InitialDelaySeconds")
@@ -309,12 +311,12 @@ func verifyElasticSearchDevProfile(t *testing.T, vmo *vmcontrollerv1.VerrazzanoM
 	assert.Equal(constants.ObjectStoreCustomerKeyVarName, env[5].Name, "Incorrect Env[6].Name")
 	assert.Equal(constants.ObjectStoreCustomerKey, env[5].ValueFrom.SecretKeyRef.Key, "Incorrect Env[6] Secret Key name")
 	assert.Equal(constants.VerrazzanoBackupScrtName, env[5].ValueFrom.SecretKeyRef.Name, "Incorrect Env[6] Secret name")
-	assert.Equal("node.roles", env[6].Name, "Incorrect Env[6].Name")
-	assert.Equal("master,data,ingest", env[6].Value, "Incorrect Env[6].Value")
-	assert.Equal("discovery.type", env[7].Name, "Incorrect Env[7].Name")
-	assert.Equal("single-node", env[7].Value, "Incorrect Env[7].Value")
-	assert.Equal("ES_JAVA_OPTS", env[8].Name, "Incorrect Env[8].Name")
-	assert.Equal("-Xms700m -Xmx700m", env[8].Value, "Incorrect Env[8].Value")
+	assert.Equal("OPENSEARCH_JAVA_OPTS", env[6].Name, "Incorrect Env[6].Name")
+	assert.Equal("-Xms700m -Xmx700m", env[6].Value, "Incorrect Env[6].Value")
+	assert.Equal("node.roles", env[7].Name, "Incorrect Env[7].Name")
+	assert.Equal("master,data,ingest", env[7].Value, "Incorrect Env[7].Value")
+	assert.Equal("discovery.type", env[8].Name, "Incorrect Env[8].Name")
+	assert.Equal("single-node", env[8].Value, "Incorrect Env[8].Value")
 
 	assert.Equal(int32(90), sts.Spec.Template.Spec.Containers[0].ReadinessProbe.InitialDelaySeconds,
 		"Incorrect Readiness Probe InitialDelaySeconds")

--- a/pkg/resources/statefulsets/statefulset_test.go
+++ b/pkg/resources/statefulsets/statefulset_test.go
@@ -32,8 +32,9 @@ var storageClass = storagev1.StorageClass{
 
 // TestVMOEmptyStatefulSetSize tests the creation of a VMI without StatefulSets
 // GIVEN a VMI spec with an empty ElasticSearch spec
-//  WHEN I call New
-//  THEN there should be no StatefulSets created
+//
+//	WHEN I call New
+//	THEN there should be no StatefulSets created
 func TestVMOEmptyStatefulSetSize(t *testing.T) {
 	vmo := &vmcontrollerv1.VerrazzanoMonitoringInstance{}
 	statefulsets, err := New(vzlog.DefaultLogger(), vmo, &storageClass, "vmi-system-es-master-0")
@@ -45,8 +46,9 @@ func TestVMOEmptyStatefulSetSize(t *testing.T) {
 
 // TestVMOEmptyStatefulSetSize tests the creation of a VMI without StatefulSets
 // GIVEN a VMI spec with an ElasticSearch spec having 'enabled' set to false
-//  WHEN I call New
-//  THEN there should be no StatefulSets created
+//
+//	WHEN I call New
+//	THEN there should be no StatefulSets created
 func TestVMODisabledSpecs(t *testing.T) {
 	vmo := &vmcontrollerv1.VerrazzanoMonitoringInstance{
 		Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
@@ -64,19 +66,21 @@ func TestVMODisabledSpecs(t *testing.T) {
 
 // TestVMOProdProfile tests the creation of a VMI StatefulSets for a Production profile
 // GIVEN a VMI spec with an ElasticSearch spec
-//  WHEN I call New
-//  THEN there should a StatefulSet for ElasticSearch
-//   AND the object should have the expected values
+//
+//	WHEN I call New
+//	THEN there should a StatefulSet for ElasticSearch
+//	 AND the object should have the expected values
 func TestVMOProdProfile(t *testing.T) {
 	runTestVMO(t, false)
 }
 
 // TestVMODevProfile tests the creation of a VMI StatefulSets for a Development/small-memory profile
 // GIVEN a VMI spec with an ElasticSearch spec
-//  WHEN I call New
-//  THEN there should a StatefulSet for ElasticSearch
-//   AND the object should have the expected values
-//   AND ElasticSearch should be configured for a single-node cluster type
+//
+//	WHEN I call New
+//	THEN there should a StatefulSet for ElasticSearch
+//	 AND the object should have the expected values
+//	 AND ElasticSearch should be configured for a single-node cluster type
 func TestVMODevProfile(t *testing.T) {
 	runTestVMO(t, true)
 }

--- a/pkg/util/logs/vzlog/vzlog_test.go
+++ b/pkg/util/logs/vzlog/vzlog_test.go
@@ -161,7 +161,8 @@ func TestLogFormat(t *testing.T) {
 // TestMultipleContexts tests the EnsureContext and DeleteLogContext
 // WHEN EnsureContext is called multiple times
 // THEN ensure that the context map has an entry for each context and that
-//   the context map is empty when they the contexts are deleted
+//
+//	the context map is empty when they the contexts are deleted
 func TestMultipleContexts(t *testing.T) {
 	const rKey1 = "k1"
 	const rKey2 = "k2"

--- a/pkg/util/memory/podmem.go
+++ b/pkg/util/memory/podmem.go
@@ -22,7 +22,7 @@ func PodMemToJvmHeapArgs(size, defaultValue string) (string, error) {
 }
 
 // PodMemToJvmHeap converts a pod resource memory (.5Gi) to the JVM heap setting
-//in the format java expects (e.g. 512m)
+// in the format java expects (e.g. 512m)
 func PodMemToJvmHeap(size string) (string, error) {
 	q, err := resource.ParseQuantity(size)
 	if err != nil {

--- a/pkg/vmo/certificate_test.go
+++ b/pkg/vmo/certificate_test.go
@@ -16,8 +16,9 @@ import (
 
 // TestCreateCertificates tests that the certificates needed for webhooks are created
 // GIVEN an output directory for certificates
-//  WHEN I call CreateCertificates
-//  THEN all the needed certificate artifacts are created
+//
+//	WHEN I call CreateCertificates
+//	THEN all the needed certificate artifacts are created
 func TestCreateCertificates(t *testing.T) {
 	assert := assert.New(t)
 
@@ -50,8 +51,9 @@ func TestCreateCertificates(t *testing.T) {
 
 // TestCreateWebhookCertificatesFail tests that the certificates needed for webhooks are not created
 // GIVEN an invalid output directory for certificates
-//  WHEN I call CreateCertificates
-//  THEN all the needed certificate artifacts are not created
+//
+//	WHEN I call CreateCertificates
+//	THEN all the needed certificate artifacts are not created
 func TestCreateWebhookCertificatesFail(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -477,7 +477,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	*********************************************/
 	err = c.indexUpgradeMonitor.MigrateOldIndices(c.log, vmo, c.osClient, c.osDashboardsClient)
 	if err != nil {
-		c.log.Errorf("Failed to migrate old indices to data stream: %v", err)
+		c.log.ErrorfThrottled("Failed to migrate old indices to data stream: %v", err)
 		errorObserved = true
 	}
 
@@ -486,7 +486,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	 **********************/
 	err = CreateRoleBindings(c, vmo)
 	if err != nil {
-		c.log.Errorf("Failed to create Role Bindings for VMI %s: %v", vmo.Name, err)
+		c.log.ErrorfThrottled("Failed to create Role Bindings for VMI %s: %v", vmo.Name, err)
 		errorObserved = true
 	}
 
@@ -495,7 +495,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	**********************/
 	err = CreateConfigmaps(c, vmo)
 	if err != nil {
-		c.log.Errorf("Failed to create configmaps for VMI %s: %v", vmo.Name, err)
+		c.log.ErrorfThrottled("Failed to create configmaps for VMI %s: %v", vmo.Name, err)
 		errorObserved = true
 	}
 
@@ -504,7 +504,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	 **********************/
 	err = CreateServices(c, vmo)
 	if err != nil {
-		c.log.Errorf("Failed to create Services for VMI %s: %v", vmo.Name, err)
+		c.log.ErrorfThrottled("Failed to create Services for VMI %s: %v", vmo.Name, err)
 		errorObserved = true
 	}
 
@@ -513,7 +513,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	 **********************/
 	pvcToAdMap, err := CreatePersistentVolumeClaims(c, vmo)
 	if err != nil {
-		c.log.Errorf("Failed to create/update PVCs for VMI %s: %v", vmo.Name, err)
+		c.log.ErrorfThrottled("Failed to create/update PVCs for VMI %s: %v", vmo.Name, err)
 		errorObserved = true
 	}
 
@@ -522,7 +522,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	 **********************/
 	existingCluster, err := CreateStatefulSets(c, vmo)
 	if err != nil {
-		c.log.Errorf("Failed to create/update statefulsets for VMI %s: %v", vmo.Name, err)
+		c.log.ErrorfThrottled("Failed to create/update statefulsets for VMI %s: %v", vmo.Name, err)
 		errorObserved = true
 	}
 
@@ -533,7 +533,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	if !errorObserved {
 		deploymentsDirty, err = CreateDeployments(c, vmo, pvcToAdMap, existingCluster)
 		if err != nil {
-			c.log.Errorf("Failed to create/update deployments for VMI %s: %v", vmo.Name, err)
+			c.log.ErrorfThrottled("Failed to create/update deployments for VMI %s: %v", vmo.Name, err)
 			functionMetric.IncError()
 			errorObserved = true
 		}
@@ -543,7 +543,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	 **********************/
 	err = CreateIngresses(c, vmo)
 	if err != nil {
-		c.log.Errorf("Failed to create Ingresses for VMI %s: %v", vmo.Name, err)
+		c.log.ErrorfThrottled("Failed to create Ingresses for VMI %s: %v", vmo.Name, err)
 		errorObserved = true
 	}
 
@@ -569,13 +569,13 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 
 	autoExpandIndexErr := <-autoExpandIndexChannel
 	if autoExpandIndexErr != nil {
-		c.log.Errorf("Failed to update auto expand settings for indices: %v", autoExpandIndexErr)
+		c.log.ErrorfThrottled("Failed to update auto expand settings for indices: %v", autoExpandIndexErr)
 		errorObserved = true
 	}
 
 	ismErr := <-ismChannel
 	if ismErr != nil {
-		c.log.Errorf("Failed to configure ISM Policies: %v", ismErr)
+		c.log.ErrorfThrottled("Failed to configure ISM Policies: %v", ismErr)
 		errorObserved = true
 	}
 

--- a/pkg/vmo/deployment.go
+++ b/pkg/vmo/deployment.go
@@ -301,7 +301,7 @@ func updateAllDeployments(controller *Controller, vmo *vmcontrollerv1.Verrazzano
 	return false, nil
 }
 
-//isUpdateAllowed checks if OpenSearch nodes are allowed to update. If a data node is removed when the cluster is yellow,
+// isUpdateAllowed checks if OpenSearch nodes are allowed to update. If a data node is removed when the cluster is yellow,
 // data loss may occur.
 func isUpdateAllowed(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, current *appsv1.Deployment) bool {
 	// if current is an OpenSearch data node

--- a/pkg/vmo/http.go
+++ b/pkg/vmo/http.go
@@ -16,8 +16,12 @@ import (
 func StartHTTPServer(controller *Controller, certdir string, port string) {
 	setupHandlers(controller)
 	go wait.Until(func() {
+		server := &http.Server{
+			Addr:              ":" + port,
+			ReadHeaderTimeout: 3 * time.Second,
+		}
 		controller.log.Oncef("Starting HTTP server")
-		err := http.ListenAndServeTLS(":"+port, path.Join(certdir, "tls.crt"), path.Join(certdir, "tls.key"), nil)
+		err := server.ListenAndServeTLS(path.Join(certdir, "tls.crt"), path.Join(certdir, "tls.key"))
 		if err != nil {
 			controller.log.Errorf("Failed to start HTTP server for VMI: %v", err)
 		}

--- a/pkg/vmo/metricsexporter_test.go
+++ b/pkg/vmo/metricsexporter_test.go
@@ -42,8 +42,9 @@ var delegate = metricsexporter.TestDelegate
 
 // TestInitializeAllMetricsArray tests that the metrics maps are added to the allmetrics array
 // GIVEN populated metrics maps
-//  WHEN I call initializeAllMetricsArray
-//  THEN all the needed metrics are placed in the allmetrics array
+//
+//	WHEN I call initializeAllMetricsArray
+//	THEN all the needed metrics are placed in the allmetrics array
 func TestInitializeAllMetricsArray(t *testing.T) {
 	clearMetrics()
 	assert := assert.New(t)
@@ -54,8 +55,9 @@ func TestInitializeAllMetricsArray(t *testing.T) {
 
 // TestNoMetrics, TestValid & TestInvalid tests that metrics in the allmetrics array are registered and failedMetrics are retried
 // GIVEN a populated allMetrics array
-//  WHEN I call registerMetricsHandlers
-//  THEN all the valid metrics are registered and failedMetrics are retried
+//
+//	WHEN I call registerMetricsHandlers
+//	THEN all the valid metrics are registered and failedMetrics are retried
 func TestRegistrationSystem(t *testing.T) {
 	testCases := []registerTest{
 		{
@@ -212,8 +214,9 @@ func createControllerForTesting() (*Controller, *vmctl.VerrazzanoMonitoringInsta
 
 // TestReconcileMetrics tests that the FunctionMetrics methods record metrics properly when the reconcile function is called
 // GIVEN a FunctionMetric corresponding to the reconcile function
-//  WHEN I call reconcile
-//  THEN the metrics for the reconcile function are to be captured
+//
+//	WHEN I call reconcile
+//	THEN the metrics for the reconcile function are to be captured
 func TestReconcileAndUpdateMetrics(t *testing.T) {
 
 	controller, vmo := createControllerForTesting()
@@ -237,8 +240,9 @@ func TestReconcileAndUpdateMetrics(t *testing.T) {
 
 // TestDeploymentMetrics tests that the FunctionMetrics methods record metrics properly when the createDeployment function is called
 // GIVEN a FunctionMetric corresponding to the deployment function
-//  WHEN I call createDeployments
-//  THEN the metrics for the CreateDeployments function are to be captured, with the exception of (trivial) error metrics
+//
+//	WHEN I call createDeployments
+//	THEN the metrics for the CreateDeployments function are to be captured, with the exception of (trivial) error metrics
 func TestDeploymentMetrics(t *testing.T) {
 
 	controller, vmo := createControllerForTesting()
@@ -306,7 +310,7 @@ func TestServiceMetrics(t *testing.T) {
 	assert.LessOrEqual(t, int64(newTimeStamp*10)/10, time.Now().Unix())
 }
 
-//helper function to ensure consistency between tests
+// helper function to ensure consistency between tests
 func clearMetrics() {
 	*allMetrics = []prometheus.Collector{}
 	for c := range metricsexporter.TestDelegate.GetFailedMetricsMap() {

--- a/pkg/vmo/pvc.go
+++ b/pkg/vmo/pvc.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 )
 
-//CreatePersistentVolumeClaims Creates PVCs for the given VMO instance.  Returns a pvc->AD map, which is populated *only if* AD information
+// CreatePersistentVolumeClaims Creates PVCs for the given VMO instance.  Returns a pvc->AD map, which is populated *only if* AD information
 // can be specified for new PVCs or determined from existing PVCs.  A pvc-AD map with empty AD values instructs the
 // subsequent deployment processing logic to do the job of choosing ADs.
 func CreatePersistentVolumeClaims(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) (map[string]string, error) {

--- a/pkg/vmo/pvc_update.go
+++ b/pkg/vmo/pvc_update.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-//resizePVC resizes a PVC to a new size
+// resizePVC resizes a PVC to a new size
 // if the underlying storage class does not support expansion, a new PVC will be created.
 func resizePVC(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, existingPVC, expectedPVC *corev1.PersistentVolumeClaim, storageClass *storagev1.StorageClass) (*string, error) {
 	if storageClass.AllowVolumeExpansion != nil && *storageClass.AllowVolumeExpansion {
@@ -55,7 +55,7 @@ func resizePVC(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringI
 	return &expectedPVC.Name, nil
 }
 
-//cleanupUnusedPVCs finds any unused PVCs and deletes them
+// cleanupUnusedPVCs finds any unused PVCs and deletes them
 func cleanupUnusedPVCs(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) error {
 	selector := labels.SelectorFromSet(resources.GetMetaLabels(vmo))
 	deployments, err := controller.deploymentLister.Deployments(vmo.Namespace).List(selector)
@@ -78,7 +78,7 @@ func cleanupUnusedPVCs(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMon
 	return nil
 }
 
-//getInUsePVCNames gets the names of PVCs that are currently used by VMO deployments
+// getInUsePVCNames gets the names of PVCs that are currently used by VMO deployments
 func getInUsePVCNames(deployments []*appsv1.Deployment, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) map[string]bool {
 	inUsePVCNames := map[string]bool{}
 	for _, deployment := range deployments {
@@ -99,7 +99,7 @@ func getInUsePVCNames(deployments []*appsv1.Deployment, vmo *vmcontrollerv1.Verr
 	return inUsePVCNames
 }
 
-//getUnboundPVCs gets the VMO-managed PVCs which are not currently used by VMO deployments
+// getUnboundPVCs gets the VMO-managed PVCs which are not currently used by VMO deployments
 func getUnboundPVCs(pvcs []*corev1.PersistentVolumeClaim, inUsePVCNames map[string]bool) []*corev1.PersistentVolumeClaim {
 	var unboundPVCs []*corev1.PersistentVolumeClaim
 	for _, pvc := range pvcs {
@@ -110,12 +110,12 @@ func getUnboundPVCs(pvcs []*corev1.PersistentVolumeClaim, inUsePVCNames map[stri
 	return unboundPVCs
 }
 
-//isOpenSearchPVC checks if a PVC is an OpenSearch PVC
+// isOpenSearchPVC checks if a PVC is an OpenSearch PVC
 func isOpenSearchPVC(pvc *corev1.PersistentVolumeClaim) bool {
 	return strings.Contains(pvc.Name, "es-data")
 }
 
-//pvcNeedsResize a PVC only needs resize if it is greater than the existing PVC size
+// pvcNeedsResize a PVC only needs resize if it is greater than the existing PVC size
 func pvcNeedsResize(existingPVC, expectedPVC *corev1.PersistentVolumeClaim) bool {
 	existingStorage := existingPVC.Spec.Resources.Requests.Storage()
 	expectedStorage := expectedPVC.Spec.Resources.Requests.Storage()
@@ -123,7 +123,7 @@ func pvcNeedsResize(existingPVC, expectedPVC *corev1.PersistentVolumeClaim) bool
 	return compare > 0
 }
 
-//newPVCName adds a prefix if not present, otherwise it rewrites the existing prefix
+// newPVCName adds a prefix if not present, otherwise it rewrites the existing prefix
 func newPVCName(pvcName string, size int) (string, error) {
 	pvcNameSplit := strings.Split(pvcName, "-")
 	suffix, err := resources.GetNewRandomID(size)
@@ -140,7 +140,7 @@ func newPVCName(pvcName string, size int) (string, error) {
 	return strings.Join(pvcNameSplit, "-"), nil
 }
 
-//updateVMOStorageForPVC updates the VMO storage to replace an old PVC with a new PVC
+// updateVMOStorageForPVC updates the VMO storage to replace an old PVC with a new PVC
 func updateVMOStorageForPVC(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, oldPVCName, newPVCName string) {
 	updateStorage := func(storage *vmcontrollerv1.Storage) {
 		if storage != nil {
@@ -157,7 +157,7 @@ func updateVMOStorageForPVC(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, ol
 	updateStorage(vmo.Spec.Elasticsearch.DataNode.Storage)
 }
 
-//setPerNodeStorage updates the VMO OpenSearch storage spec to reflect the current API
+// setPerNodeStorage updates the VMO OpenSearch storage spec to reflect the current API
 func setPerNodeStorage(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) {
 	updateFunc := func(storage *vmcontrollerv1.Storage, node *vmcontrollerv1.ElasticsearchNode) {
 		if node.Replicas > 0 && node.Storage == nil {

--- a/pkg/vmo/statefulset.go
+++ b/pkg/vmo/statefulset.go
@@ -83,7 +83,7 @@ func logReturnError(log vzlog.VerrazzanoLogger, sts *appsv1.StatefulSet, err err
 	return log.ErrorfNewErr("Failed to update StatefulSets %s:%s: %v", sts.Namespace, sts.Name, err)
 }
 
-//getInitialMasterNodes returns the initial master nodes string if the cluster is not already bootstrapped
+// getInitialMasterNodes returns the initial master nodes string if the cluster is not already bootstrapped
 func getInitialMasterNodes(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, existing []*appsv1.StatefulSet) string {
 	if len(existing) > 0 {
 		return ""
@@ -110,7 +110,7 @@ func updateStatefulSet(c *Controller, sts *appsv1.StatefulSet, vmo *vmcontroller
 	return nil
 }
 
-//scaleDownStatefulSet scales down a statefulset, and deletes the statefulset if it is already at 1 or fewer replicas.
+// scaleDownStatefulSet scales down a statefulset, and deletes the statefulset if it is already at 1 or fewer replicas.
 func scaleDownStatefulSet(c *Controller, expectedList []*appsv1.StatefulSet, statefulSet *appsv1.StatefulSet, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) error {
 	deleteSTS := func() error {
 		err := c.kubeclientset.AppsV1().StatefulSets(vmo.Namespace).Delete(context.TODO(), statefulSet.Name, metav1.DeleteOptions{})

--- a/test/integ/util/certs.go
+++ b/test/integ/util/certs.go
@@ -49,6 +49,7 @@ func pemBlockForKey(priv interface{}) *pem.Block {
 }
 
 // GenerateKeys this generates keys
+//
 //	host  	   : string "Comma-separated hostnames and IPs to generate a certificate for"
 //	validFrom  : string "Creation date formatted as Jan 1 15:04:05 2011"
 //	validFor   : time.Duration 365*24*time.Hour, "Duration that certificate is valid for"
@@ -137,7 +138,7 @@ func GenerateKeys(host string, domain string, validFrom string, validFor time.Du
 		zap.S().Errorf("Failed to create certificate: %s", err)
 	}
 
-	certOut, err := os.Create(os.TempDir() + "/tls.crt")
+	certOut, err := os.CreateTemp(os.TempDir(), "cert")
 	if err != nil {
 		zap.S().Errorf("failed to open"+os.TempDir()+"/tls.crt for writing: %s", err)
 	}

--- a/verrazzano-backup-hook/log/log.go
+++ b/verrazzano-backup-hook/log/log.go
@@ -9,7 +9,7 @@ import (
 	"log"
 )
 
-//Logger constructs a logger that prints out messages in json and also logs to a file
+// Logger constructs a logger that prints out messages in json and also logs to a file
 func Logger(filePath string) (*zap.SugaredLogger, error) {
 	logger, err := zap.NewProduction()
 	if err != nil {

--- a/verrazzano-backup-hook/opensearch/opensearch.go
+++ b/verrazzano-backup-hook/opensearch/opensearch.go
@@ -118,7 +118,7 @@ func (o *OpensearchImpl) EnsureOpenSearchIsReachable() error {
 	return nil
 }
 
-//EnsureOpenSearchIsHealthy ensures OpenSearch cluster is healthy
+// EnsureOpenSearchIsHealthy ensures OpenSearch cluster is healthy
 func (o *OpensearchImpl) EnsureOpenSearchIsHealthy() error {
 	o.Log.Infof("Checking if cluster is healthy")
 	var clusterHealth types.OpenSearchHealthResponse

--- a/verrazzano-backup-hook/utilities/vzk8sfake/spdy.go
+++ b/verrazzano-backup-hook/utilities/vzk8sfake/spdy.go
@@ -13,18 +13,18 @@ import (
 // PodSTDOUT can be used to output arbitrary strings during unit testing
 var PodSTDOUT = ""
 
-//NewPodExecutor should be used instead of remotecommand.NewSPDYExecutor in unit tests
+// NewPodExecutor should be used instead of remotecommand.NewSPDYExecutor in unit tests
 func NewPodExecutor(config *rest.Config, method string, url *url.URL) (remotecommand.Executor, error) {
 	return &dummyExecutor{method: method, url: url}, nil
 }
 
-//dummyExecutor is for unit testing
+// dummyExecutor is for unit testing
 type dummyExecutor struct {
 	method string
 	url    *url.URL
 }
 
-//Stream on a dummyExecutor sets stdout to PodSTDOUT
+// Stream on a dummyExecutor sets stdout to PodSTDOUT
 func (f *dummyExecutor) Stream(options remotecommand.StreamOptions) error {
 	if options.Stdout != nil {
 		buf := new(bytes.Buffer)


### PR DESCRIPTION
When misspell linter was added to Verrazzano, Jenkins build was failing in the System component metrics stage. After probing I figured out that the failure was because vmoTimestampMetric, which is one of the constants for sample metrics of system components had it's value changed from "vmo_configmap_last_succesful_timestamp" to "vmo_configmap_last_successful_timestamp" as successful was reported as a spelling error by misspell linter. These errors traced back to metrics exporter.go file of Verrazzano Monitoring Operator repository. 