### PR TITLE
VZ-7330:Successful wrongly spelt (#270)

### DIFF
--- a/pkg/metricsexporter/metricsexporter.go
+++ b/pkg/metricsexporter/metricsexporter.go
@@ -305,19 +305,19 @@ func initDurationMetricMap() map[metricName]*DurationMetric {
 func initTimestampMetricMap() map[metricName]*TimestampMetric {
 	return map[metricName]*TimestampMetric{
 		NamesConfigMap: {
-			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_configmap_last_succesful_timestamp", Help: "The timestamp of the last time the configMap function completed successfully"}, []string{"configMap_index"}),
+			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_configmap_last_successful_timestamp", Help: "The timestamp of the last time the configMap function completed successfully"}, []string{"configMap_index"}),
 			labelFunction: &configMapLabelFunction,
 		},
 		NamesServices: {
-			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_services_last_succesful_timestamp", Help: "The timestamp of the last time the createService function completed successfully"}, []string{"service_index"}),
+			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_services_last_successful_timestamp", Help: "The timestamp of the last time the createService function completed successfully"}, []string{"service_index"}),
 			labelFunction: &servicesLabelFunction,
 		},
 		NamesRoleBindings: {
-			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_rolebindings_last_succesful_timestamp", Help: "The timestamp of the last time the roleBindings function completed successfully"}, []string{"rolebindings_index"}),
+			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_rolebindings_last_successful_timestamp", Help: "The timestamp of the last time the roleBindings function completed successfully"}, []string{"rolebindings_index"}),
 			labelFunction: &roleBindingLabelFunction,
 		},
 		NamesVMOUpdate: {
-			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_update_last_succesful_timestamp", Help: "The timestamp of the last time the vmo update completed successfully"}, []string{"update_index"}),
+			metric:        prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "vmo_update_last_successful_timestamp", Help: "The timestamp of the last time the vmo update completed successfully"}, []string{"update_index"}),
 			labelFunction: &VMOUpdateLabelFunction,
 		},
 	}
@@ -356,7 +356,7 @@ func (md *metricsDelegate) initializeFailedMetricsArray() {
 	}
 }
 
-// registerMetricsHandlersHelper loops through the failed metrics map and deletes metrics which have been registered succesfully
+// registerMetricsHandlersHelper loops through the failed metrics map and deletes metrics which have been registered successfully
 func (md *metricsDelegate) registerMetricsHandlersHelper() error {
 	var errorObserved error
 	for metric := range MetricsExp.internalConfig.failedMetrics {


### PR DESCRIPTION
When misspell linter was added to Verrazzano, Jenkins build was failing in the System component metrics stage. After probing I figured out that the failure was because vmoTimestampMetric, which is one of the constants for sample metrics of system components had it's value changed from "vmo_configmap_last_succesful_timestamp" to "vmo_configmap_last_successful_timestamp" as successful was reported as a spelling error by misspell linter. These errors traced back to metrics exporter.go file of Verrazzano Monitoring Operator repository.