### PR TITLE
VZ-7396: Remove ES access URL on a new install and preserve it for upgrade. 

### DIFF
--- a/pkg/config/components.go
+++ b/pkg/config/components.go
@@ -108,8 +108,8 @@ var OidcProxy = ComponentDetails{
 
 // ElasticsearchIngest is the default Elasticsearch IngestNodes configuration
 var ElasticsearchIngest = ComponentDetails{
-	Name:         "os-ingest",
-	EndpointName: "opensearch",
+	Name:         "es-ingest",
+	EndpointName: "elasticsearch",
 	//NOTE: update ELASTICSEARCH_WAIT_TARGET_VERSION env (constants.ESWaitTargetVersionEnv) value to match the version reported by this image
 	EnvName:           "ELASTICSEARCH_IMAGE",
 	ImagePullPolicy:   constants.DefaultImagePullPolicy,

--- a/pkg/config/components.go
+++ b/pkg/config/components.go
@@ -98,7 +98,7 @@ var Kibana = ComponentDetails{
 	OidcProxy:         &OidcProxy,
 }
 
-// OpenSearchDashboards is the default Kibana configuration
+// OpenSearchDashboards is the default OpenSearchDashboards configuration
 var OpenSearchDashboards = ComponentDetails{
 	Name:              "OpenSearchDashboards",
 	EnvName:           "KIBANA_IMAGE",

--- a/pkg/config/components.go
+++ b/pkg/config/components.go
@@ -109,7 +109,7 @@ var OidcProxy = ComponentDetails{
 // ElasticsearchIngest is the default Elasticsearch IngestNodes configuration
 var ElasticsearchIngest = ComponentDetails{
 	Name:         "es-ingest",
-	EndpointName: "elasticsearch",
+	EndpointName: "opensearch",
 	//NOTE: update ELASTICSEARCH_WAIT_TARGET_VERSION env (constants.ESWaitTargetVersionEnv) value to match the version reported by this image
 	EnvName:           "ELASTICSEARCH_IMAGE",
 	ImagePullPolicy:   constants.DefaultImagePullPolicy,

--- a/pkg/config/components.go
+++ b/pkg/config/components.go
@@ -98,6 +98,18 @@ var Kibana = ComponentDetails{
 	OidcProxy:         &OidcProxy,
 }
 
+// OpenSearchDashboards is the default Kibana configuration
+var OpenSearchDashboards = ComponentDetails{
+	Name:              "OpenSearchDashboards",
+	EnvName:           "KIBANA_IMAGE",
+	ImagePullPolicy:   constants.DefaultImagePullPolicy,
+	Port:              5601,
+	LivenessHTTPPath:  "/api/status",
+	ReadinessHTTPPath: "/api/status",
+	Privileged:        false,
+	OidcProxy:         &OidcProxy,
+}
+
 // OidcProxy is the default OIDC proxy configuration
 var OidcProxy = ComponentDetails{
 	Name:            "oidc",

--- a/pkg/config/components.go
+++ b/pkg/config/components.go
@@ -100,7 +100,7 @@ var Kibana = ComponentDetails{
 
 // OpenSearchDashboards is the default OpenSearchDashboards configuration
 var OpenSearchDashboards = ComponentDetails{
-	Name:              "OpenSearchDashboards",
+	Name:              "opensearchdashboards",
 	EnvName:           "KIBANA_IMAGE",
 	ImagePullPolicy:   constants.DefaultImagePullPolicy,
 	Port:              5601,

--- a/pkg/config/components.go
+++ b/pkg/config/components.go
@@ -109,7 +109,7 @@ var OidcProxy = ComponentDetails{
 // ElasticsearchIngest is the default Elasticsearch IngestNodes configuration
 var ElasticsearchIngest = ComponentDetails{
 	Name:         "es-ingest",
-	EndpointName: "opensearch",
+	EndpointName: "elasticsearch",
 	//NOTE: update ELASTICSEARCH_WAIT_TARGET_VERSION env (constants.ESWaitTargetVersionEnv) value to match the version reported by this image
 	EnvName:           "ELASTICSEARCH_IMAGE",
 	ImagePullPolicy:   constants.DefaultImagePullPolicy,

--- a/pkg/config/components.go
+++ b/pkg/config/components.go
@@ -108,7 +108,7 @@ var OidcProxy = ComponentDetails{
 
 // ElasticsearchIngest is the default Elasticsearch IngestNodes configuration
 var ElasticsearchIngest = ComponentDetails{
-	Name:         "es-ingest",
+	Name:         "os-ingest",
 	EndpointName: "opensearch",
 	//NOTE: update ELASTICSEARCH_WAIT_TARGET_VERSION env (constants.ESWaitTargetVersionEnv) value to match the version reported by this image
 	EnvName:           "ELASTICSEARCH_IMAGE",

--- a/pkg/config/components.go
+++ b/pkg/config/components.go
@@ -120,6 +120,20 @@ var ElasticsearchIngest = ComponentDetails{
 	OidcProxy:         &OidcProxy,
 }
 
+// OpensearchIngest is the default Elasticsearch IngestNodes configuration
+var OpensearchIngest = ComponentDetails{
+	Name:         "os-ingest",
+	EndpointName: "opensearch",
+	//NOTE: update ELASTICSEARCH_WAIT_TARGET_VERSION env (constants.ESWaitTargetVersionEnv) value to match the version reported by this image
+	EnvName:           "ELASTICSEARCH_IMAGE",
+	ImagePullPolicy:   constants.DefaultImagePullPolicy,
+	Port:              constants.OSHTTPPort,
+	LivenessHTTPPath:  "/_cluster/health",
+	ReadinessHTTPPath: "/_cluster/health",
+	Privileged:        false,
+	OidcProxy:         &OidcProxy,
+}
+
 // ElasticsearchMaster is the default Elasticsearch MasterNodes configuration
 var ElasticsearchMaster = ComponentDetails{
 	Name:            "es-master",

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -406,15 +406,6 @@ func OidcProxyIngressHost(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, comp
 	return fmt.Sprintf("%s.%s", host, vmo.Spec.URI)
 }
 
-// OidcProxyIngressHost returns OIDC Proxy ingress host.
-func OidcProxyIngressHostES(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) string {
-	host := "elasticsearch-testing"
-	if component.EndpointName != "" {
-		host = component.EndpointName
-	}
-	return fmt.Sprintf("%s.%s", host, vmo.Spec.URI)
-}
-
 // CreateOidcProxy creates OpenID Connect (OIDC) proxy container and config Volume
 func CreateOidcProxy(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, vmoResources *vmcontrollerv1.Resources, component *config.ComponentDetails) ([]corev1.Volume, *corev1.Container) {
 	var volumes []corev1.Volume

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -407,10 +407,10 @@ func OidcProxyIngressHost(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, comp
 }
 
 // OidcProxyIngressHost returns OIDC Proxy ingress host.
-func OidcProxyIngressHostOS(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) string {
+func OidcProxyIngressHostES(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) string {
 	host := component.Name
 	if component.EndpointName != "" {
-		host = "opensearch"
+		host = "elasticsearch"
 	}
 	return fmt.Sprintf("%s.%s", host, vmo.Spec.URI)
 }

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -165,7 +165,7 @@ func GetMetaLabels(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) map[string]
 func GetCompLabel(componentName string) string {
 	var componentLabelValue string
 	switch componentName {
-	case config.ElasticsearchMaster.Name, config.ElasticsearchData.Name, config.ElasticsearchIngest.Name:
+	case config.ElasticsearchMaster.Name, config.ElasticsearchData.Name, config.ElasticsearchIngest.Name, config.OpensearchIngest.Name:
 		componentLabelValue = constants.ComponentOpenSearchValue
 	default:
 		componentLabelValue = componentName

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -406,6 +406,15 @@ func OidcProxyIngressHost(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, comp
 	return fmt.Sprintf("%s.%s", host, vmo.Spec.URI)
 }
 
+// OidcProxyIngressHost returns OIDC Proxy ingress host.
+func OidcProxyIngressHostES(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) string {
+	host := "elasticsearch-testing"
+	if component.EndpointName != "" {
+		host = component.EndpointName
+	}
+	return fmt.Sprintf("%s.%s", host, vmo.Spec.URI)
+}
+
 // CreateOidcProxy creates OpenID Connect (OIDC) proxy container and config Volume
 func CreateOidcProxy(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, vmoResources *vmcontrollerv1.Resources, component *config.ComponentDetails) ([]corev1.Volume, *corev1.Container) {
 	var volumes []corev1.Volume

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -406,6 +406,15 @@ func OidcProxyIngressHost(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, comp
 	return fmt.Sprintf("%s.%s", host, vmo.Spec.URI)
 }
 
+// OidcProxyIngressHost returns OIDC Proxy ingress host.
+func OidcProxyIngressHostES(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) string {
+	host := component.Name
+	if component.EndpointName != "" {
+		host = "elasticsearch"
+	}
+	return fmt.Sprintf("%s.%s", host, vmo.Spec.URI)
+}
+
 // CreateOidcProxy creates OpenID Connect (OIDC) proxy container and config Volume
 func CreateOidcProxy(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, vmoResources *vmcontrollerv1.Resources, component *config.ComponentDetails) ([]corev1.Volume, *corev1.Container) {
 	var volumes []corev1.Volume

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -6,6 +6,7 @@ package resources
 import (
 	"crypto/rand"
 	"fmt"
+	netv1 "k8s.io/api/networking/v1"
 	"math/big"
 	"os"
 	"regexp"
@@ -431,6 +432,30 @@ func CreateOidcProxy(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, vmoResour
 	}
 	volumes = append(volumes, configVolume)
 	return volumes, &oidcProxContainer
+}
+
+// getIngressRule returns the ingressRule with the provided ingress host
+func GetIngressRule(ingressHost string) netv1.IngressRule {
+	ingressRule := netv1.IngressRule{
+		Host: ingressHost,
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
+					{
+						Path: "/()(.*)",
+						Backend: netv1.IngressBackend{
+							Service: &netv1.IngressServiceBackend{
+								Port: netv1.ServiceBackendPort{
+									Number: int32(8775),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return ingressRule
 }
 
 // OidcProxyService creates OidcProxy Service

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -406,15 +406,6 @@ func OidcProxyIngressHost(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, comp
 	return fmt.Sprintf("%s.%s", host, vmo.Spec.URI)
 }
 
-// OidcProxyIngressHost returns OIDC Proxy ingress host.
-func OidcProxyIngressHostES(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) string {
-	host := component.Name
-	if component.EndpointName != "" {
-		host = "elasticsearch"
-	}
-	return fmt.Sprintf("%s.%s", host, vmo.Spec.URI)
-}
-
 // CreateOidcProxy creates OpenID Connect (OIDC) proxy container and config Volume
 func CreateOidcProxy(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, vmoResources *vmcontrollerv1.Resources, component *config.ComponentDetails) ([]corev1.Volume, *corev1.Container) {
 	var volumes []corev1.Volume

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -407,10 +407,10 @@ func OidcProxyIngressHost(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, comp
 }
 
 // OidcProxyIngressHost returns OIDC Proxy ingress host.
-func OidcProxyIngressHostES(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) string {
+func OidcProxyIngressHostOS(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) string {
 	host := component.Name
 	if component.EndpointName != "" {
-		host = "elasticsearch"
+		host = "opensearch"
 	}
 	return fmt.Sprintf("%s.%s", host, vmo.Spec.URI)
 }

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -250,7 +250,7 @@ func getIngressRuleForESHost(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, c
 	}
 	pathType := netv1.PathTypeImplementationSpecific
 	serviceName := resources.AuthProxyMetaName()
-	ingressHostES := resources.OidcProxyIngressHostES(vmo, component)
+	ingressHostES := resources.OidcProxyIngressHost(vmo, component)
 	ingressRule := netv1.IngressRule{
 		Host: ingressHostES,
 		IngressRuleValue: netv1.IngressRuleValue{

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -167,7 +167,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 		if config.ElasticsearchIngest.OidcProxy != nil {
 			ingress := newOidcProxyIngress(vmo, &config.ElasticsearchIngest)
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
-			ingressES := newOidcProxyIngressES(vmo, &config.ElasticsearchIngest)
+			ingressES := newOidcProxyIngressOS(vmo, &config.ElasticsearchIngest)
 			ingresses = append(ingresses, ingress)
 			ingressES.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
 			ingresses = append(ingresses, ingressES)
@@ -296,14 +296,13 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 }
 
 // newOidcProxyIngress creates the Ingress of the OidcProxy
-func newOidcProxyIngressES(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) *netv1.Ingress {
+func newOidcProxyIngressOS(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) *netv1.Ingress {
 	port, err := strconv.ParseInt(resources.AuthProxyPort(), 10, 32)
 	if err != nil {
 		port = 8775
 	}
 	serviceName := resources.AuthProxyMetaName()
-	//ingressHost := resources.OidcProxyIngressHost(vmo, component)
-	ingressHost := resources.OidcProxyIngressHostES(vmo, component)
+	ingressHost := resources.OidcProxyIngressHostOS(vmo, component)
 	pathType := netv1.PathTypeImplementationSpecific
 	ingressClassName := getIngressClassName(vmo)
 	ingressRule := netv1.IngressRule{
@@ -352,7 +351,7 @@ func newOidcProxyIngressES(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, com
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations:     map[string]string{},
 			Labels:          resources.GetMetaLabels(vmo),
-			Name:            fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, "es-ingest"),
+			Name:            fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, "os-ingest"),
 			Namespace:       vmo.Namespace,
 			OwnerReferences: resources.GetOwnerReferences(vmo),
 		},
@@ -360,7 +359,7 @@ func newOidcProxyIngressES(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, com
 			TLS: []netv1.IngressTLS{
 				{
 					Hosts:      []string{ingressHost},
-					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, "es-ingest"),
+					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, "os-ingest"),
 				},
 			},
 			Rules:            []netv1.IngressRule{ingressRule},

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -167,6 +167,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 		if config.ElasticsearchIngest.OidcProxy != nil {
 			ingress := newOidcProxyIngress(vmo, &config.ElasticsearchIngest)
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
+			ingress.Annotations["nginx.ingress.kubernetes.io/server-alias"] = resources.OidcProxyIngressHostES(vmo, &config.ElasticsearchIngest)
 			ingresses = append(ingresses, ingress)
 		} else {
 			var ingress *netv1.Ingress
@@ -236,7 +237,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 			},
 		},
 	}
-	ingressRuleES := netv1.IngressRule{
+	/*ingressRuleES := netv1.IngressRule{
 		Host: ingressHostES,
 		IngressRuleValue: netv1.IngressRuleValue{
 			HTTP: &netv1.HTTPIngressRuleValue{
@@ -256,7 +257,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 				},
 			},
 		},
-	}
+	}*/
 	ingress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations:     map[string]string{},
@@ -272,7 +273,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
 				},
 			},
-			Rules:            []netv1.IngressRule{ingressRule, ingressRuleES},
+			Rules:            []netv1.IngressRule{ingressRule},
 			IngressClassName: &ingressClassName,
 		},
 	}

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -215,7 +215,6 @@ func setIngressTLSHostES(ingressHost string, ingressTLS []netv1.IngressTLS) []ne
 
 // getIngressRuleForESHost creates ingress rule
 func getIngressRuleForESHost(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) netv1.IngressRule {
-
 	port, err := strconv.ParseInt(resources.AuthProxyPort(), 10, 32)
 	if err != nil {
 		port = 8775

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -167,10 +167,10 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 		if config.ElasticsearchIngest.OidcProxy != nil {
 			ingress := newOidcProxyIngress(vmo, &config.ElasticsearchIngest)
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
-			ingressES := newOidcProxyIngressOS(vmo, &config.ElasticsearchIngest)
+			ingressOS := newOidcProxyIngress(vmo, &config.OpensearchIngest)
 			ingresses = append(ingresses, ingress)
-			ingressES.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
-			ingresses = append(ingresses, ingressES)
+			ingressOS.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
+			ingresses = append(ingresses, ingressOS)
 		} else {
 			var ingress *netv1.Ingress
 			ingRule := createIngressRuleElement(vmo, config.ElasticsearchIngest)
@@ -273,93 +273,6 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 				{
 					Hosts:      []string{ingressHost},
 					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
-				},
-			},
-			Rules:            []netv1.IngressRule{ingressRule},
-			IngressClassName: &ingressClassName,
-		},
-	}
-	ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = constants.NginxClientMaxBodySize
-	if len(vmo.Spec.IngressTargetDNSName) != 0 {
-		ingress.Annotations["external-dns.alpha.kubernetes.io/target"] = vmo.Spec.IngressTargetDNSName
-		ingress.Annotations["external-dns.alpha.kubernetes.io/ttl"] = strconv.Itoa(constants.ExternalDNSTTLSeconds)
-	}
-	if vmo.Spec.AutoSecret {
-		ingress.Annotations["kubernetes.io/tls-acme"] = "true"
-	} else {
-		ingress.Annotations["kubernetes.io/tls-acme"] = "false"
-	}
-	ingress.Annotations["nginx.ingress.kubernetes.io/rewrite-target"] = "/$2"
-	setNginxRoutingAnnotations(ingress)
-	ingress.Annotations["cert-manager.io/common-name"] = ingressHost
-	return ingress
-}
-
-// newOidcProxyIngress creates the Ingress of the OidcProxy
-func newOidcProxyIngressOS(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) *netv1.Ingress {
-	port, err := strconv.ParseInt(resources.AuthProxyPort(), 10, 32)
-	if err != nil {
-		port = 8775
-	}
-	serviceName := resources.AuthProxyMetaName()
-	ingressHost := resources.OidcProxyIngressHostOS(vmo, component)
-	pathType := netv1.PathTypeImplementationSpecific
-	ingressClassName := getIngressClassName(vmo)
-	ingressRule := netv1.IngressRule{
-		Host: ingressHost,
-		IngressRuleValue: netv1.IngressRuleValue{
-			HTTP: &netv1.HTTPIngressRuleValue{
-				Paths: []netv1.HTTPIngressPath{
-					{
-						Path:     "/()(.*)",
-						PathType: &pathType,
-						Backend: netv1.IngressBackend{
-							Service: &netv1.IngressServiceBackend{
-								Name: serviceName,
-								Port: netv1.ServiceBackendPort{
-									Number: int32(port),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	/*	ingressRuleES := netv1.IngressRule{
-		Host: ingressHostES,
-		IngressRuleValue: netv1.IngressRuleValue{
-			HTTP: &netv1.HTTPIngressRuleValue{
-				Paths: []netv1.HTTPIngressPath{
-					{
-						Path:     "/()(.*)",
-						PathType: &pathType,
-						Backend: netv1.IngressBackend{
-							Service: &netv1.IngressServiceBackend{
-								Name: serviceName,
-								Port: netv1.ServiceBackendPort{
-									Number: int32(port),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}*/
-	ingress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations:     map[string]string{},
-			Labels:          resources.GetMetaLabels(vmo),
-			Name:            fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, "os-ingest"),
-			Namespace:       vmo.Namespace,
-			OwnerReferences: resources.GetOwnerReferences(vmo),
-		},
-		Spec: netv1.IngressSpec{
-			TLS: []netv1.IngressTLS{
-				{
-					Hosts:      []string{ingressHost},
-					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, "os-ingest"),
 				},
 			},
 			Rules:            []netv1.IngressRule{ingressRule},

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -161,9 +161,9 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 			ingresses = append(ingresses, ingressOSD)
 		} else {
 			// Create Ingress Rule for Kibana Endpoint
-			ingRule := createIngressRuleElement(vmo, config.Kibana)
+			ingRule := createIngressRuleElement(vmo, config.OpenSearchDashboards)
 			host := config.Kibana.Name + "." + vmo.Spec.URI
-			healthLocations := noAuthOnHealthCheckSnippet(vmo, "", config.Kibana)
+			healthLocations := noAuthOnHealthCheckSnippet(vmo, "", config.OpenSearchDashboards)
 
 			ingress, err := createIngressElement(vmo, host, config.Kibana, ingRule, healthLocations)
 			if err != nil {

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -315,6 +315,7 @@ func getIngressClassName(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) strin
 	return defaultIngressClassName
 }
 
+// AddNewRuleAndHostTLSForIngress updates ingress with additional Rule and TLS Host
 func AddNewRuleAndHostTLSForIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, ingress *netv1.Ingress, componentDetails *config.ComponentDetails) *netv1.Ingress {
 	//Add ingress rule for ES
 	ingressRuleES := getIngressRuleForESHost(vmo, componentDetails)

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -169,6 +169,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
 			ingressES := newOidcProxyIngressES(vmo, &config.ElasticsearchIngest)
 			ingresses = append(ingresses, ingress)
+			ingressES.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
 			ingresses = append(ingresses, ingressES)
 		} else {
 			var ingress *netv1.Ingress
@@ -351,7 +352,7 @@ func newOidcProxyIngressES(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, com
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations:     map[string]string{},
 			Labels:          resources.GetMetaLabels(vmo),
-			Name:            fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, component.Name),
+			Name:            fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, "es-ingest"),
 			Namespace:       vmo.Namespace,
 			OwnerReferences: resources.GetOwnerReferences(vmo),
 		},
@@ -359,7 +360,7 @@ func newOidcProxyIngressES(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, com
 			TLS: []netv1.IngressTLS{
 				{
 					Hosts:      []string{ingressHost},
-					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
+					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, "es-ingest"),
 				},
 			},
 			Rules:            []netv1.IngressRule{ingressRule},

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -150,37 +150,16 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 	if vmo.Spec.Kibana.Enabled {
 		if config.Kibana.OidcProxy != nil {
 			ingressOSD := newOidcProxyIngress(vmo, &config.OpenSearchDashboards)
-
-			/*			//Add ingress rule for ES
-						ingressRuleOSD := getIngressRuleForESHost(vmo, &config.Kibana)
-						ingressRules := append(ingressOSD.Spec.Rules, ingressRuleOSD)
-						ingressOSD.Spec.Rules = ingressRules
-						//Add ES host to ingress tls
-						ingressHostES := resources.OidcProxyIngressHost(vmo, &config.Kibana)
-						ingressOSDTLS := setIngressTLSHostES(ingressHostES, ingressOSD.Spec.TLS)
-						ingressOSD.Spec.TLS = ingressOSDTLS
-			*/
 			ingresses = append(ingresses, ingressOSD)
 		} else {
 			// Create Ingress Rule for Kibana Endpoint
 			ingRule := createIngressRuleElement(vmo, config.OpenSearchDashboards)
 			host := config.Kibana.Name + "." + vmo.Spec.URI
 			healthLocations := noAuthOnHealthCheckSnippet(vmo, "", config.OpenSearchDashboards)
-
 			ingress, err := createIngressElement(vmo, host, config.Kibana, ingRule, healthLocations)
 			if err != nil {
 				return ingresses, err
 			}
-
-			/*			//Add ingress rule for ES
-						ingressRuleOSD := getIngressRuleForESHost(vmo, &config.Kibana)
-						ingressRules := append(ingress.Spec.Rules, ingressRuleOSD)
-						ingress.Spec.Rules = ingressRules
-						//Add ES host to ingress tls
-						ingressHostES := resources.OidcProxyIngressHost(vmo, &config.Kibana)
-						ingressOSDTLS := setIngressTLSHostES(ingressHostES, ingress.Spec.TLS)
-						ingress.Spec.TLS = ingressOSDTLS*/
-
 			ingresses = append(ingresses, ingress)
 		}
 	}
@@ -188,7 +167,6 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 		if config.ElasticsearchIngest.OidcProxy != nil {
 			ingress := newOidcProxyIngress(vmo, &config.OpensearchIngest)
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
-
 			ingresses = append(ingresses, ingress)
 		} else {
 			var ingress *netv1.Ingress
@@ -199,19 +177,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 			if err != nil {
 				return ingresses, err
 			}
-
-			/*			//Add ingress rule for ES
-						ingressRuleES := getIngressRuleForESHost(vmo, &config.ElasticsearchIngest)
-						ingressRules := append(ingress.Spec.Rules, ingressRuleES)
-						ingress.Spec.Rules = ingressRules
-						//Add ES host to ingress tls
-						ingressHostES := resources.OidcProxyIngressHost(vmo, &config.ElasticsearchIngest)
-						ingressTLS := setIngressTLSHostES(ingressHostES, ingress.Spec.TLS)
-						ingress.Spec.TLS = ingressTLS
-			*/
-
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] = constants.NginxProxyReadTimeoutForKibana
-
 			ingresses = append(ingresses, ingress)
 		}
 

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -167,7 +167,6 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 		if config.ElasticsearchIngest.OidcProxy != nil {
 			ingress := newOidcProxyIngress(vmo, &config.ElasticsearchIngest)
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
-			ingress.Annotations["nginx.ingress.kubernetes.io/server-alias"] = resources.OidcProxyIngressHostES(vmo, &config.ElasticsearchIngest)
 			ingresses = append(ingresses, ingress)
 		} else {
 			var ingress *netv1.Ingress
@@ -237,7 +236,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 			},
 		},
 	}
-	/*ingressRuleES := netv1.IngressRule{
+	ingressRuleES := netv1.IngressRule{
 		Host: ingressHostES,
 		IngressRuleValue: netv1.IngressRuleValue{
 			HTTP: &netv1.HTTPIngressRuleValue{
@@ -257,7 +256,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 				},
 			},
 		},
-	}*/
+	}
 	ingress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations:     map[string]string{},
@@ -273,7 +272,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
 				},
 			},
-			Rules:            []netv1.IngressRule{ingressRule},
+			Rules:            []netv1.IngressRule{ingressRule, ingressRuleES},
 			IngressClassName: &ingressClassName,
 		},
 	}

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -268,11 +268,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 		Spec: netv1.IngressSpec{
 			TLS: []netv1.IngressTLS{
 				{
-					Hosts:      []string{ingressHost},
-					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
-				},
-				{
-					Hosts:      []string{ingressHostES},
+					Hosts:      []string{ingressHost, ingressHostES},
 					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
 				},
 			},

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -172,7 +172,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 			ingressRules := append(ingress.Spec.Rules, ingressRuleES)
 			ingress.Spec.Rules = ingressRules
 			//Add ES host to ingress tls
-			ingressHostES := resources.OidcProxyIngressHost(vmo, &config.OpensearchIngest)
+			ingressHostES := resources.OidcProxyIngressHost(vmo, &config.ElasticsearchIngest)
 			ingressTLS := setIngressTLSHostES(ingressHostES, ingress.Spec.TLS)
 			ingress.Spec.TLS = ingressTLS
 			ingresses = append(ingresses, ingress)

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -235,27 +235,6 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 			},
 		},
 	}
-	ingressESRule := netv1.IngressRule{
-		Host: resources.OidcProxyIngressHostES(vmo, component),
-		IngressRuleValue: netv1.IngressRuleValue{
-			HTTP: &netv1.HTTPIngressRuleValue{
-				Paths: []netv1.HTTPIngressPath{
-					{
-						Path:     "/()(.*)",
-						PathType: &pathType,
-						Backend: netv1.IngressBackend{
-							Service: &netv1.IngressServiceBackend{
-								Name: serviceName,
-								Port: netv1.ServiceBackendPort{
-									Number: int32(port),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 	ingress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations:     map[string]string{},
@@ -270,12 +249,8 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 					Hosts:      []string{ingressHost},
 					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
 				},
-				{
-					Hosts:      []string{resources.OidcProxyIngressHostES(vmo, component)},
-					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
-				},
 			},
-			Rules:            []netv1.IngressRule{ingressRule, ingressESRule},
+			Rules:            []netv1.IngressRule{ingressRule},
 			IngressClassName: &ingressClassName,
 		},
 	}

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -167,10 +167,10 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 		if config.ElasticsearchIngest.OidcProxy != nil {
 			ingress := newOidcProxyIngress(vmo, &config.ElasticsearchIngest)
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
-			ingressOS := newOidcProxyIngress(vmo, &config.OpensearchIngest)
+			//ingressOS := newOidcProxyIngress(vmo, &config.OpensearchIngest)
 			ingresses = append(ingresses, ingress)
-			ingressOS.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
-			ingresses = append(ingresses, ingressOS)
+			//ingressOS.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
+			//ingresses = append(ingresses, ingressOS)
 		} else {
 			var ingress *netv1.Ingress
 			ingRule := createIngressRuleElement(vmo, config.ElasticsearchIngest)
@@ -215,7 +215,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 	}
 	serviceName := resources.AuthProxyMetaName()
 	ingressHost := resources.OidcProxyIngressHost(vmo, component)
-	//ingressHostES := resources.OidcProxyIngressHostES(vmo, component)
+	ingressHostES := resources.OidcProxyIngressHostOS(vmo, component)
 	pathType := netv1.PathTypeImplementationSpecific
 	ingressClassName := getIngressClassName(vmo)
 	ingressRule := netv1.IngressRule{
@@ -239,7 +239,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 			},
 		},
 	}
-	/*	ingressRuleES := netv1.IngressRule{
+	ingressRuleES := netv1.IngressRule{
 		Host: ingressHostES,
 		IngressRuleValue: netv1.IngressRuleValue{
 			HTTP: &netv1.HTTPIngressRuleValue{
@@ -259,7 +259,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 				},
 			},
 		},
-	}*/
+	}
 	ingress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations:     map[string]string{},
@@ -271,11 +271,11 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 		Spec: netv1.IngressSpec{
 			TLS: []netv1.IngressTLS{
 				{
-					Hosts:      []string{ingressHost},
+					Hosts:      []string{ingressHost, ingressHostES},
 					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
 				},
 			},
-			Rules:            []netv1.IngressRule{ingressRule},
+			Rules:            []netv1.IngressRule{ingressRule, ingressRuleES},
 			IngressClassName: &ingressClassName,
 		},
 	}

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -235,6 +235,27 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 			},
 		},
 	}
+	ingressESRule := netv1.IngressRule{
+		Host: resources.OidcProxyIngressHostES(vmo, component),
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
+					{
+						Path:     "/()(.*)",
+						PathType: &pathType,
+						Backend: netv1.IngressBackend{
+							Service: &netv1.IngressServiceBackend{
+								Name: serviceName,
+								Port: netv1.ServiceBackendPort{
+									Number: int32(port),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	ingress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations:     map[string]string{},
@@ -249,8 +270,12 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 					Hosts:      []string{ingressHost},
 					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
 				},
+				{
+					Hosts:      []string{resources.OidcProxyIngressHostES(vmo, component)},
+					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, component.Name),
+				},
 			},
-			Rules:            []netv1.IngressRule{ingressRule},
+			Rules:            []netv1.IngressRule{ingressRule, ingressESRule},
 			IngressClassName: &ingressClassName,
 		},
 	}

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -150,14 +150,16 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 	if vmo.Spec.Kibana.Enabled {
 		if config.Kibana.OidcProxy != nil {
 			ingressOSD := newOidcProxyIngress(vmo, &config.OpenSearchDashboards)
-			//Add ingress rule for ES
-			ingressRuleOSD := getIngressRuleForESHost(vmo, &config.Kibana)
-			ingressRules := append(ingressOSD.Spec.Rules, ingressRuleOSD)
-			ingressOSD.Spec.Rules = ingressRules
-			//Add ES host to ingress tls
-			ingressHostES := resources.OidcProxyIngressHost(vmo, &config.Kibana)
-			ingressOSDTLS := setIngressTLSHostES(ingressHostES, ingressOSD.Spec.TLS)
-			ingressOSD.Spec.TLS = ingressOSDTLS
+
+			/*			//Add ingress rule for ES
+						ingressRuleOSD := getIngressRuleForESHost(vmo, &config.Kibana)
+						ingressRules := append(ingressOSD.Spec.Rules, ingressRuleOSD)
+						ingressOSD.Spec.Rules = ingressRules
+						//Add ES host to ingress tls
+						ingressHostES := resources.OidcProxyIngressHost(vmo, &config.Kibana)
+						ingressOSDTLS := setIngressTLSHostES(ingressHostES, ingressOSD.Spec.TLS)
+						ingressOSD.Spec.TLS = ingressOSDTLS
+			*/
 			ingresses = append(ingresses, ingressOSD)
 		} else {
 			// Create Ingress Rule for Kibana Endpoint
@@ -169,14 +171,16 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 			if err != nil {
 				return ingresses, err
 			}
-			//Add ingress rule for ES
-			ingressRuleOSD := getIngressRuleForESHost(vmo, &config.Kibana)
-			ingressRules := append(ingress.Spec.Rules, ingressRuleOSD)
-			ingress.Spec.Rules = ingressRules
-			//Add ES host to ingress tls
-			ingressHostES := resources.OidcProxyIngressHost(vmo, &config.Kibana)
-			ingressOSDTLS := setIngressTLSHostES(ingressHostES, ingress.Spec.TLS)
-			ingress.Spec.TLS = ingressOSDTLS
+
+			/*			//Add ingress rule for ES
+						ingressRuleOSD := getIngressRuleForESHost(vmo, &config.Kibana)
+						ingressRules := append(ingress.Spec.Rules, ingressRuleOSD)
+						ingress.Spec.Rules = ingressRules
+						//Add ES host to ingress tls
+						ingressHostES := resources.OidcProxyIngressHost(vmo, &config.Kibana)
+						ingressOSDTLS := setIngressTLSHostES(ingressHostES, ingress.Spec.TLS)
+						ingress.Spec.TLS = ingressOSDTLS*/
+
 			ingresses = append(ingresses, ingress)
 		}
 	}
@@ -184,14 +188,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 		if config.ElasticsearchIngest.OidcProxy != nil {
 			ingress := newOidcProxyIngress(vmo, &config.OpensearchIngest)
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "65M"
-			//Add ingress rule for ES
-			ingressRuleES := getIngressRuleForESHost(vmo, &config.ElasticsearchIngest)
-			ingressRules := append(ingress.Spec.Rules, ingressRuleES)
-			ingress.Spec.Rules = ingressRules
-			//Add ES host to ingress tls
-			ingressHostES := resources.OidcProxyIngressHost(vmo, &config.ElasticsearchIngest)
-			ingressTLS := setIngressTLSHostES(ingressHostES, ingress.Spec.TLS)
-			ingress.Spec.TLS = ingressTLS
+
 			ingresses = append(ingresses, ingress)
 		} else {
 			var ingress *netv1.Ingress
@@ -202,15 +199,19 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 			if err != nil {
 				return ingresses, err
 			}
-			//Add ingress rule for ES
-			ingressRuleES := getIngressRuleForESHost(vmo, &config.ElasticsearchIngest)
-			ingressRules := append(ingress.Spec.Rules, ingressRuleES)
-			ingress.Spec.Rules = ingressRules
-			//Add ES host to ingress tls
-			ingressHostES := resources.OidcProxyIngressHost(vmo, &config.ElasticsearchIngest)
-			ingressTLS := setIngressTLSHostES(ingressHostES, ingress.Spec.TLS)
-			ingress.Spec.TLS = ingressTLS
+
+			/*			//Add ingress rule for ES
+						ingressRuleES := getIngressRuleForESHost(vmo, &config.ElasticsearchIngest)
+						ingressRules := append(ingress.Spec.Rules, ingressRuleES)
+						ingress.Spec.Rules = ingressRules
+						//Add ES host to ingress tls
+						ingressHostES := resources.OidcProxyIngressHost(vmo, &config.ElasticsearchIngest)
+						ingressTLS := setIngressTLSHostES(ingressHostES, ingress.Spec.TLS)
+						ingress.Spec.TLS = ingressTLS
+			*/
+
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] = constants.NginxProxyReadTimeoutForKibana
+
 			ingresses = append(ingresses, ingress)
 		}
 
@@ -347,4 +348,17 @@ func getIngressClassName(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) strin
 		return *vmi.Spec.IngressClassName
 	}
 	return defaultIngressClassName
+}
+
+func AddNewRuleAndHostTLSForIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, ingress *netv1.Ingress, componentDetails *config.ComponentDetails) *netv1.Ingress {
+
+	//Add ingress rule for ES
+	ingressRuleES := getIngressRuleForESHost(vmo, componentDetails)
+	ingressRules := append(ingress.Spec.Rules, ingressRuleES)
+	ingress.Spec.Rules = ingressRules
+	//Add ES host to ingress tls
+	ingressHostES := resources.OidcProxyIngressHost(vmo, componentDetails)
+	ingressTLS := setIngressTLSHostES(ingressHostES, ingress.Spec.TLS)
+	ingress.Spec.TLS = ingressTLS
+	return ingress
 }

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -207,11 +207,13 @@ func noAuthOnHealthCheckSnippet(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance
 `
 }
 
+// setIngressTLSHostES updates ingress with additional host
 func setIngressTLSHostES(ingressHost string, ingressTLS []netv1.IngressTLS) []netv1.IngressTLS {
 	ingressTLS[0].Hosts = append(ingressTLS[0].Hosts, ingressHost)
 	return ingressTLS
 }
 
+// getIngressRuleForESHost creates ingress rule
 func getIngressRuleForESHost(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, component *config.ComponentDetails) netv1.IngressRule {
 
 	port, err := strconv.ParseInt(resources.AuthProxyPort(), 10, 32)

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -350,7 +350,6 @@ func getIngressClassName(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) strin
 }
 
 func AddNewRuleAndHostTLSForIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, ingress *netv1.Ingress, componentDetails *config.ComponentDetails) *netv1.Ingress {
-
 	//Add ingress rule for ES
 	ingressRuleES := getIngressRuleForESHost(vmo, componentDetails)
 	ingressRules := append(ingress.Spec.Rules, ingressRuleES)

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -343,6 +343,9 @@ func DoesIngressContainDeprecatedESHost(ingress *netv1.Ingress, vmo *vmcontrolle
 }
 
 // addDeprecatedHostsIfNecessary updates new ingress objects with deprecated hosts if required
+// For upgrade check, if the user has deprecated Elasticsearch/Kibana ingress
+// Then update the new opensearch/opensearchdashboards ingress with additional Elasticsearch/Kibana rule and hosts
+// To support access to the deprecated Elasticsearch/Kibana URL and this scenario is only for upgrade.
 func addDeprecatedHostsIfNecessary(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, existingIngresses map[string]*netv1.Ingress, newIngressObject *netv1.Ingress, deprecatedIngressComponent *config.ComponentDetails, component *config.ComponentDetails) *netv1.Ingress {
 
 	// If the existing ingress with deprecated component name exists then update a new ingress object with deprecated Rule and TLS host

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -169,6 +169,14 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 			if err != nil {
 				return ingresses, err
 			}
+			//Add ingress rule for ES
+			ingressRuleOSD := getIngressRuleForESHost(vmo, &config.Kibana)
+			ingressRules := append(ingress.Spec.Rules, ingressRuleOSD)
+			ingress.Spec.Rules = ingressRules
+			//Add ES host to ingress tls
+			ingressHostES := resources.OidcProxyIngressHost(vmo, &config.Kibana)
+			ingressOSDTLS := setIngressTLSHostES(ingressHostES, ingress.Spec.TLS)
+			ingress.Spec.TLS = ingressOSDTLS
 			ingresses = append(ingresses, ingress)
 		}
 	}
@@ -194,6 +202,14 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) ([]*netv1.Ingress, er
 			if err != nil {
 				return ingresses, err
 			}
+			//Add ingress rule for ES
+			ingressRuleES := getIngressRuleForESHost(vmo, &config.ElasticsearchIngest)
+			ingressRules := append(ingress.Spec.Rules, ingressRuleES)
+			ingress.Spec.Rules = ingressRules
+			//Add ES host to ingress tls
+			ingressHostES := resources.OidcProxyIngressHost(vmo, &config.ElasticsearchIngest)
+			ingressTLS := setIngressTLSHostES(ingressHostES, ingress.Spec.TLS)
+			ingress.Spec.TLS = ingressTLS
 			ingress.Annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] = constants.NginxProxyReadTimeoutForKibana
 			ingresses = append(ingresses, ingress)
 		}

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -238,8 +238,7 @@ func noAuthOnHealthCheckSnippet(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance
 }
 
 func setIngressTLSHostES(ingressHost string, ingressTLS []netv1.IngressTLS) []netv1.IngressTLS {
-	hosts := append(ingressTLS[0].Hosts, ingressHost)
-	ingressTLS[0].Hosts = hosts
+	ingressTLS[0].Hosts = append(ingressTLS[0].Hosts, ingressHost)
 	return ingressTLS
 }
 

--- a/pkg/resources/ingresses/ingress_test.go
+++ b/pkg/resources/ingresses/ingress_test.go
@@ -82,7 +82,10 @@ func TestVMOWithIngresses(t *testing.T) {
 	assert.Equal(t, getIngressClassName(vmo), *ingresses[0].Spec.IngressClassName)
 }
 
-func TestIngressesWithDeprecatedHosts(t *testing.T) {
+// TestIngressesToAddDeprecatedHosts updates the new OS and OSD ingresses
+// With the rules and hosts of deprecated ES and Kibana ingresses.
+// Tests VPO Upgrade scenario
+func TestIngressesToAddDeprecatedHosts(t *testing.T) {
 	const vmiName = "system"
 	vmo := &vmcontrollerv1.VerrazzanoMonitoringInstance{
 		Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
@@ -168,6 +171,165 @@ func TestIngressesWithDeprecatedHosts(t *testing.T) {
 				},
 			},
 			Rules: []netv1.IngressRule{ingressKibanaRule},
+		}}
+	existingIngress[resources.GetMetaName("system", config.Kibana.Name)] = deprecatedKibanaIngress
+	ingresses, err := New(vmo, existingIngress)
+	if err != nil {
+		t.Error(err)
+	}
+
+	fmt.Println(ingresses[1].Spec.Rules[0].Host)
+	assert.Equal(t, 2, len(ingresses[2].Spec.Rules), "Length of Opensearch Ingress Rules")
+	assert.Equal(t, 2, len(ingresses[2].Spec.Rules), "Length of Opendashboards Ingress Rules")
+	assert.Equal(t, "api.example.com", ingresses[0].Spec.TLS[0].Hosts[0], "TLS hosts")
+	assert.Equal(t, "kibana.example.com", ingresses[1].Spec.TLS[0].Hosts[1], "TLS hosts")
+	assert.Equal(t, "opensearchdashboards.example.com", ingresses[1].Spec.TLS[0].Hosts[0], "Deprecated TLS host")
+	assert.Equal(t, "opensearch.example.com", ingresses[2].Spec.TLS[0].Hosts[0], "TLS hosts")
+	assert.Equal(t, "elasticsearch.example.com", ingresses[2].Spec.TLS[0].Hosts[1], "Deprecated TLS host")
+	assert.Equal(t, 3, len(ingresses), "Length of generated Ingresses")
+	assert.Equal(t, 1, len(ingresses[0].Spec.TLS), "Number of TLS elements in generated Ingress")
+	assert.Equal(t, 1, len(ingresses[0].Spec.TLS[0].Hosts), "Number of hosts in generated Ingress")
+	assert.Equal(t, vmiName+"-tls-api", ingresses[0].Spec.TLS[0].SecretName, "TLS secret")
+	assert.Equal(t, vmiName+"-tls-os-ingest", ingresses[2].Spec.TLS[0].SecretName, "TLS secret")
+	assert.Equal(t, "basic", ingresses[0].Annotations["nginx.ingress.kubernetes.io/auth-type"], "Auth type")
+	assert.Equal(t, "secret", ingresses[0].Annotations["nginx.ingress.kubernetes.io/auth-secret"], "Auth secret")
+	assert.Equal(t, "example.com auth", ingresses[0].Annotations["nginx.ingress.kubernetes.io/auth-realm"], "Auth realm")
+	assert.Equal(t, "true", ingresses[0].Annotations["nginx.ingress.kubernetes.io/service-upstream"], "Service upstream")
+	assert.Equal(t, "${service_name}.${namespace}.svc.cluster.local", ingresses[0].Annotations["nginx.ingress.kubernetes.io/upstream-vhost"], "Upstream vhost")
+	assert.Equal(t, "api.example.com", ingresses[0].Annotations["cert-manager.io/common-name"], "TLS cert CN")
+	assert.Equal(t, "opensearch.example.com", ingresses[2].Annotations["cert-manager.io/common-name"], "TLS cert CN")
+	assert.Equal(t, getIngressClassName(vmo), *ingresses[0].Spec.IngressClassName)
+}
+
+// TestIngressesToPreserveAdditionalDeprecatedHosts tests reconcile with the existing OS and OSD ingresses
+// And preserves the existing ES and Kibana ingress rules/hosts in OS/OSD ingress during upgrade.
+// Tests VPO Upgrade scenario
+func TestIngressesToPreserveAdditionalDeprecatedHosts(t *testing.T) {
+	const vmiName = "system"
+	vmo := &vmcontrollerv1.VerrazzanoMonitoringInstance{
+		Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
+			SecretName: "secret",
+			URI:        "example.com",
+			Kibana: vmcontrollerv1.Kibana{
+				Enabled: true,
+			},
+			Elasticsearch: vmcontrollerv1.Elasticsearch{
+				Enabled: true,
+			},
+		},
+	}
+	vmo.Name = vmiName
+	ingressESHost := resources.OidcProxyIngressHost(vmo, &config.ElasticsearchIngest)
+	ingressESRule := netv1.IngressRule{
+		Host: ingressESHost,
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
+					{
+						Path: "/()(.*)",
+						Backend: netv1.IngressBackend{
+							Service: &netv1.IngressServiceBackend{
+								Port: netv1.ServiceBackendPort{
+									Number: int32(8775),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ingressOSHost := resources.OidcProxyIngressHost(vmo, &config.OpensearchIngest)
+	ingressOSRule := netv1.IngressRule{
+		Host: ingressOSHost,
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
+					{
+						Path: "/()(.*)",
+						Backend: netv1.IngressBackend{
+							Service: &netv1.IngressServiceBackend{
+								Port: netv1.ServiceBackendPort{
+									Number: int32(8775),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	deprecatedESIngress := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, config.ElasticsearchIngest.Name),
+			Namespace: vmo.Namespace,
+		},
+		Spec: netv1.IngressSpec{
+			TLS: []netv1.IngressTLS{
+				{
+					Hosts:      []string{ingressESHost, ingressOSHost},
+					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, config.ElasticsearchIngest.Name),
+				},
+			},
+			Rules: []netv1.IngressRule{ingressESRule, ingressOSRule},
+		}}
+
+	existingIngress := make(map[string]*netv1.Ingress)
+	existingIngress[resources.GetMetaName("system", config.ElasticsearchIngest.Name)] = deprecatedESIngress
+
+	ingressKibanaHost := resources.OidcProxyIngressHost(vmo, &config.Kibana)
+	ingressKibanaRule := netv1.IngressRule{
+		Host: ingressKibanaHost,
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
+					{
+						Path: "/()(.*)",
+						Backend: netv1.IngressBackend{
+							Service: &netv1.IngressServiceBackend{
+								Port: netv1.ServiceBackendPort{
+									Number: int32(8775),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ingressOSDHost := resources.OidcProxyIngressHost(vmo, &config.OpenSearchDashboards)
+	ingressOSDRule := netv1.IngressRule{
+		Host: ingressOSDHost,
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
+					{
+						Path: "/()(.*)",
+						Backend: netv1.IngressBackend{
+							Service: &netv1.IngressServiceBackend{
+								Port: netv1.ServiceBackendPort{
+									Number: int32(8775),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	deprecatedKibanaIngress := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, config.Kibana.Name),
+			Namespace: vmo.Namespace,
+		},
+		Spec: netv1.IngressSpec{
+			TLS: []netv1.IngressTLS{
+				{
+					Hosts:      []string{ingressKibanaHost, ingressOSDHost},
+					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, config.Kibana.Name),
+				},
+			},
+			Rules: []netv1.IngressRule{ingressKibanaRule, ingressOSDRule},
 		}}
 	existingIngress[resources.GetMetaName("system", config.Kibana.Name)] = deprecatedKibanaIngress
 	ingresses, err := New(vmo, existingIngress)

--- a/pkg/resources/ingresses/ingress_test.go
+++ b/pkg/resources/ingresses/ingress_test.go
@@ -61,10 +61,10 @@ func TestVMOWithIngresses(t *testing.T) {
 	assert.Equal(t, 1, len(ingresses[0].Spec.TLS[0].Hosts), "Number of hosts in generated Ingress")
 	assert.Equal(t, "api.example.com", ingresses[0].Spec.TLS[0].Hosts[0], "TLS hosts")
 	assert.Equal(t, "grafana.example.com", ingresses[1].Spec.TLS[0].Hosts[0], "TLS hosts")
-	assert.Equal(t, "elasticsearch.example.com", ingresses[2].Spec.TLS[0].Hosts[0], "TLS hosts")
+	assert.Equal(t, "opensearch.example.com", ingresses[2].Spec.TLS[0].Hosts[0], "TLS hosts")
 	assert.Equal(t, vmiName+"-tls-api", ingresses[0].Spec.TLS[0].SecretName, "TLS secret")
 	assert.Equal(t, vmiName+"-tls-grafana", ingresses[1].Spec.TLS[0].SecretName, "TLS secret")
-	assert.Equal(t, vmiName+"-tls-es-ingest", ingresses[2].Spec.TLS[0].SecretName, "TLS secret")
+	assert.Equal(t, vmiName+"-tls-os-ingest", ingresses[2].Spec.TLS[0].SecretName, "TLS secret")
 	assert.Equal(t, "basic", ingresses[0].Annotations["nginx.ingress.kubernetes.io/auth-type"], "Auth type")
 	assert.Equal(t, "secret", ingresses[0].Annotations["nginx.ingress.kubernetes.io/auth-secret"], "Auth secret")
 	assert.Equal(t, "example.com auth", ingresses[0].Annotations["nginx.ingress.kubernetes.io/auth-realm"], "Auth realm")
@@ -72,7 +72,7 @@ func TestVMOWithIngresses(t *testing.T) {
 	assert.Equal(t, "${service_name}.${namespace}.svc.cluster.local", ingresses[0].Annotations["nginx.ingress.kubernetes.io/upstream-vhost"], "Upstream vhost")
 	assert.Equal(t, "api.example.com", ingresses[0].Annotations["cert-manager.io/common-name"], "TLS cert CN")
 	assert.Equal(t, "grafana.example.com", ingresses[1].Annotations["cert-manager.io/common-name"], "TLS cert CN")
-	assert.Equal(t, "elasticsearch.example.com", ingresses[2].Annotations["cert-manager.io/common-name"], "TLS cert CN")
+	assert.Equal(t, "opensearch.example.com", ingresses[2].Annotations["cert-manager.io/common-name"], "TLS cert CN")
 	assert.Equal(t, getIngressClassName(vmo), *ingresses[0].Spec.IngressClassName)
 }
 

--- a/pkg/resources/ingresses/ingress_test.go
+++ b/pkg/resources/ingresses/ingress_test.go
@@ -101,25 +101,7 @@ func TestIngressesToAddDeprecatedHosts(t *testing.T) {
 	}
 	vmo.Name = vmiName
 	ingressESHost := resources.OidcProxyIngressHost(vmo, &config.ElasticsearchIngest)
-	ingressESRule := netv1.IngressRule{
-		Host: ingressESHost,
-		IngressRuleValue: netv1.IngressRuleValue{
-			HTTP: &netv1.HTTPIngressRuleValue{
-				Paths: []netv1.HTTPIngressPath{
-					{
-						Path: "/()(.*)",
-						Backend: netv1.IngressBackend{
-							Service: &netv1.IngressServiceBackend{
-								Port: netv1.ServiceBackendPort{
-									Number: int32(8775),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	ingressESRule := resources.GetIngressRule(ingressESHost)
 	deprecatedESIngress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, config.ElasticsearchIngest.Name),
@@ -139,25 +121,7 @@ func TestIngressesToAddDeprecatedHosts(t *testing.T) {
 	existingIngress[resources.GetMetaName("system", config.ElasticsearchIngest.Name)] = deprecatedESIngress
 
 	ingressKibanaHost := resources.OidcProxyIngressHost(vmo, &config.Kibana)
-	ingressKibanaRule := netv1.IngressRule{
-		Host: ingressKibanaHost,
-		IngressRuleValue: netv1.IngressRuleValue{
-			HTTP: &netv1.HTTPIngressRuleValue{
-				Paths: []netv1.HTTPIngressPath{
-					{
-						Path: "/()(.*)",
-						Backend: netv1.IngressBackend{
-							Service: &netv1.IngressServiceBackend{
-								Port: netv1.ServiceBackendPort{
-									Number: int32(8775),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	ingressKibanaRule := resources.GetIngressRule(ingressKibanaHost)
 	deprecatedKibanaIngress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, config.Kibana.Name),
@@ -220,45 +184,9 @@ func TestIngressesToPreserveAdditionalDeprecatedHosts(t *testing.T) {
 	}
 	vmo.Name = vmiName
 	ingressESHost := resources.OidcProxyIngressHost(vmo, &config.ElasticsearchIngest)
-	ingressESRule := netv1.IngressRule{
-		Host: ingressESHost,
-		IngressRuleValue: netv1.IngressRuleValue{
-			HTTP: &netv1.HTTPIngressRuleValue{
-				Paths: []netv1.HTTPIngressPath{
-					{
-						Path: "/()(.*)",
-						Backend: netv1.IngressBackend{
-							Service: &netv1.IngressServiceBackend{
-								Port: netv1.ServiceBackendPort{
-									Number: int32(8775),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	ingressESRule := resources.GetIngressRule(ingressESHost)
 	ingressOSHost := resources.OidcProxyIngressHost(vmo, &config.OpensearchIngest)
-	ingressOSRule := netv1.IngressRule{
-		Host: ingressOSHost,
-		IngressRuleValue: netv1.IngressRuleValue{
-			HTTP: &netv1.HTTPIngressRuleValue{
-				Paths: []netv1.HTTPIngressPath{
-					{
-						Path: "/()(.*)",
-						Backend: netv1.IngressBackend{
-							Service: &netv1.IngressServiceBackend{
-								Port: netv1.ServiceBackendPort{
-									Number: int32(8775),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	ingressOSRule := resources.GetIngressRule(ingressOSHost)
 	deprecatedESIngress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, config.ElasticsearchIngest.Name),
@@ -278,45 +206,9 @@ func TestIngressesToPreserveAdditionalDeprecatedHosts(t *testing.T) {
 	existingIngress[resources.GetMetaName("system", config.ElasticsearchIngest.Name)] = deprecatedESIngress
 
 	ingressKibanaHost := resources.OidcProxyIngressHost(vmo, &config.Kibana)
-	ingressKibanaRule := netv1.IngressRule{
-		Host: ingressKibanaHost,
-		IngressRuleValue: netv1.IngressRuleValue{
-			HTTP: &netv1.HTTPIngressRuleValue{
-				Paths: []netv1.HTTPIngressPath{
-					{
-						Path: "/()(.*)",
-						Backend: netv1.IngressBackend{
-							Service: &netv1.IngressServiceBackend{
-								Port: netv1.ServiceBackendPort{
-									Number: int32(8775),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	ingressKibanaRule := resources.GetIngressRule(ingressKibanaHost)
 	ingressOSDHost := resources.OidcProxyIngressHost(vmo, &config.OpenSearchDashboards)
-	ingressOSDRule := netv1.IngressRule{
-		Host: ingressOSDHost,
-		IngressRuleValue: netv1.IngressRuleValue{
-			HTTP: &netv1.HTTPIngressRuleValue{
-				Paths: []netv1.HTTPIngressPath{
-					{
-						Path: "/()(.*)",
-						Backend: netv1.IngressBackend{
-							Service: &netv1.IngressServiceBackend{
-								Port: netv1.ServiceBackendPort{
-									Number: int32(8775),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	ingressOSDRule := resources.GetIngressRule(ingressOSDHost)
 	deprecatedKibanaIngress := &netv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, config.Kibana.Name),

--- a/pkg/resources/ingresses/ingress_test.go
+++ b/pkg/resources/ingresses/ingress_test.go
@@ -4,6 +4,7 @@
 package ingresses
 
 import (
+	netv1 "k8s.io/api/networking/v1"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,7 @@ func TestVMONoIngress(t *testing.T) {
 			},
 		},
 	}
-	ingresses, err := New(vmo)
+	ingresses, err := New(vmo, map[string]*netv1.Ingress{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -52,7 +53,7 @@ func TestVMOWithIngresses(t *testing.T) {
 		},
 	}
 	vmo.Name = vmiName
-	ingresses, err := New(vmo)
+	ingresses, err := New(vmo, map[string]*netv1.Ingress{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -111,7 +112,8 @@ func TestVMOWithCascadingDelete(t *testing.T) {
 			},
 		},
 	}
-	ingresses, err := New(vmo)
+
+	ingresses, err := New(vmo, map[string]*netv1.Ingress{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -122,7 +124,7 @@ func TestVMOWithCascadingDelete(t *testing.T) {
 
 	// Without CascadingDelete
 	vmo.Spec.CascadingDelete = false
-	ingresses, err = New(vmo)
+	ingresses, err = New(vmo, map[string]*netv1.Ingress{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/resources/ingresses/ingress_test.go
+++ b/pkg/resources/ingresses/ingress_test.go
@@ -4,7 +4,12 @@
 package ingresses
 
 import (
+	"fmt"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,6 +78,122 @@ func TestVMOWithIngresses(t *testing.T) {
 	assert.Equal(t, "${service_name}.${namespace}.svc.cluster.local", ingresses[0].Annotations["nginx.ingress.kubernetes.io/upstream-vhost"], "Upstream vhost")
 	assert.Equal(t, "api.example.com", ingresses[0].Annotations["cert-manager.io/common-name"], "TLS cert CN")
 	assert.Equal(t, "grafana.example.com", ingresses[1].Annotations["cert-manager.io/common-name"], "TLS cert CN")
+	assert.Equal(t, "opensearch.example.com", ingresses[2].Annotations["cert-manager.io/common-name"], "TLS cert CN")
+	assert.Equal(t, getIngressClassName(vmo), *ingresses[0].Spec.IngressClassName)
+}
+
+func TestIngressesWithDeprecatedHosts(t *testing.T) {
+	const vmiName = "system"
+	vmo := &vmcontrollerv1.VerrazzanoMonitoringInstance{
+		Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
+			SecretName: "secret",
+			URI:        "example.com",
+			Kibana: vmcontrollerv1.Kibana{
+				Enabled: true,
+			},
+			Elasticsearch: vmcontrollerv1.Elasticsearch{
+				Enabled: true,
+			},
+		},
+	}
+	vmo.Name = vmiName
+	ingressESHost := resources.OidcProxyIngressHost(vmo, &config.ElasticsearchIngest)
+	ingressESRule := netv1.IngressRule{
+		Host: ingressESHost,
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
+					{
+						Path: "/()(.*)",
+						Backend: netv1.IngressBackend{
+							Service: &netv1.IngressServiceBackend{
+								Port: netv1.ServiceBackendPort{
+									Number: int32(8775),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	deprecatedESIngress := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, config.ElasticsearchIngest.Name),
+			Namespace: vmo.Namespace,
+		},
+		Spec: netv1.IngressSpec{
+			TLS: []netv1.IngressTLS{
+				{
+					Hosts:      []string{ingressESHost},
+					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, config.ElasticsearchIngest.Name),
+				},
+			},
+			Rules: []netv1.IngressRule{ingressESRule},
+		}}
+
+	existingIngress := make(map[string]*netv1.Ingress)
+	existingIngress[resources.GetMetaName("system", config.ElasticsearchIngest.Name)] = deprecatedESIngress
+
+	ingressKibanaHost := resources.OidcProxyIngressHost(vmo, &config.Kibana)
+	ingressKibanaRule := netv1.IngressRule{
+		Host: ingressKibanaHost,
+		IngressRuleValue: netv1.IngressRuleValue{
+			HTTP: &netv1.HTTPIngressRuleValue{
+				Paths: []netv1.HTTPIngressPath{
+					{
+						Path: "/()(.*)",
+						Backend: netv1.IngressBackend{
+							Service: &netv1.IngressServiceBackend{
+								Port: netv1.ServiceBackendPort{
+									Number: int32(8775),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	deprecatedKibanaIngress := &netv1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s%s-%s", constants.VMOServiceNamePrefix, vmo.Name, config.Kibana.Name),
+			Namespace: vmo.Namespace,
+		},
+		Spec: netv1.IngressSpec{
+			TLS: []netv1.IngressTLS{
+				{
+					Hosts:      []string{ingressKibanaHost},
+					SecretName: fmt.Sprintf("%s-tls-%s", vmo.Name, config.Kibana.Name),
+				},
+			},
+			Rules: []netv1.IngressRule{ingressKibanaRule},
+		}}
+	existingIngress[resources.GetMetaName("system", config.Kibana.Name)] = deprecatedKibanaIngress
+	ingresses, err := New(vmo, existingIngress)
+	if err != nil {
+		t.Error(err)
+	}
+
+	fmt.Println(ingresses[1].Spec.Rules[0].Host)
+	assert.Equal(t, 2, len(ingresses[2].Spec.Rules), "Length of Opensearch Ingress Rules")
+	assert.Equal(t, 2, len(ingresses[2].Spec.Rules), "Length of Opendashboards Ingress Rules")
+	assert.Equal(t, "api.example.com", ingresses[0].Spec.TLS[0].Hosts[0], "TLS hosts")
+	assert.Equal(t, "kibana.example.com", ingresses[1].Spec.TLS[0].Hosts[1], "TLS hosts")
+	assert.Equal(t, "opensearchdashboards.example.com", ingresses[1].Spec.TLS[0].Hosts[0], "Deprecated TLS host")
+	assert.Equal(t, "opensearch.example.com", ingresses[2].Spec.TLS[0].Hosts[0], "TLS hosts")
+	assert.Equal(t, "elasticsearch.example.com", ingresses[2].Spec.TLS[0].Hosts[1], "Deprecated TLS host")
+	assert.Equal(t, 3, len(ingresses), "Length of generated Ingresses")
+	assert.Equal(t, 1, len(ingresses[0].Spec.TLS), "Number of TLS elements in generated Ingress")
+	assert.Equal(t, 1, len(ingresses[0].Spec.TLS[0].Hosts), "Number of hosts in generated Ingress")
+	assert.Equal(t, vmiName+"-tls-api", ingresses[0].Spec.TLS[0].SecretName, "TLS secret")
+	assert.Equal(t, vmiName+"-tls-os-ingest", ingresses[2].Spec.TLS[0].SecretName, "TLS secret")
+	assert.Equal(t, "basic", ingresses[0].Annotations["nginx.ingress.kubernetes.io/auth-type"], "Auth type")
+	assert.Equal(t, "secret", ingresses[0].Annotations["nginx.ingress.kubernetes.io/auth-secret"], "Auth secret")
+	assert.Equal(t, "example.com auth", ingresses[0].Annotations["nginx.ingress.kubernetes.io/auth-realm"], "Auth realm")
+	assert.Equal(t, "true", ingresses[0].Annotations["nginx.ingress.kubernetes.io/service-upstream"], "Service upstream")
+	assert.Equal(t, "${service_name}.${namespace}.svc.cluster.local", ingresses[0].Annotations["nginx.ingress.kubernetes.io/upstream-vhost"], "Upstream vhost")
+	assert.Equal(t, "api.example.com", ingresses[0].Annotations["cert-manager.io/common-name"], "TLS cert CN")
 	assert.Equal(t, "opensearch.example.com", ingresses[2].Annotations["cert-manager.io/common-name"], "TLS cert CN")
 	assert.Equal(t, getIngressClassName(vmo), *ingresses[0].Spec.IngressClassName)
 }

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -82,6 +82,7 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 		masterServiceHTTP.Spec.Selector = map[string]string{nodes.RoleMaster: nodes.RoleAssigned}
 		dataService.Spec.Selector = map[string]string{nodes.RoleData: nodes.RoleAssigned}
 		ingestService.Spec.Selector = map[string]string{nodes.RoleIngest: nodes.RoleAssigned}
+		ingestServiceOS.Spec.Selector = map[string]string{nodes.RoleIngest: nodes.RoleAssigned}
 	}
 
 	return []*corev1.Service{

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -84,11 +84,10 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 // 'app in (system-es-master, system-es-data, system-es-ingest)'
 // to select all pods in the vmi cluster
 func OpenSearchPodSelector(vmoName string) string {
-	return fmt.Sprintf("%s in (%s, %s, %s, %s)",
+	return fmt.Sprintf("%s in (%s, %s, %s)",
 		constants.ServiceAppLabel,
 		fmt.Sprintf("%s-%s", vmoName, config.ElasticsearchMaster.Name),
 		fmt.Sprintf("%s-%s", vmoName, config.ElasticsearchData.Name),
-		fmt.Sprintf("%s-%s", vmoName, config.ElasticsearchIngest.Name),
 		fmt.Sprintf("%s-%s", vmoName, config.OpensearchIngest.Name),
 	)
 }

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -102,6 +102,7 @@ func OpenSearchPodSelector(vmoName string) string {
 		fmt.Sprintf("%s-%s", vmoName, config.ElasticsearchMaster.Name),
 		fmt.Sprintf("%s-%s", vmoName, config.ElasticsearchData.Name),
 		fmt.Sprintf("%s-%s", vmoName, config.ElasticsearchIngest.Name),
+		fmt.Sprintf("%s-%s", vmoName, config.OpensearchIngest.Name),
 	)
 }
 

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -25,6 +25,17 @@ func createOpenSearchIngestServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitor
 	return openSearchIngestService
 }
 
+// Creates OpenSearch Client service element
+func createOSIngestServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *corev1.Service {
+	var openSearchIngestService = createServiceElement(vmo, config.OpensearchIngest)
+	if nodes.IsSingleNodeCluster(vmo) {
+		openSearchIngestService.Spec.Selector = resources.GetSpecID(vmo.Name, config.ElasticsearchMaster.Name)
+		// In dev mode, only a single node/pod all ingest/data goes to the 9200 port on the back end node
+		openSearchIngestService.Spec.Ports = []corev1.ServicePort{resources.GetServicePort(config.ElasticsearchData)}
+	}
+	return openSearchIngestService
+}
+
 // Creates OpenSearch MasterNodes service element
 func createOpenSearchMasterServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *corev1.Service {
 	openSearchMasterService := createServiceElement(vmo, config.ElasticsearchMaster)
@@ -63,6 +74,7 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 	masterServiceHTTP := createMasterServiceHTTP(vmo)
 	dataService := createOpenSearchDataServiceElements(vmo)
 	ingestService := createOpenSearchIngestServiceElements(vmo)
+	ingestServiceOS := createOSIngestServiceElements(vmo)
 
 	// if the cluster supports node role selectors, use those instead of service app selectors
 	if useNodeRoleSelectors {
@@ -77,6 +89,7 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 		masterServiceHTTP,
 		dataService,
 		ingestService,
+		ingestServiceOS,
 	}
 }
 

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -97,7 +97,7 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 // 'app in (system-es-master, system-es-data, system-es-ingest)'
 // to select all pods in the vmi cluster
 func OpenSearchPodSelector(vmoName string) string {
-	return fmt.Sprintf("%s in (%s, %s, %s)",
+	return fmt.Sprintf("%s in (%s, %s, %s, %s)",
 		constants.ServiceAppLabel,
 		fmt.Sprintf("%s-%s", vmoName, config.ElasticsearchMaster.Name),
 		fmt.Sprintf("%s-%s", vmoName, config.ElasticsearchData.Name),

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -25,17 +25,6 @@ func createOpenSearchIngestServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitor
 	return openSearchIngestService
 }
 
-// Creates OpenSearch Client service element
-func createOSIngestServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *corev1.Service {
-	var openSearchIngestService = createServiceElement(vmo, config.OpensearchIngest)
-	if nodes.IsSingleNodeCluster(vmo) {
-		openSearchIngestService.Spec.Selector = resources.GetSpecID(vmo.Name, config.ElasticsearchMaster.Name)
-		// In dev mode, only a single node/pod all ingest/data goes to the 9200 port on the back end node
-		openSearchIngestService.Spec.Ports = []corev1.ServicePort{resources.GetServicePort(config.ElasticsearchData)}
-	}
-	return openSearchIngestService
-}
-
 // Creates OpenSearch MasterNodes service element
 func createOpenSearchMasterServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) *corev1.Service {
 	openSearchMasterService := createServiceElement(vmo, config.ElasticsearchMaster)
@@ -74,7 +63,6 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 	masterServiceHTTP := createMasterServiceHTTP(vmo)
 	dataService := createOpenSearchDataServiceElements(vmo)
 	ingestService := createOpenSearchIngestServiceElements(vmo)
-	//ingestServiceOS := createOSIngestServiceElements(vmo)
 
 	// if the cluster supports node role selectors, use those instead of service app selectors
 	if useNodeRoleSelectors {
@@ -82,7 +70,6 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 		masterServiceHTTP.Spec.Selector = map[string]string{nodes.RoleMaster: nodes.RoleAssigned}
 		dataService.Spec.Selector = map[string]string{nodes.RoleData: nodes.RoleAssigned}
 		ingestService.Spec.Selector = map[string]string{nodes.RoleIngest: nodes.RoleAssigned}
-		//	ingestServiceOS.Spec.Selector = map[string]string{nodes.RoleIngest: nodes.RoleAssigned}
 	}
 
 	return []*corev1.Service{
@@ -90,7 +77,6 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 		masterServiceHTTP,
 		dataService,
 		ingestService,
-		//	ingestServiceOS,
 	}
 }
 

--- a/pkg/resources/services/elasticsearch.go
+++ b/pkg/resources/services/elasticsearch.go
@@ -74,7 +74,7 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 	masterServiceHTTP := createMasterServiceHTTP(vmo)
 	dataService := createOpenSearchDataServiceElements(vmo)
 	ingestService := createOpenSearchIngestServiceElements(vmo)
-	ingestServiceOS := createOSIngestServiceElements(vmo)
+	//ingestServiceOS := createOSIngestServiceElements(vmo)
 
 	// if the cluster supports node role selectors, use those instead of service app selectors
 	if useNodeRoleSelectors {
@@ -82,7 +82,7 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 		masterServiceHTTP.Spec.Selector = map[string]string{nodes.RoleMaster: nodes.RoleAssigned}
 		dataService.Spec.Selector = map[string]string{nodes.RoleData: nodes.RoleAssigned}
 		ingestService.Spec.Selector = map[string]string{nodes.RoleIngest: nodes.RoleAssigned}
-		ingestServiceOS.Spec.Selector = map[string]string{nodes.RoleIngest: nodes.RoleAssigned}
+		//	ingestServiceOS.Spec.Selector = map[string]string{nodes.RoleIngest: nodes.RoleAssigned}
 	}
 
 	return []*corev1.Service{
@@ -90,7 +90,7 @@ func createOpenSearchServiceElements(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 		masterServiceHTTP,
 		dataService,
 		ingestService,
-		ingestServiceOS,
+		//	ingestServiceOS,
 	}
 }
 

--- a/pkg/resources/services/elasticsearch_test.go
+++ b/pkg/resources/services/elasticsearch_test.go
@@ -97,7 +97,7 @@ func createDevProfileOS() *vmcontrollerv1.VerrazzanoMonitoringInstance {
 
 func TestOpenSearchPodSelector(t *testing.T) {
 	selector := OpenSearchPodSelector("system")
-	expected := "app in (system-es-master, system-es-data, system-es-ingest)"
+	expected := "app in (system-es-master, system-es-data, system-os-ingest)"
 	assert.Equal(t, expected, selector)
 }
 

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -105,10 +105,6 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 	return nil
 }
 
-// For upgrade check, if the user has deprecated Elasticsearch/Kibana ingress
-// Then update the new opensearch/opensearchdashboards ingress with additional Elasticsearch/Kibana rule and hosts
-// To support access to the deprecated Elasticsearch/Kibana URL. This case is only for upgrade.
-
 // getRequiredExistingIngresses retrieves the required ingress objects
 func getRequiredExistingIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) map[string]*netv1.Ingress {
 	existingIngressMap := make(map[string]*netv1.Ingress)

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -106,13 +106,13 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 			// To support access to the deprecated Elasticsearch/Kibana URL.
 			if ingress.Name == "vmi-system-es-ingest" && OSIngest != nil {
 				controller.log.Info("Inside vmi-system-es-ingest")
-				ingress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSIngest, &config.ElasticsearchIngest)
-				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingress, metav1.UpdateOptions{})
+				ingressOS := ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSIngest, &config.ElasticsearchIngest)
+				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOS, metav1.UpdateOptions{})
 			}
 			if ingress.Name == "vmi-system-kibana" && OSDIngest != nil {
 				controller.log.Info("Inside vmi-system-kibana")
-				ingress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSDIngest, &config.Kibana)
-				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingress, metav1.UpdateOptions{})
+				ingressOSD := ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSDIngest, &config.Kibana)
+				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOSD, metav1.UpdateOptions{})
 			}
 			if err != nil {
 				controller.log.Errorf("Failed to update Ingress %s/%s: %v", vmo.Namespace, ingress, err)

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -49,6 +49,7 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 		//Save Ingress object for later use -
 		if curIngress.Name == "vmi-system-os-ingest" {
 			controller.log.Oncef("Inside vmi-system-os-ingest object assignment")
+			controller.log.Oncef("rule.Host %v == resources.OidcProxyIngressHost(vmo, componentDetails%v", curIngress.Spec.Rules, resources.OidcProxyIngressHost(vmo, &config.OpensearchIngest))
 			if DoesIngressContainDeprecatedESHost(curIngress, vmo, &config.ElasticsearchIngest) {
 				controller.log.Oncef("DoesIngressContainDeprecatedESHost--Inside vmi-system-os-ingest object assignment -------")
 				curIngress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, curIngress, &config.ElasticsearchIngest)

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -6,16 +6,14 @@ package vmo
 import (
 	"context"
 	"errors"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
-	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
-	netv1 "k8s.io/api/networking/v1"
-	controllerruntime "sigs.k8s.io/controller-runtime"
-
 	"github.com/verrazzano/pkg/diff"
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/metricsexporter"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources/ingresses"
+	netv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -52,6 +50,7 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 		if curIngress.Name == "vmi-system-os-ingest" {
 			controller.log.Oncef("Inside vmi-system-os-ingest object assignment")
 			if DoesIngressContainDeprecatedESHost(curIngress, vmo, &config.ElasticsearchIngest) {
+				controller.log.Oncef("DoesIngressContainDeprecatedESHost--Inside vmi-system-os-ingest object assignment -------")
 				curIngress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, curIngress, &config.ElasticsearchIngest)
 			}
 			OSIngest = curIngress
@@ -59,6 +58,7 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 		if curIngress.Name == "vmi-system-opensearchdashboards" {
 			controller.log.Oncef("Inside vmi-system-opensearchdashboards object assignment")
 			if DoesIngressContainDeprecatedESHost(curIngress, vmo, &config.Kibana) {
+				controller.log.Oncef("DoesIngressContainDeprecatedESHost--------Inside vmi-system-opensearchdashboards object assignment")
 				curIngress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, curIngress, &config.Kibana)
 			}
 			OSDIngest = curIngress
@@ -155,10 +155,8 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 func DoesIngressContainDeprecatedESHost(ingress *netv1.Ingress, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, componentDetails *config.ComponentDetails) bool {
 	for _, rule := range ingress.Spec.Rules {
 		if rule.Host == resources.OidcProxyIngressHost(vmo, componentDetails) {
-			controllerruntime.Log.Info("DoesIngressContainDeprecatedESHost returns true")
 			return true
 		}
 	}
-	controllerruntime.Log.Info("DoesIngressContainDeprecatedESHost returns false")
 	return false
 }

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -114,11 +114,7 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 			if ingress.Name == "vmi-system-es-ingest" && OSIngest != nil {
 				controller.log.Info("Inside vmi-system-es-ingest--%v--------%v-------%s", OSIngest.Spec.Rules, OSIngest.Spec.Rules, OSIngest.Name)
 				ingressOS := ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSIngest, &config.ElasticsearchIngest)
-				specDiffs := diff.Diff(OSIngest, ingressOS)
-				if specDiffs != "" {
-					controller.log.Oncef("ES Ingress %s : Spec differences %s", OSIngest.Name, specDiffs)
-					_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOS, metav1.UpdateOptions{})
-				}
+				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOS, metav1.UpdateOptions{})
 				controller.log.Info("UPDATED INGRESS PRINT vmi-system-os-ingest%v ------%v------_%s", ingressOS.Spec.Rules, ingressOS.Spec.TLS, ingressOS.Name)
 				if err != nil {
 					controller.log.Errorf("Failed to update Ingress %s/%s: %v", vmo.Namespace, ingressOS, err)
@@ -130,11 +126,7 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 				controller.log.Info("Inside vmi-system-kibana %v -----%v-------%s ", OSDIngest.Spec.Rules, OSDIngest.Spec.TLS, OSDIngest.Name)
 				ingressOSD := ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSDIngest, &config.Kibana)
 				controller.log.Info("UPDATED INGRESS PRINT vmi-system-kibana%v ------%v------%s", ingressOSD.Spec.Rules, ingressOSD.Spec.TLS, ingressOSD.Name)
-				specDiffs := diff.Diff(OSDIngest, ingressOSD)
-				if specDiffs != "" {
-					controller.log.Oncef("OSD Ingress %s : Spec differences %s", OSDIngest.Name, specDiffs)
-					_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOSD, metav1.UpdateOptions{})
-				}
+				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOSD, metav1.UpdateOptions{})
 				if err != nil {
 					controller.log.Errorf("Failed to update Ingress %s/%s: %v", vmo.Namespace, ingressOSD, err)
 					functionMetric.IncError()

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -143,6 +143,7 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 	return nil
 }
 
+// DoesIngressContainDeprecatedESHost Checks if the ingress contain Deprecated ES host
 func DoesIngressContainDeprecatedESHost(ingress *netv1.Ingress, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, componentDetails *config.ComponentDetails) bool {
 	for _, rule := range ingress.Spec.Rules {
 		if rule.Host == resources.OidcProxyIngressHost(vmo, componentDetails) {

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -48,14 +48,18 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 	OSDIngest := &netv1.Ingress{}
 	for _, curIngress := range ingList {
 		//Save Ingress object for later use -
-		if curIngress.Name == "vmi-system-os-ingest" && DoesIngressContainDeprecatedESHost(curIngress, vmo, &config.ElasticsearchIngest) {
+		if curIngress.Name == "vmi-system-os-ingest") {
 			controller.log.Oncef("Inside vmi-system-os-ingest object assignment")
-			curIngress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, curIngress, &config.ElasticsearchIngest)
+			if DoesIngressContainDeprecatedESHost(curIngress, vmo, &config.ElasticsearchIngest) {
+				curIngress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, curIngress, &config.ElasticsearchIngest)
+			}
 			OSIngest = curIngress
 		}
-		if curIngress.Name == "vmi-system-opensearchdashboards" && DoesIngressContainDeprecatedESHost(curIngress, vmo, &config.Kibana) {
+		if curIngress.Name == "vmi-system-opensearchdashboards" {
 			controller.log.Oncef("Inside vmi-system-opensearchdashboards object assignment")
-			curIngress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, curIngress, &config.Kibana)
+			if DoesIngressContainDeprecatedESHost(curIngress, vmo, &config.Kibana) {
+				curIngress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, curIngress, &config.Kibana)
+			}
 			OSDIngest = curIngress
 		}
 

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -48,7 +48,7 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 	OSDIngest := &netv1.Ingress{}
 	for _, curIngress := range ingList {
 		//Save Ingress object for later use -
-		if curIngress.Name == "vmi-system-os-ingest") {
+		if curIngress.Name == "vmi-system-os-ingest" {
 			controller.log.Oncef("Inside vmi-system-os-ingest object assignment")
 			if DoesIngressContainDeprecatedESHost(curIngress, vmo, &config.ElasticsearchIngest) {
 				curIngress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, curIngress, &config.ElasticsearchIngest)

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -106,11 +106,18 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 			// To support access to the deprecated Elasticsearch/Kibana URL.
 			if ingress.Name == "vmi-system-es-ingest" && OSIngest != nil {
 				controller.log.Info("Inside vmi-system-es-ingest")
-				ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSIngest, &config.ElasticsearchIngest)
+				ingress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSIngest, &config.ElasticsearchIngest)
+				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingress, metav1.UpdateOptions{})
 			}
 			if ingress.Name == "vmi-system-kibana" && OSDIngest != nil {
 				controller.log.Info("Inside vmi-system-kibana")
-				ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSDIngest, &config.Kibana)
+				ingress = ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSDIngest, &config.Kibana)
+				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingress, metav1.UpdateOptions{})
+			}
+			if err != nil {
+				controller.log.Errorf("Failed to update Ingress %s/%s: %v", vmo.Namespace, ingress, err)
+				functionMetric.IncError()
+				return err
 			}
 
 			controller.log.Oncef("Deleting ingress %s", ingress.Name)

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -105,12 +105,12 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 			// If exists then update the new opensearch/opensearchdashboards ingress with an old Elasticsearch/Kibana rule and host
 			// To support access to the deprecated Elasticsearch/Kibana URL.
 			if ingress.Name == "vmi-system-es-ingest" && OSIngest != nil {
-				controller.log.Info("Inside vmi-system-es-ingest")
+				controller.log.Info("Inside vmi-system-es-ingest", OSIngest.Spec.Rules)
 				ingressOS := ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSIngest, &config.ElasticsearchIngest)
 				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOS, metav1.UpdateOptions{})
 			}
 			if ingress.Name == "vmi-system-kibana" && OSDIngest != nil {
-				controller.log.Info("Inside vmi-system-kibana")
+				controller.log.Info("Inside vmi-system-kibana", OSDIngest.Spec.Rules)
 				ingressOSD := ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSDIngest, &config.Kibana)
 				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOSD, metav1.UpdateOptions{})
 			}

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -48,9 +48,11 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 	for _, curIngress := range ingList {
 		//Save Ingress object for later use -
 		if curIngress.Name == "vmi-system-os-ingest" {
+			controller.log.Oncef("Inside vmi-system-os-ingest object assignment")
 			OSIngest = curIngress
 		}
-		if curIngress.Name == "vmi-system-kibana" {
+		if curIngress.Name == "vmi-system-opensearchdashboards" {
+			controller.log.Oncef("Inside vmi-system-opensearchdashboards object assignment")
 			OSDIngest = curIngress
 		}
 
@@ -102,10 +104,12 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 			// For upgrade check if the user has deprecated Elasticsearch/Kibana ingress
 			// If exists then update the new opensearch/opensearchdashboards ingress with an old Elasticsearch/Kibana rule and host
 			// To support access to the deprecated Elasticsearch/Kibana URL.
-			if ingress.Name == "vmi-system-es-ingest" {
+			if ingress.Name == "vmi-system-es-ingest" && OSIngest != nil {
+				controller.log.Info("Inside vmi-system-es-ingest")
 				ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSIngest, &config.ElasticsearchIngest)
 			}
-			if ingress.Name == "vmi-system-kibana" {
+			if ingress.Name == "vmi-system-kibana" && OSDIngest != nil {
+				controller.log.Info("Inside vmi-system-kibana")
 				ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSDIngest, &config.Kibana)
 			}
 

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -105,19 +105,26 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 			// If exists then update the new opensearch/opensearchdashboards ingress with an old Elasticsearch/Kibana rule and host
 			// To support access to the deprecated Elasticsearch/Kibana URL.
 			if ingress.Name == "vmi-system-es-ingest" && OSIngest != nil {
-				controller.log.Info("Inside vmi-system-es-ingest", OSIngest.Spec.Rules)
+				controller.log.Info("Inside vmi-system-es-ingest--%v--------%v-------%s", OSIngest.Spec.Rules, OSIngest.Spec.Rules, OSIngest.Name)
 				ingressOS := ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSIngest, &config.ElasticsearchIngest)
+				controller.log.Info("UPDATED INGRESS PRINT vmi-system-os-ingest%v ------%v------_%s", ingressOS.Spec.Rules, ingressOS.Spec.TLS, ingressOS.Name)
 				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOS, metav1.UpdateOptions{})
+				if err != nil {
+					controller.log.Errorf("Failed to update Ingress %s/%s: %v", vmo.Namespace, ingressOS, err)
+					functionMetric.IncError()
+					return err
+				}
 			}
 			if ingress.Name == "vmi-system-kibana" && OSDIngest != nil {
-				controller.log.Info("Inside vmi-system-kibana", OSDIngest.Spec.Rules)
+				controller.log.Info("Inside vmi-system-kibana %v -----%v-------%s ", OSDIngest.Spec.Rules, OSDIngest.Spec.TLS, OSDIngest.Name)
 				ingressOSD := ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSDIngest, &config.Kibana)
+				controller.log.Info("UPDATED INGRESS PRINT vmi-system-kibana%v ------%v------%s", ingressOSD.Spec.Rules, ingressOSD.Spec.TLS, ingressOSD.Name)
 				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOSD, metav1.UpdateOptions{})
-			}
-			if err != nil {
-				controller.log.Errorf("Failed to update Ingress %s/%s: %v", vmo.Namespace, ingress, err)
-				functionMetric.IncError()
-				return err
+				if err != nil {
+					controller.log.Errorf("Failed to update Ingress %s/%s: %v", vmo.Namespace, ingressOSD, err)
+					functionMetric.IncError()
+					return err
+				}
 			}
 
 			controller.log.Oncef("Deleting ingress %s", ingress.Name)

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -9,6 +9,7 @@ import (
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/config"
 	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/resources"
 	netv1 "k8s.io/api/networking/v1"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"github.com/verrazzano/pkg/diff"
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
@@ -154,8 +155,10 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 func DoesIngressContainDeprecatedESHost(ingress *netv1.Ingress, vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, componentDetails *config.ComponentDetails) bool {
 	for _, rule := range ingress.Spec.Rules {
 		if rule.Host == resources.OidcProxyIngressHost(vmo, componentDetails) {
+			controllerruntime.Log.Info("DoesIngressContainDeprecatedESHost returns true")
 			return true
 		}
 	}
+	controllerruntime.Log.Info("DoesIngressContainDeprecatedESHost returns false")
 	return false
 }

--- a/pkg/vmo/ingress.go
+++ b/pkg/vmo/ingress.go
@@ -107,8 +107,13 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 			if ingress.Name == "vmi-system-es-ingest" && OSIngest != nil {
 				controller.log.Info("Inside vmi-system-es-ingest--%v--------%v-------%s", OSIngest.Spec.Rules, OSIngest.Spec.Rules, OSIngest.Name)
 				ingressOS := ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSIngest, &config.ElasticsearchIngest)
+				specDiffs := diff.Diff(OSIngest, ingressOS)
+				if specDiffs != "" {
+					controller.log.Oncef("ES Ingress %s : Spec differences %s", OSIngest.Name, specDiffs)
+					_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOS, metav1.UpdateOptions{})
+				}
 				controller.log.Info("UPDATED INGRESS PRINT vmi-system-os-ingest%v ------%v------_%s", ingressOS.Spec.Rules, ingressOS.Spec.TLS, ingressOS.Name)
-				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOS, metav1.UpdateOptions{})
+				//_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOS, metav1.UpdateOptions{})
 				if err != nil {
 					controller.log.Errorf("Failed to update Ingress %s/%s: %v", vmo.Namespace, ingressOS, err)
 					functionMetric.IncError()
@@ -119,7 +124,12 @@ func CreateIngresses(controller *Controller, vmo *vmcontrollerv1.VerrazzanoMonit
 				controller.log.Info("Inside vmi-system-kibana %v -----%v-------%s ", OSDIngest.Spec.Rules, OSDIngest.Spec.TLS, OSDIngest.Name)
 				ingressOSD := ingresses.AddNewRuleAndHostTLSForIngress(vmo, OSDIngest, &config.Kibana)
 				controller.log.Info("UPDATED INGRESS PRINT vmi-system-kibana%v ------%v------%s", ingressOSD.Spec.Rules, ingressOSD.Spec.TLS, ingressOSD.Name)
-				_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOSD, metav1.UpdateOptions{})
+				specDiffs := diff.Diff(OSDIngest, ingressOSD)
+				if specDiffs != "" {
+					controller.log.Oncef("OSD Ingress %s : Spec differences %s", OSDIngest.Name, specDiffs)
+					_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOSD, metav1.UpdateOptions{})
+				}
+				//_, err = controller.kubeclientset.NetworkingV1().Ingresses(vmo.Namespace).Update(context.TODO(), ingressOSD, metav1.UpdateOptions{})
 				if err != nil {
 					controller.log.Errorf("Failed to update Ingress %s/%s: %v", vmo.Namespace, ingressOSD, err)
 					functionMetric.IncError()


### PR DESCRIPTION
PR does the following:
- New install - Removes Elasticsearch/Kibana references from ingresses.
- Upgrade - preserves the deprecated Elasticsearch/Kibana ingress URL by updating the new ingresses with an additional Rule and TLS host. 