### PR TITLE
VZ-7585:  verrazzano-monitoring-operator make manifests/make generate does not run in pipeline 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,6 +64,21 @@ pipeline {
             }
         }
 
+        stage('Check Repo Clean') {
+            steps {
+                checkRepoClean()
+            }
+            post {
+                failure {
+                    script {
+                        sh """
+                            echo 'Error: Found modified files after manifest/generate actions...'
+                        """
+                    }
+                }
+            }
+        }
+
         stage('Build') {
             when { not { buildingTag() } }
             steps {
@@ -191,5 +206,12 @@ pipeline {
             }
         }
     }
+}
 
+def checkRepoClean() {
+    sh """
+        cd ${GO_REPO_PATH}/verrazzano-monitoring-operator
+        echo 'Check for forgotten manifest/generate actions...'
+        (make check-repo-clean)
+    """
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,15 +68,6 @@ pipeline {
             steps {
                 checkRepoClean()
             }
-            post {
-                failure {
-                    script {
-                        sh """
-                            echo 'Error: Found modified files after manifest/generate actions...'
-                        """
-                    }
-                }
-            }
         }
 
         stage('Build') {

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ INTEG_RUN_REGEX=Test
 INGRESS_CONTROLLER_SVC_NAME:=ingress-controller
 GO ?= go
 HELM_CHART_NAME ?= verrazzano-monitoring-operator
-CONTROLLER_GEN_VERSION ?= $(shell go list -m -f '{{.Version}}' sigs.k8s.io/controller-tools)
+CONTROLLER_GEN_VERSION ?= v0.8.0
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 CRD_PATH:=./k8s/crds
 CRD_FILE:=./k8s/crds/verrazzano.io_verrazzanomonitoringinstances.yaml
@@ -81,6 +81,7 @@ endif
 	ACTUAL_CONTROLLER_GEN_VERSION=$$(${CONTROLLER_GEN} --version | awk '{print $$2}') ; \
 	if [ "$${ACTUAL_CONTROLLER_GEN_VERSION}" != "${CONTROLLER_GEN_VERSION}" ] ; then \
 		echo  "Bad controller-gen version $${ACTUAL_CONTROLLER_GEN_VERSION}, please install ${CONTROLLER_GEN_VERSION}" ; \
+		exit 1; \
 	fi ; \
 	}
 
@@ -187,3 +188,8 @@ ifeq (, $(shell command -v golangci-lint))
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.49.0
 endif
 	golangci-lint run
+
+# check if the repo is clean after running generate
+.PHONY: check-repo-clean
+check-repo-clean: generate manifests
+	./build/scripts/check_if_clean_after_generate.sh

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ generate:
 .PHONY: controller-gen
 controller-gen:
 ifeq (, $(shell command -v controller-gen))
-	$(GO) get sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
+	$(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
 	$(eval CONTROLLER_GEN=$(GOBIN)/controller-gen)
 else
 	$(eval CONTROLLER_GEN=$(shell command -v controller-gen))

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,14 @@ DOCKER_IMAGE_TAG ?= local-$(shell git rev-parse --short HEAD)
 
 CREATE_LATEST_TAG=0
 
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+
 ifeq ($(MAKECMDGOALS),$(filter $(MAKECMDGOALS),push push-tag push-eswait push-tag-eswait))
     ifndef DOCKER_REPO
         $(error DOCKER_REPO must be defined as the name of the docker repository where image will be pushed)
@@ -70,11 +78,11 @@ generate:
 
 .PHONY: controller-gen
 controller-gen:
-ifeq (, $(shell command -v controller-gen))
+ifeq (, $(shell which controller-gen))
 	$(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@${CONTROLLER_GEN_VERSION}
 	$(eval CONTROLLER_GEN=$(GOBIN)/controller-gen)
 else
-	$(eval CONTROLLER_GEN=$(shell command -v controller-gen))
+	$(eval CONTROLLER_GEN=$(shell which controller-gen))
 endif
 	@{ \
 	set -eu; \

--- a/build/scripts/check_if_clean_after_generate.sh
+++ b/build/scripts/check_if_clean_after_generate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021, 2022, Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+#
+
+# this attempts to detect if someone has made an update and forgot to run make generate
+# if so, it dumps out the status and diffs in the output so you can see what the issue was
+# we purposely cause the build to fail in this situation - we do not want the build to
+# rely on generated files that are not version controlled.
+
+if [[ -n $(git status --porcelain) ]]; then
+  git status
+  git diff
+  echo "****************************************************************************************************************"
+  echo "* ERROR: The result of a 'make generate', 'make manifests' or 'make copyright-check' resulted in files being   *"
+  echo "*        modified. These changes need to be included in your PR.                                               *"
+  echo "****************************************************************************************************************"
+  exit 1
+fi


### PR DESCRIPTION
Hardcoding `sigs.k8s.io/controller-tools` to `v0.8.0` since it does not exist as a module dependency in `go.mod`.
Make sure to correctly populate `$GOBIN` environment variable.
Switching from `command` bash shell builtin to `which` since `command` is hashed command. If someone removes `controller-gen` binary from their machine, then `command -v controller-gen` can still falsely indicate the `controller-gen` binary exists.
Added make target for repo clean for manifests verification.