### PR TITLE
VZ-7793 - Retry fetching kubecontext 

### DIFF
--- a/verrazzano-backup-hook/main.go
+++ b/verrazzano-backup-hook/main.go
@@ -126,7 +126,8 @@ func main() {
 					log.Panic(err)
 				}
 				retryCount = retryCount + 1
-				// setting k8sContextReady flag to true so that this valid checks pass
+				// setting k8sContextReady flag to true os that subsequent checks dont re-use old value
+				// This flag will be changed to false if any k8s go-client retrieval fails.
 				log.Info("Resetting k8s context flag to true...")
 				k8sContextReady = true
 			}

--- a/verrazzano-backup-hook/main.go
+++ b/verrazzano-backup-hook/main.go
@@ -126,12 +126,13 @@ func main() {
 					log.Panic(err)
 				}
 				retryCount = retryCount + 1
+				// setting k8sContextReady flag to true so that this valid checks pass
+				k8sContextReady = true
 			}
 		} else {
 			done = true
 			log.Info("kubecontext retrieval successful")
 		}
-
 	}
 
 	// Initialize K8s object

--- a/verrazzano-backup-hook/main.go
+++ b/verrazzano-backup-hook/main.go
@@ -127,6 +127,7 @@ func main() {
 				}
 				retryCount = retryCount + 1
 				// setting k8sContextReady flag to true so that this valid checks pass
+				log.Info("Resetting k8s context flag to true...")
 				k8sContextReady = true
 			}
 		} else {


### PR DESCRIPTION
When kubecontext is fetched too soon after pod bringup, it errors out . As a result  a retry is needed. The retry logic was not setting a specific flag hence even after retry the wait loop kept going and ultimately failed after max tries