### PR TITLE
VZ-7845 - Implement retry while updating OS keystore

### DIFF
--- a/verrazzano-backup-hook/main.go
+++ b/verrazzano-backup-hook/main.go
@@ -149,7 +149,7 @@ func main() {
 	}
 
 	// Update OpenSearch keystore
-	_, err = k8s.UpdateKeystore(openSearchConData)
+	_, err = k8s.UpdateKeystore(openSearchConData, globalTimeout)
 	if err != nil {
 		log.Errorf("Unable to update keystore")
 		os.Exit(1)

--- a/verrazzano-backup-hook/utilities/k8s/fake/clientset.go
+++ b/verrazzano-backup-hook/utilities/k8s/fake/clientset.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package fake
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	restclient "k8s.io/client-go/rest"
+	fakeRESTClient "k8s.io/client-go/rest/fake"
+)
+
+func NewClientsetConfig(objects ...runtime.Object) (*restclient.Config, kubernetes.Interface) {
+	cfg := &restclient.Config{}
+	client := fakeclientset.NewSimpleClientset(objects...)
+	wrappedClient := &WrappedClientset{Clientset: client}
+	return cfg, wrappedClient
+}
+
+/*
+There is a deficiency in the FakeCoreV1 implementation that returns a nil RESTClient
+To get around this limitation, we wrap the fakes in our own types, which supply a valid
+RESTClient for unit testing.
+*/
+type (
+	WrappedClientset struct {
+		*fakeclientset.Clientset
+	}
+	WrappedCoreV1 struct {
+		fakecorev1.FakeCoreV1
+		RestClient restclient.Interface
+	}
+)
+
+func (w *WrappedClientset) CoreV1() corev1.CoreV1Interface {
+	return &WrappedCoreV1{
+		FakeCoreV1: fakecorev1.FakeCoreV1{
+			Fake: &w.Fake,
+		},
+		RestClient: &fakeRESTClient.RESTClient{GroupVersion: schema.GroupVersion{Version: "v1"}},
+	}
+}
+
+func (w *WrappedCoreV1) RESTClient() restclient.Interface {
+	return w.RestClient
+}

--- a/verrazzano-backup-hook/utilities/k8s/fake/spydy_utils.go
+++ b/verrazzano-backup-hook/utilities/k8s/fake/spydy_utils.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+package fake
+
+import (
+	"bytes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"net/url"
+)
+
+// PodExecResult can be used to output arbitrary strings during unit testing
+var PodExecResult = func(url *url.URL) (string, string, error) { return "", "", nil }
+
+// NewPodExecutor should be used instead of remotecommand.NewSPDYExecutor in unit tests
+func NewPodExecutor(config *rest.Config, method string, url *url.URL) (remotecommand.Executor, error) {
+	return &dummyExecutor{method: method, url: url}, nil
+}
+
+// dummyExecutor is for unit testing
+type dummyExecutor struct {
+	method string
+	url    *url.URL
+}
+
+// Stream on a dummyExecutor sets stdout to PodExecResult
+func (f *dummyExecutor) Stream(options remotecommand.StreamOptions) error {
+	stdout, stderr, err := PodExecResult(f.url)
+	if options.Stdout != nil {
+		buf := new(bytes.Buffer)
+		buf.WriteString(stdout)
+		if _, err := options.Stdout.Write(buf.Bytes()); err != nil {
+			return err
+		}
+	}
+	if options.Stderr != nil {
+		buf := new(bytes.Buffer)
+		buf.WriteString(stderr)
+		if _, err := options.Stderr.Write(buf.Bytes()); err != nil {
+			return err
+		}
+	}
+	return err
+}

--- a/verrazzano-backup-hook/utilities/k8s/interface.go
+++ b/verrazzano-backup-hook/utilities/k8s/interface.go
@@ -27,7 +27,7 @@ type K8s interface {
 	IsPodReady(pod *v1.Pod) (bool, error)
 	ExecPod(cfg *rest.Config, pod *v1.Pod, container string, command []string) (string, string, error)
 	UpdateKeystore(connData *model.ConnectionData, timeout string) (bool, error)
-	ExecRetry(pod *v1.Pod, timeout string, execCmd []string) error
+	ExecRetry(pod *v1.Pod, container, timeout string, execCmd []string) error
 }
 
 type K8sImpl struct {

--- a/verrazzano-backup-hook/utilities/k8s/interface.go
+++ b/verrazzano-backup-hook/utilities/k8s/interface.go
@@ -26,7 +26,8 @@ type K8s interface {
 	CheckAllPodsAfterRestore() error
 	IsPodReady(pod *v1.Pod) (bool, error)
 	ExecPod(cfg *rest.Config, pod *v1.Pod, container string, command []string) (string, string, error)
-	UpdateKeystore(connData *model.ConnectionData) (bool, error)
+	UpdateKeystore(connData *model.ConnectionData, timeout string) (bool, error)
+	ExecRetry(pod *v1.Pod, timeout string, execCmd []string) error
 }
 
 type K8sImpl struct {

--- a/verrazzano-backup-hook/utilities/k8s/k8sHelper.go
+++ b/verrazzano-backup-hook/utilities/k8s/k8sHelper.go
@@ -410,13 +410,13 @@ func (k *K8sImpl) UpdateKeystore(connData *model.ConnectionData, timeout string)
 		return false, err
 	}
 	for _, pod := range esMasterPods.Items {
-		err = k.ExecRetry(&pod, constants.OpenSearchMasterPodContainerName, timeout, accessKeyCmd)
+		err = k.ExecRetry(&pod, constants.OpenSearchMasterPodContainerName, timeout, accessKeyCmd) //nolint:gosec //#gosec G601
 		if err != nil {
 			k.Log.Errorf("Unable to exec into pod %s due to %v", pod.Name, err)
 			return false, err
 		}
 
-		err = k.ExecRetry(&pod, constants.OpenSearchMasterPodContainerName, timeout, secretKeyCmd)
+		err = k.ExecRetry(&pod, constants.OpenSearchMasterPodContainerName, timeout, secretKeyCmd) //nolint:gosec //#gosec G601
 		if err != nil {
 			k.Log.Errorf("Unable to exec into pod %s due to %v", pod.Name, err)
 			return false, err
@@ -432,13 +432,13 @@ func (k *K8sImpl) UpdateKeystore(connData *model.ConnectionData, timeout string)
 	}
 
 	for _, pod := range esDataPods.Items {
-		err = k.ExecRetry(&pod, constants.OpenSearchDataPodContainerName, timeout, accessKeyCmd)
+		err = k.ExecRetry(&pod, constants.OpenSearchDataPodContainerName, timeout, accessKeyCmd) //nolint:gosec //#gosec G601
 		if err != nil {
 			k.Log.Errorf("Unable to exec into pod %s due to %v", pod.Name, err)
 			return false, err
 		}
 
-		err = k.ExecRetry(&pod, constants.OpenSearchDataPodContainerName, timeout, secretKeyCmd)
+		err = k.ExecRetry(&pod, constants.OpenSearchDataPodContainerName, timeout, secretKeyCmd) //nolint:gosec //#gosec G601
 		if err != nil {
 			k.Log.Errorf("Unable to exec into pod %s due to %v", pod.Name, err)
 			return false, err

--- a/verrazzano-backup-hook/utilities/k8s/k8sHelper.go
+++ b/verrazzano-backup-hook/utilities/k8s/k8sHelper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/verrazzano/verrazzano-monitoring-operator/verrazzano-backup-hook/constants"
 	model "github.com/verrazzano/verrazzano-monitoring-operator/verrazzano-backup-hook/types"
 	futil "github.com/verrazzano/verrazzano-monitoring-operator/verrazzano-backup-hook/utilities"
+	vmofake "github.com/verrazzano/verrazzano-monitoring-operator/verrazzano-backup-hook/utilities/k8s/fake"
 	"go.uber.org/zap"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -380,7 +381,15 @@ func (k *K8sImpl) ExecPod(pod *v1.Pod, container string, command []string) (stri
 			Stderr:    true,
 			TTY:       true,
 		}, scheme.ParameterCodec)
-	executor, err := NewPodExecutor(k.K8sConfig, "POST", request.URL())
+
+	var executor remotecommand.Executor
+	var err error
+	if futil.GetEnvWithDefault(constants.DevKey, constants.FalseString) == constants.TrueString {
+		executor, err = vmofake.NewPodExecutor(k.K8sConfig, "POST", request.URL())
+	} else {
+		executor, err = NewPodExecutor(k.K8sConfig, "POST", request.URL())
+	}
+
 	if err != nil {
 		return "", "", err
 	}

--- a/verrazzano-backup-hook/utilities/k8s/k8sHelper_test.go
+++ b/verrazzano-backup-hook/utilities/k8s/k8sHelper_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/verrazzano/verrazzano-monitoring-operator/verrazzano-backup-hook/constants"
 	"github.com/verrazzano/verrazzano-monitoring-operator/verrazzano-backup-hook/log"
 	kutil "github.com/verrazzano/verrazzano-monitoring-operator/verrazzano-backup-hook/utilities/k8s"
+	vmofake "github.com/verrazzano/verrazzano-monitoring-operator/verrazzano-backup-hook/utilities/k8s/fake"
 	"go.uber.org/zap"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -18,10 +19,13 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 )
+
+const resultString = "{\"result\":\"result\"}"
 
 var (
 	TestPod = v1.Pod{
@@ -361,4 +365,37 @@ func TestIsPodReady(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, ok, false)
 
+}
+
+// TestExecRetry tests the ExecRetry method for the following use case.
+// GIVEN k8s client
+// WHEN exec command fails
+// THEN there is a retry of the exec command
+
+func TestExecRetry(t *testing.T) {
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "foo",
+		},
+	}
+
+	log, f := logHelper()
+	defer os.Remove(f)
+	defer os.Unsetenv(constants.DevKey)
+
+	os.Setenv(constants.OpenSearchHealthCheckTimeoutKey, "1s")
+	os.Setenv(constants.DevKey, constants.TrueString)
+
+	var clientk client.Client
+	config, fc := vmofake.NewClientsetConfig()
+	dclient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	k8s := kutil.New(dclient, clientk, fc, config, "default", log)
+
+	var accessKeyCmd []string
+	accessKeyCmd = append(accessKeyCmd, "/bin/sh", "-c", fmt.Sprintf("echo %s | %s", strconv.Quote("ACCESS_KEY"), constants.OpenSearchKeystoreAccessKeyCmd))
+
+	err := k8s.ExecRetry(pod, constants.OpenSearchDataPodContainerName, "1s", accessKeyCmd)
+	assert.Nil(t, err)
 }

--- a/verrazzano-backup-hook/utilities/k8s/k8sHelper_test.go
+++ b/verrazzano-backup-hook/utilities/k8s/k8sHelper_test.go
@@ -25,8 +25,6 @@ import (
 	"testing"
 )
 
-const resultString = "{\"result\":\"result\"}"
-
 var (
 	TestPod = v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Sometimes kubectl exec fails while updating opensearch keystore. This PR will add a retry with a global timeout for the exec operations