### PR TITLE
Embed ISM policy in VMO code

### DIFF
--- a/docker-images/verrazzano-monitoring-operator/Dockerfile
+++ b/docker-images/verrazzano-monitoring-operator/Dockerfile
@@ -32,13 +32,9 @@ RUN yum update -y \
     && yum clean all \
     && rm -rf /var/cache/yum
 COPY --from=build_base /usr/bin/verrazzano-monitoring-operator /usr/local/bin/verrazzano-monitoring-operator
-COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano-monitoring-operator/k8s/manifests/opensearch/vz-application-default-ISM-policy.json /usr/local/bin/k8s/manifests/opensearch/vz-application-default-ISM-policy.json
-COPY --from=build_base /root/go/src/github.com/verrazzano/verrazzano-monitoring-operator/k8s/manifests/opensearch/vz-system-default-ISM-policy.json /usr/local/bin/k8s/manifests/opensearch/vz-system-default-ISM-policy.json
 WORKDIR /usr/local/bin/
 RUN groupadd -r verrazzano-monitoring-operator && useradd --no-log-init -r -g verrazzano-monitoring-operator -u 1000 verrazzano-monitoring-operator
-RUN chown 1000:verrazzano-monitoring-operator /usr/local/bin/verrazzano-monitoring-operator && chmod 500 /usr/local/bin/verrazzano-monitoring-operator  \
-    && chown 1000:verrazzano-monitoring-operator /usr/local/bin/k8s/manifests/opensearch/vz-application-default-ISM-policy.json && chmod 400 /usr/local/bin/k8s/manifests/opensearch/vz-system-default-ISM-policy.json  \
-    && chown 1000:verrazzano-monitoring-operator /usr/local/bin/k8s/manifests/opensearch/vz-system-default-ISM-policy.json && chmod 400 /usr/local/bin/k8s/manifests/opensearch/vz-system-default-ISM-policy.json
+RUN chown 1000:verrazzano-monitoring-operator /usr/local/bin/verrazzano-monitoring-operator && chmod 500 /usr/local/bin/verrazzano-monitoring-operator
 USER 1000
 
 ENTRYPOINT ["/usr/local/bin/verrazzano-monitoring-operator"]

--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+// Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+
+// Package verrazzanomonitoringoperator is used to reference the embedded OpenSearch ISM policy files in the binary.
+package verrazzanomonitoringoperator
+
+import (
+	"embed"
+)
+
+//go:embed k8s/manifests/opensearch
+var openSearchISMPolicyFS embed.FS
+
+// GetEmbeddedISMPolicy returns the embedded openSearch ISM policies file system.
+func GetEmbeddedISMPolicy() embed.FS {
+	return openSearchISMPolicyFS
+}

--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -8,11 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/verrazzano/pkg/diff"
 
+	verrazzanomonitoringoperator "github.com/verrazzano/verrazzano-monitoring-operator"
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 )
 
@@ -253,7 +253,7 @@ func (o *OSClient) deletePolicy(opensearchEndpoint, policyName string) (*http.Re
 // updateISMPolicyFromFile creates or updates the ISM policy from the given json file.
 // If ISM policy doesn't exist, it will create new. Otherwise, it'll create one.
 func (o *OSClient) updateISMPolicyFromFile(openSearchEndpoint string, policyFilePath string, policyFileName string, policyName string) (*ISMPolicy, error) {
-	policy, err := getISMPolicyFromFile(policyFilePath, policyFileName)
+	policy, err := getISMPolicyFromFile(policyFileName)
 	if err != nil {
 		return nil, err
 	}
@@ -364,8 +364,9 @@ func toISMPolicy(policy *vmcontrollerv1.IndexManagementPolicy) *ISMPolicy {
 }
 
 // getISMPolicyFromFile reads the given json file and return the ISMPolicy object after unmarshalling.
-func getISMPolicyFromFile(policyFilePath, policyFileName string) (*ISMPolicy, error) {
-	policyBytes, err := os.ReadFile(policyFilePath + policyFileName)
+func getISMPolicyFromFile(policyFileName string) (*ISMPolicy, error) {
+	ismPolicyFs := verrazzanomonitoringoperator.GetEmbeddedISMPolicy()
+	policyBytes, err := ismPolicyFs.ReadFile(policyFileName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -252,7 +252,7 @@ func (o *OSClient) deletePolicy(opensearchEndpoint, policyName string) (*http.Re
 
 // updateISMPolicyFromFile creates or updates the ISM policy from the given json file.
 // If ISM policy doesn't exist, it will create new. Otherwise, it'll create one.
-func (o *OSClient) updateISMPolicyFromFile(openSearchEndpoint string, policyFilePath string, policyFileName string, policyName string) (*ISMPolicy, error) {
+func (o *OSClient) updateISMPolicyFromFile(openSearchEndpoint string, policyFileName string, policyName string) (*ISMPolicy, error) {
 	policy, err := getISMPolicyFromFile(policyFileName)
 	if err != nil {
 		return nil, err
@@ -269,7 +269,7 @@ func (o *OSClient) updateISMPolicyFromFile(openSearchEndpoint string, policyFile
 func (o *OSClient) createOrUpdateDefaultISMPolicy(openSearchEndpoint string) ([]*ISMPolicy, error) {
 	var defaultPolicies []*ISMPolicy
 	for policyName, policyFile := range defaultISMPoliciesMap {
-		createdPolicy, err := o.updateISMPolicyFromFile(openSearchEndpoint, defaultPolicyPath, policyFile, policyName)
+		createdPolicy, err := o.updateISMPolicyFromFile(openSearchEndpoint, policyFile, policyName)
 		if err != nil {
 			return defaultPolicies, err
 		}
@@ -366,7 +366,7 @@ func toISMPolicy(policy *vmcontrollerv1.IndexManagementPolicy) *ISMPolicy {
 // getISMPolicyFromFile reads the given json file and return the ISMPolicy object after unmarshalling.
 func getISMPolicyFromFile(policyFileName string) (*ISMPolicy, error) {
 	ismPolicyFs := verrazzanomonitoringoperator.GetEmbeddedISMPolicy()
-	policyBytes, err := ismPolicyFs.ReadFile(policyFileName)
+	policyBytes, err := ismPolicyFs.ReadFile(defaultPolicyPath + policyFileName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -365,8 +365,8 @@ func toISMPolicy(policy *vmcontrollerv1.IndexManagementPolicy) *ISMPolicy {
 
 // getISMPolicyFromFile reads the given json file and return the ISMPolicy object after unmarshalling.
 func getISMPolicyFromFile(policyFileName string) (*ISMPolicy, error) {
-	ismPolicyFs := verrazzanomonitoringoperator.GetEmbeddedISMPolicy()
-	policyBytes, err := ismPolicyFs.ReadFile(defaultPolicyPath + policyFileName)
+	ismPolicyFS := verrazzanomonitoringoperator.GetEmbeddedISMPolicy()
+	policyBytes, err := ismPolicyFS.ReadFile(defaultPolicyPath + policyFileName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/verrazzano/pkg/diff"
 
-	verrazzanomonitoringoperator "github.com/verrazzano/verrazzano-monitoring-operator"
+	"github.com/verrazzano/verrazzano-monitoring-operator"
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
 )
 

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -22,9 +22,8 @@ import (
 )
 
 const (
-	testPolicyRelativePath = "../../" + defaultPolicyPath
-	testPolicyNotFound     = `{"error":{"root_cause":[{"type":"status_exception","reason":"Policy not found"}],"type":"status_exception","reason":"Policy not found"},"status":404}`
-	testSystemPolicy       = `
+	testPolicyNotFound = `{"error":{"root_cause":[{"type":"status_exception","reason":"Policy not found"}],"type":"status_exception","reason":"Policy not found"},"status":404}`
+	testSystemPolicy   = `
 {
     "_id" : "verrazzano-system",
     "_seq_no" : 0,
@@ -469,16 +468,13 @@ func TestConfigureIndexManagementPluginOpenSearchNotReady(t *testing.T) {
 // THEN the ISM policy object is created if given json file contains the policy. .
 func TestGetISMPolicyFromFile(t *testing.T) {
 	type args struct {
-		policyFilePath string
 		policyFileName string
 	}
 	validArgs := args{
-		policyFilePath: testPolicyRelativePath,
 		policyFileName: systemDefaultPolicyFileName,
 	}
 	invalidArgs := args{
-		policyFilePath: "dummyPath",
-		policyFileName: systemDefaultPolicyFileName,
+		policyFileName: "invalidFile",
 	}
 
 	tests := []struct {
@@ -487,19 +483,19 @@ func TestGetISMPolicyFromFile(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			"TestGetISMPolicyFromFile when file path is valid",
+			"TestGetISMPolicyFromFile when file is valid",
 			validArgs,
 			false,
 		},
 		{
-			"TestGetISMPolicyFromFile when file path is invalid",
+			"TestGetISMPolicyFromFile when file doesn't exist",
 			invalidArgs,
 			true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := getISMPolicyFromFile(tt.args.policyFilePath, tt.args.policyFileName)
+			_, err := getISMPolicyFromFile(tt.args.policyFileName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getISMPolicyFromFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -518,7 +514,7 @@ func TestUpdateISMPolicyFromFile(t *testing.T) {
 		DoHTTP            func(request *http.Request) (*http.Response, error)
 		statefulSetLister v1.StatefulSetLister
 	}
-	policy, err := getISMPolicyFromFile(testPolicyRelativePath, systemDefaultPolicyFileName)
+	policy, err := getISMPolicyFromFile(systemDefaultPolicyFileName)
 	if err != nil {
 		t.Errorf("Error while creating test policy")
 	}
@@ -554,7 +550,6 @@ func TestUpdateISMPolicyFromFile(t *testing.T) {
 	}
 	type args struct {
 		openSearchEndpoint string
-		policyFilePath     string
 		policyFileName     string
 		policyName         string
 	}
@@ -570,7 +565,6 @@ func TestUpdateISMPolicyFromFile(t *testing.T) {
 			field1,
 			args{
 				"localhost:9090",
-				testPolicyRelativePath,
 				systemDefaultPolicyFileName,
 				systemDefaultPolicy,
 			},
@@ -582,7 +576,6 @@ func TestUpdateISMPolicyFromFile(t *testing.T) {
 			fieldWithError,
 			args{
 				"localhost:9090",
-				testPolicyRelativePath,
 				systemDefaultPolicyFileName,
 				systemDefaultPolicy,
 			},
@@ -597,7 +590,7 @@ func TestUpdateISMPolicyFromFile(t *testing.T) {
 				DoHTTP:            tt.fields.DoHTTP,
 				statefulSetLister: tt.fields.statefulSetLister,
 			}
-			got, err := o.updateISMPolicyFromFile(tt.args.openSearchEndpoint, tt.args.policyFilePath, tt.args.policyFileName, tt.args.policyName)
+			got, err := o.updateISMPolicyFromFile(tt.args.openSearchEndpoint, tt.args.policyFileName, tt.args.policyName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("updateISMPolicyFromFile() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Instead of putting ISM policy files in docker image, ISM policy files are embedded in binary itself.