### PR TITLE
VZ-8308 add timestamp as timeFieldName in the default index patterns

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package constants
@@ -217,3 +217,6 @@ const IndexPattern = "index-pattern"
 
 // PodUser used in security context
 const PodUser = 1000
+
+// TimeStamp used to add timestamp as TimeFieldName in the index pattern
+const TimeStamp = "@timestamp"

--- a/pkg/opensearch_dashboards/index_pattern.go
+++ b/pkg/opensearch_dashboards/index_pattern.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022, Oracle and/or its affiliates.
+// Copyright (C) 2022, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package dashboards
@@ -35,7 +35,8 @@ func (od *OSDashboardsClient) CreateDefaultIndexPatterns(log vzlog.VerrazzanoLog
 		savedObject := SavedObjectType{
 			Type: constants.IndexPattern,
 			Attributes: Attributes{
-				Title: indexPattern,
+				Title:         indexPattern,
+				TimeFieldName: constants.TimeStamp,
 			},
 		}
 		savedObjectPayloads = append(savedObjectPayloads, savedObject)

--- a/pkg/opensearch_dashboards/opensearch_dashboards_upgrade.go
+++ b/pkg/opensearch_dashboards/opensearch_dashboards_upgrade.go
@@ -31,7 +31,8 @@ type (
 	}
 
 	Attributes struct {
-		Title string `json:"title"`
+		Title         string `json:"title"`
+		TimeFieldName string `json:"timeFieldName,omitempty"`
 	}
 )
 


### PR DESCRIPTION
Added `@timestamp` as timeFieldName in the default index patterns.

OSD Screenshots:
<img width="1023" alt="Screenshot 2023-01-25 at 10 54 51 AM" src="https://user-images.githubusercontent.com/112623165/214486807-6b5e3062-8c53-42fb-99cb-e6d5228990ec.png">
<img width="1024" alt="Screenshot 2023-01-25 at 10 55 08 AM" src="https://user-images.githubusercontent.com/112623165/214486813-31eee466-bb0e-4f31-b702-e06f74096261.png">
