### PR TITLE
Set to watch all namespaces for Grafana dashboard configmaps

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -260,6 +260,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, kubeclientset kuberne
 				{Name: "LABEL", Value: "grafana_dashboard"},
 				{Name: "LABEL_VALUE", Value: "1"},
 				{Name: "FOLDER", Value: "/etc/grafana/provisioning/dashboardjson"},
+				{Name: "NAMESPACE", Value: "ALL"},
 			}...)
 			deployment.Spec.Template.Spec.Containers[i+1].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[i+1].VolumeMounts, corev1.VolumeMount{
 				Name:      "dashboards-volume",


### PR DESCRIPTION
I tested this in a local cluster by creating a new namespace, creating a configmap containing a dashboard, and labeling the configmap. Grafana discovered and loaded the dashboard as expected.

I also looked at the documentation and the mechanism the sidecar uses by default is a watch on configmaps, so it should be fairly efficient.