### PR TITLE
VZ-8644:  Reduce VMO image size and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,17 @@ build: k8s-dist
 	docker build --pull --no-cache \
 		--build-arg BUILDVERSION=${BUILDVERSION} \
 		--build-arg BUILDDATE=${BUILDDATE} \
+		--build-arg EXTLDFLAGS="-s -w" \
+		-t ${DOCKER_IMAGE_NAME_OPERATOR}:${DOCKER_IMAGE_TAG} \
+		-f ${DOCKERFILE_OPERATOR} \
+		.
+
+.PHONY: build-debug
+build-debug: k8s-dist
+	docker build --pull --no-cache \
+		--build-arg BUILDVERSION=${BUILDVERSION} \
+		--build-arg BUILDDATE=${BUILDDATE} \
+		--build-arg EXTLDFLAGS="" \
 		-t ${DOCKER_IMAGE_NAME_OPERATOR}:${DOCKER_IMAGE_TAG} \
 		-f ${DOCKERFILE_OPERATOR} \
 		.
@@ -149,9 +160,14 @@ buildhook:
            -ldflags "-X main.buildVersion=${BUILDVERSION} -X main.buildDate=${BUILDDATE}" \
            -o /usr/bin/verrazzano-backup-hook ./verrazzano-backup-hook
 
+.PHONY: push-debug
+push-debug: build-debug push-common
 
 .PHONY: push
-push: build
+push: build push-common
+
+.PHONY: push-common
+push-common:
 	docker tag ${DOCKER_IMAGE_NAME_OPERATOR}:${DOCKER_IMAGE_TAG} ${DOCKER_IMAGE_FULLNAME_OPERATOR}:${DOCKER_IMAGE_TAG}
 	docker push ${DOCKER_IMAGE_FULLNAME_OPERATOR}:${DOCKER_IMAGE_TAG}
 

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,6 @@ endif
 
 DOCKER_NAMESPACE ?= verrazzano
 DOCKER_REPO ?= ghcr.io
-DIST_DIR:=dist
-BIN_DIR:=${DIST_DIR}/bin
 BIN_NAME:=${OPERATOR_NAME}
 K8S_EXTERNAL_IP:=localhost
 K8S_NAMESPACE:=verrazzano-system
@@ -112,28 +110,8 @@ go-vendor:
 # Docker-related tasks and functions
 #
 
-.PHONY: docker-clean
-docker-clean:
-	rm -rf ${DIST_DIR}
-
-.PHONY: k8s-dist
-k8s-dist: docker-clean
-	echo ${DOCKER_IMAGE_TAG} ${JENKINS_URL} ${CI_COMMIT_TAG} ${CI_COMMIT_SHA}
-	echo ${DOCKER_IMAGE_NAME_OPERATOR}
-	mkdir -p ${DIST_DIR}
-	cp -r docker-images/verrazzano-monitoring-operator/* ${DIST_DIR}
-	cp -r k8s/manifests/verrazzano-monitoring-operator.yaml $(DIST_DIR)/verrazzano-monitoring-operator.yaml
-
-	# Fill in Docker image and tag that's being tested
-	sed -i.bak "s|${DOCKER_REPO}/${DOCKER_NAMESPACE}/verrazzano-monitoring-operator:latest|${DOCKER_REPO}/${DOCKER_NAMESPACE}/${DOCKER_IMAGE_NAME_OPERATOR}:$(DOCKER_IMAGE_TAG)|g" $(DIST_DIR)/verrazzano-monitoring-operator.yaml
-	sed -i.bak "s/latest/$(DOCKER_IMAGE_TAG)/g" $(DIST_DIR)/verrazzano-monitoring-operator.yaml
-	sed -i.bak "s/default/${K8S_NAMESPACE}/g" $(DIST_DIR)/verrazzano-monitoring-operator.yaml
-
-	rm -rf $(DIST_DIR)/verrazzano-monitoring-operator*.bak
-	mkdir -p ${BIN_DIR}
-
 .PHONY: build
-build: k8s-dist
+build:
 	docker build --pull --no-cache \
 		--build-arg BUILDVERSION=${BUILDVERSION} \
 		--build-arg BUILDDATE=${BUILDDATE} \
@@ -143,7 +121,7 @@ build: k8s-dist
 		.
 
 .PHONY: build-debug
-build-debug: k8s-dist
+build-debug:
 	docker build --pull --no-cache \
 		--build-arg BUILDVERSION=${BUILDVERSION} \
 		--build-arg BUILDDATE=${BUILDDATE} \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) 2020, 2022, Oracle and/or its affiliates.
+# Copyright (C) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 OPERATOR_NAME:=verrazzano-monitoring-operator
 ESWAIT_NAME:=verrazzano-monitoring-instance-eswait
@@ -64,8 +64,8 @@ CRD_FILE:=./k8s/crds/verrazzano.io_verrazzanomonitoringinstances.yaml
 .PHONY: all
 all: build
 
-BUILDVERSION=`git describe --tags`
-BUILDDATE=`date +%FT%T%z`
+BUILDVERSION=$(shell grep verrazzano-development-version .verrazzano-development-version | cut -d= -f 2)
+BUILDDATE=$(shell date +"%Y-%m-%dT%H:%M:%SZ")
 
 .PHONY: manifests
 manifests: controller-gen

--- a/docker-images/verrazzano-monitoring-operator/Dockerfile
+++ b/docker-images/verrazzano-monitoring-operator/Dockerfile
@@ -30,7 +30,7 @@ FROM ghcr.io/oracle/oraclelinux:8-slim AS final
 
 RUN microdnf update -y \
     && microdnf clean all \
-    && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum /var/lib/rpm/__db.* \
     && groupadd -r verrazzano-monitoring-operator \
     && useradd --no-log-init -r -g verrazzano-monitoring-operator -u 1000 verrazzano-monitoring-operator
 

--- a/docker-images/verrazzano-monitoring-operator/Dockerfile
+++ b/docker-images/verrazzano-monitoring-operator/Dockerfile
@@ -20,8 +20,7 @@ ENV GOPATH /root/go
 ENV CGO_ENABLED 0
 COPY . .
 RUN go build \
-    -ldflags '-extldflags "-static"' \
-    -ldflags "-X main.buildVersion=${BUILDVERSION} -X main.buildDate=${BUILDDATE}" \
+    -ldflags "-s -w -extldflags -static -X 'main.buildVersion=$BUILDVERSION' -X 'main.buildDate=$BUILDDATE'" \
     -o /usr/bin/verrazzano-monitoring-operator ./cmd/verrazzano-monitoring-ctrl \
     && chmod 500 /usr/bin/verrazzano-monitoring-operator
 

--- a/docker-images/verrazzano-monitoring-operator/Dockerfile
+++ b/docker-images/verrazzano-monitoring-operator/Dockerfile
@@ -22,19 +22,20 @@ COPY . .
 RUN go build \
     -ldflags '-extldflags "-static"' \
     -ldflags "-X main.buildVersion=${BUILDVERSION} -X main.buildDate=${BUILDDATE}" \
-    -o /usr/bin/verrazzano-monitoring-operator ./cmd/verrazzano-monitoring-ctrl
+    -o /usr/bin/verrazzano-monitoring-operator ./cmd/verrazzano-monitoring-ctrl \
+    && chmod 500 /usr/bin/verrazzano-monitoring-operator
 
 
 FROM ghcr.io/oracle/oraclelinux:7-slim AS final
 
 RUN yum update -y \
-    && yum install -y openssl \
     && yum clean all \
     && rm -rf /var/cache/yum
-COPY --from=build_base /usr/bin/verrazzano-monitoring-operator /usr/local/bin/verrazzano-monitoring-operator
-WORKDIR /usr/local/bin/
-RUN groupadd -r verrazzano-monitoring-operator && useradd --no-log-init -r -g verrazzano-monitoring-operator -u 1000 verrazzano-monitoring-operator
-RUN chown 1000:verrazzano-monitoring-operator /usr/local/bin/verrazzano-monitoring-operator && chmod 500 /usr/local/bin/verrazzano-monitoring-operator
+
+RUN groupadd -r verrazzano-monitoring-operator \
+    && useradd --no-log-init -r -g verrazzano-monitoring-operator -u 1000 verrazzano-monitoring-operator
+
+COPY --from=build_base --chown=verrazzano-monitoring-operator:verrazzano-monitoring-operator /usr/bin/verrazzano-monitoring-operator /usr/local/bin/verrazzano-monitoring-operator
 USER 1000
 
 ENTRYPOINT ["/usr/local/bin/verrazzano-monitoring-operator"]

--- a/docker-images/verrazzano-monitoring-operator/Dockerfile
+++ b/docker-images/verrazzano-monitoring-operator/Dockerfile
@@ -13,6 +13,7 @@ RUN yum update -y \
 
 ARG BUILDVERSION
 ARG BUILDDATE
+ARG EXTLDFLAGS
 
 # Need to use specific WORKDIR to match verrazzano-monitoring-operator's source packages
 WORKDIR /root/go/src/github.com/verrazzano/verrazzano-monitoring-operator
@@ -20,7 +21,7 @@ ENV GOPATH /root/go
 ENV CGO_ENABLED 0
 COPY . .
 RUN go build \
-    -ldflags "-s -w -extldflags -static -X 'main.buildVersion=$BUILDVERSION' -X 'main.buildDate=$BUILDDATE'" \
+    -ldflags "$EXTLDFLAGS -extldflags -static -X 'main.buildVersion=$BUILDVERSION' -X 'main.buildDate=$BUILDDATE'" \
     -o /usr/bin/verrazzano-monitoring-operator ./cmd/verrazzano-monitoring-ctrl \
     && chmod 500 /usr/bin/verrazzano-monitoring-operator
 
@@ -29,6 +30,7 @@ FROM ghcr.io/oracle/oraclelinux:8-slim AS final
 
 RUN microdnf update -y \
     && microdnf clean all \
+    && rm -rf /var/cache/yum \
     && groupadd -r verrazzano-monitoring-operator \
     && useradd --no-log-init -r -g verrazzano-monitoring-operator -u 1000 verrazzano-monitoring-operator
 

--- a/docker-images/verrazzano-monitoring-operator/Dockerfile
+++ b/docker-images/verrazzano-monitoring-operator/Dockerfile
@@ -29,9 +29,8 @@ FROM ghcr.io/oracle/oraclelinux:7-slim AS final
 
 RUN yum update -y \
     && yum clean all \
-    && rm -rf /var/cache/yum
-
-RUN groupadd -r verrazzano-monitoring-operator \
+    && rm -rf /var/cache/yum \
+    && groupadd -r verrazzano-monitoring-operator \
     && useradd --no-log-init -r -g verrazzano-monitoring-operator -u 1000 verrazzano-monitoring-operator
 
 COPY --from=build_base --chown=verrazzano-monitoring-operator:verrazzano-monitoring-operator /usr/bin/verrazzano-monitoring-operator /usr/local/bin/verrazzano-monitoring-operator

--- a/docker-images/verrazzano-monitoring-operator/Dockerfile
+++ b/docker-images/verrazzano-monitoring-operator/Dockerfile
@@ -25,11 +25,10 @@ RUN go build \
     && chmod 500 /usr/bin/verrazzano-monitoring-operator
 
 
-FROM ghcr.io/oracle/oraclelinux:7-slim AS final
+FROM ghcr.io/oracle/oraclelinux:8-slim AS final
 
-RUN yum update -y \
-    && yum clean all \
-    && rm -rf /var/cache/yum \
+RUN microdnf update -y \
+    && microdnf clean all \
     && groupadd -r verrazzano-monitoring-operator \
     && useradd --no-log-init -r -g verrazzano-monitoring-operator -u 1000 verrazzano-monitoring-operator
 


### PR DESCRIPTION
This pull request includes the following changes:
1. Reduce the VMO image size from 255MB to 148MB.
2. Use oraclelinux:8-slim to build final image.
3. Changed existing Makefile targets to build without symbol tables. This reduces the image size by about 20MB.
4. Added Makefile debug targets to build VMO with symbol tables if you need to debug.
5. Some cleanup in Makefile