### PR TITLE
VZ-8763: Modify plugin install logic to fail only the master node in case of install failure.

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -351,7 +351,7 @@ func NewOpenSearchDashboardsDeployment(vmo *vmcontrollerv1.VerrazzanoMonitoringI
 		deployment.Spec.Template.Spec.Containers[0].Command = []string{
 			"sh",
 			"-c",
-			fmt.Sprintf(resources.OpenSearchDashboardCmdTmpl, resources.GetOSPluginsInstallTmpl(resources.GetOSDashboardPluginList(vmo), resources.OSDashboardPluginsInstallCmd)),
+			fmt.Sprintf(resources.OpenSearchDashboardCmdTmpl, resources.GetOSPluginsInstallTmpl(resources.GetOSDashboardPluginList(vmo), resources.OSDashboardPluginsInstallCmd, resources.OSDashboardPluginsInstallTmpl)),
 		}
 	}
 

--- a/pkg/resources/deployments/elasticsearch.go
+++ b/pkg/resources/deployments/elasticsearch.go
@@ -132,7 +132,7 @@ func (es ElasticsearchBasic) createElasticsearchIngestDeploymentElements(vmo *vm
 		ingestDeployment.Spec.Template.Spec.Containers[0].Command = []string{
 			"sh",
 			"-c",
-			fmt.Sprintf(resources.OpenSearchIngestCmdTmpl, resources.GetOSPluginsInstallTmpl(resources.GetOpenSearchPluginList(vmo), resources.OSPluginsInstallCmd)),
+			fmt.Sprintf(resources.OpenSearchIngestCmdTmpl, resources.GetOSPluginsInstallTmpl(resources.GetOpenSearchPluginList(vmo), resources.OSPluginsInstallCmd, resources.OSIngestPluginsInstallTmpl)),
 		}
 		ingestDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = fmt.Sprintf("%d", constants.OSTransportPort)
 		ingestDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = fmt.Sprintf("%d", constants.OSTransportPort)
@@ -236,7 +236,7 @@ func (es ElasticsearchBasic) createElasticsearchDataDeploymentElements(vmo *vmco
 			dataDeployment.Spec.Template.Spec.Containers[0].Command = []string{
 				"sh",
 				"-c",
-				resources.CreateOpenSearchContainerCMD(javaOpts, resources.GetOpenSearchPluginList(vmo)),
+				resources.CreateOpenSearchContainerCMD(javaOpts, resources.GetOpenSearchPluginList(vmo), resources.OSDataPluginsInstallTmpl),
 			}
 
 			// add the required istio annotations to allow inter-es component communication

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -36,7 +36,7 @@ const (
 	set -euo pipefail
     %s
 	/usr/local/bin/docker-entrypoint.sh
-    set +euo pipefail`
+    `
 	OpenSearchDashboardCmdTmpl = `#!/usr/bin/env bash -e
     %s
 	/usr/local/bin/opensearch-dashboards-docker`
@@ -69,6 +69,7 @@ const (
      %s
     `
 	OSIngestPluginsInstallTmpl = `
+     set +euo pipefail
      # Install OS plugins that are not bundled with OS
      %s
     `

--- a/pkg/resources/helper_test.go
+++ b/pkg/resources/helper_test.go
@@ -118,30 +118,34 @@ func TestCreateOpenSearchContainerCMD(t *testing.T) {
 	containerCmdWithoutJavaOpts := fmt.Sprintf(containerCmdTmpl, "", "")
 	containerCmdWithJavaOpts := fmt.Sprintf(containerCmdTmpl, jvmOptsDisableCmd, "")
 	var tests = []struct {
-		description    string
-		javaOpts       string
-		expectedResult string
+		description          string
+		javaOpts             string
+		expectedResult       string
+		OSPluginsInstallTmpl string
 	}{
 		{
 			"testCreateOpenSearchContainerCMD with empty jvmOpts",
 			"",
 			containerCmdWithoutJavaOpts,
+			OSMasterPluginsInstallTmpl,
 		},
 		{
 			"testCreateOpenSearchContainerCMD with jvmOpts not containing jvm memory settings",
 			"-Xsomething",
 			containerCmdWithoutJavaOpts,
+			OpenSearchIngestCmdTmpl,
 		},
 		{
 			"testCreateOpenSearchContainerCMD with jvmOpts containing jvm memory settings",
 			"-Xms1g -Xmx2g",
 			containerCmdWithJavaOpts,
+			OpenSearchIngestCmdTmpl,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			r := CreateOpenSearchContainerCMD(tt.javaOpts, []string{})
+			r := CreateOpenSearchContainerCMD(tt.javaOpts, []string{}, tt.OSPluginsInstallTmpl)
 			assert.Equal(t, tt.expectedResult, r)
 		})
 	}
@@ -261,7 +265,7 @@ func TestGetOSPluginsInstallTmpl(t *testing.T) {
 		{
 			"TestGetOSPluginsInstallTmpl when list of plugins is provided",
 			[]string{plugin},
-			fmt.Sprintf(OSPluginsInstallTmpl, fmt.Sprintf(OSPluginsInstallCmd, plugin)),
+			fmt.Sprintf(OSMasterPluginsInstallTmpl, fmt.Sprintf(OSPluginsInstallCmd, plugin)),
 		},
 		{
 			"TestGetOSPluginsInstallTmpl when no plugin is provided",
@@ -271,7 +275,7 @@ func TestGetOSPluginsInstallTmpl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetOSPluginsInstallTmpl(tt.plugins, OSPluginsInstallCmd); got != tt.want {
+			if got := GetOSPluginsInstallTmpl(tt.plugins, OSPluginsInstallCmd, OSMasterPluginsInstallTmpl); got != tt.want {
 				t.Errorf("GetOSPluginsInstallTmpl() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -85,7 +85,7 @@ func createOpenSearchStatefulSet(log vzlog.VerrazzanoLogger, vmo *vmcontrollerv1
 	esMasterContainer.Command = []string{
 		"sh",
 		"-c",
-		resources.CreateOpenSearchContainerCMD(javaOpts, resources.GetOpenSearchPluginList(vmo)),
+		resources.CreateOpenSearchContainerCMD(javaOpts, resources.GetOpenSearchPluginList(vmo), resources.OSMasterPluginsInstallTmpl),
 	}
 	var envVars = []corev1.EnvVar{
 		{


### PR DESCRIPTION
Currently, if the plugin installs through vz CR fails, the entire OS cluster goes into a bad state, and due to this any VZ CR update for OS doesn't take place as we have a check where we do not allow any changes to sts/deployments if cluster health is not green. This issue is to enhance the logic to not put the entire cluster into a bad state if plugin installs fail for any reason and only the master node will fail so that the customer can figure out that there was something wrong and at the same time cluster is operational.