### PR TITLE
VZ-8729: Enhanced condition to handle to ISM Management

### DIFF
--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
 	"net/http"
 	"strings"
 
@@ -252,11 +253,7 @@ func (o *OSClient) deletePolicy(opensearchEndpoint, policyName string) (*http.Re
 
 // updateISMPolicyFromFile creates or updates the ISM policy from the given json file.
 // If ISM policy doesn't exist, it will create new. Otherwise, it'll create one.
-func (o *OSClient) updateISMPolicyFromFile(openSearchEndpoint string, policyFileName string, policyName string) (*ISMPolicy, error) {
-	policy, err := getISMPolicyFromFile(policyFileName)
-	if err != nil {
-		return nil, err
-	}
+func (o *OSClient) updateISMPolicy(openSearchEndpoint string, policyName string, policy *ISMPolicy) (*ISMPolicy, error) {
 	existingPolicyURL := fmt.Sprintf("%s/_plugins/_ism/policies/%s", openSearchEndpoint, policyName)
 	existingPolicy, err := o.getPolicyByName(existingPolicyURL)
 	if err != nil {
@@ -266,14 +263,27 @@ func (o *OSClient) updateISMPolicyFromFile(openSearchEndpoint string, policyFile
 }
 
 // createOrUpdateDefaultISMPolicy creates the default ISM policies if not exist, else the policies will be updated.
-func (o *OSClient) createOrUpdateDefaultISMPolicy(openSearchEndpoint string) ([]*ISMPolicy, error) {
+func (o *OSClient) createOrUpdateDefaultISMPolicy(log vzlog.VerrazzanoLogger, openSearchEndpoint string) ([]*ISMPolicy, error) {
 	var defaultPolicies []*ISMPolicy
+	allPolicyList, err := o.getAllPolicies(openSearchEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("os system has %v policies", len(allPolicyList.Policies))
 	for policyName, policyFile := range defaultISMPoliciesMap {
-		createdPolicy, err := o.updateISMPolicyFromFile(openSearchEndpoint, policyFile, policyName)
+		policy, err := getISMPolicyFromFile(policyFile)
 		if err != nil {
-			return defaultPolicies, err
+			return nil, err
 		}
-		defaultPolicies = append(defaultPolicies, createdPolicy)
+		log.Debugf("checking if custom policy exists for %s from file %s", policyName, policyFile)
+		if !o.isCustomPolicyExists(log, policy, policyName, allPolicyList.Policies) {
+			log.Debugf("creating default policy for policy %s", policyName)
+			createdPolicy, err := o.updateISMPolicy(openSearchEndpoint, policyName, policy)
+			if err != nil {
+				return defaultPolicies, err
+			}
+			defaultPolicies = append(defaultPolicies, createdPolicy)
+		}
 	}
 	return defaultPolicies, nil
 }
@@ -376,4 +386,27 @@ func getISMPolicyFromFile(policyFileName string) (*ISMPolicy, error) {
 		return nil, err
 	}
 	return &policy, nil
+}
+
+func (o *OSClient) isCustomPolicyExists(log vzlog.VerrazzanoLogger, searchPolicy *ISMPolicy, searchPolicyName string, policyList []ISMPolicy) bool {
+	for _, policy := range policyList {
+		if *policy.ID != searchPolicyName && policy.Policy.ISMTemplate[0].Priority == searchPolicy.Policy.ISMTemplate[0].Priority && isItemAlreadyExists(log, policy.Policy.ISMTemplate[0].IndexPatterns, searchPolicy.Policy.ISMTemplate[0].IndexPatterns) {
+			log.Debugf("custom policy exists for policy %s", searchPolicyName)
+			return true
+		}
+	}
+	return false
+}
+func isItemAlreadyExists(log vzlog.VerrazzanoLogger, allListPolicyPatterns []string, subListPolicyPattern []string) bool {
+	matched := false
+	log.Debugf("searching for index pattern %s in all ISM policies %s", subListPolicyPattern, allListPolicyPatterns)
+	for _, al := range allListPolicyPatterns {
+		for _, sl := range subListPolicyPattern {
+			if al == sl {
+				matched = true
+				break
+			}
+		}
+	}
+	return matched
 }

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -590,7 +590,11 @@ func TestUpdateISMPolicyFromFile(t *testing.T) {
 				DoHTTP:            tt.fields.DoHTTP,
 				statefulSetLister: tt.fields.statefulSetLister,
 			}
-			got, err := o.updateISMPolicyFromFile(tt.args.openSearchEndpoint, tt.args.policyFileName, tt.args.policyName)
+			policyObject, err := getISMPolicyFromFile(tt.args.policyFileName)
+			if err != nil {
+				return
+			}
+			got, err := o.updateISMPolicy(tt.args.openSearchEndpoint, tt.args.policyFileName, policyObject)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("updateISMPolicyFromFile() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
 	"net/http"
 
 	"go.uber.org/zap"
@@ -129,7 +130,7 @@ func (o *OSClient) DeleteDefaultISMPolicy(vmi *vmcontrollerv1.VerrazzanoMonitori
 
 // SyncDefaultISMPolicy set up the default ISM Policies.
 // The returned channel should be read for exactly one response, which tells whether default ISM policies are synced.
-func (o *OSClient) SyncDefaultISMPolicy(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) chan error {
+func (o *OSClient) SyncDefaultISMPolicy(log vzlog.VerrazzanoLogger, vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) chan error {
 	ch := make(chan error)
 	go func() {
 		if !vmi.Spec.Opensearch.Enabled || vmi.Spec.Opensearch.DisableDefaultPolicy {
@@ -142,7 +143,8 @@ func (o *OSClient) SyncDefaultISMPolicy(vmi *vmcontrollerv1.VerrazzanoMonitoring
 			return
 		}
 		openSearchEndpoint := resources.GetOpenSearchHTTPEndpoint(vmi)
-		_, err := o.createOrUpdateDefaultISMPolicy(openSearchEndpoint)
+		log.Debugf("calling createOrUpdateDefaultISMPolicy")
+		_, err := o.createOrUpdateDefaultISMPolicy(log, openSearchEndpoint)
 		ch <- err
 	}()
 

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -143,7 +143,6 @@ func (o *OSClient) SyncDefaultISMPolicy(log vzlog.VerrazzanoLogger, vmi *vmcontr
 			return
 		}
 		openSearchEndpoint := resources.GetOpenSearchHTTPEndpoint(vmi)
-		log.Debugf("calling createOrUpdateDefaultISMPolicy")
 		_, err := o.createOrUpdateDefaultISMPolicy(log, openSearchEndpoint)
 		ch <- err
 	}()

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -489,7 +489,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	/*********************
 	 * Synchronise Default ISM Policies
 	 **********************/
-	defaultISMChannel := c.osClient.SyncDefaultISMPolicy(vmo)
+	defaultISMChannel := c.osClient.SyncDefaultISMPolicy(c.log, vmo)
 
 	/********************************************
 	 * Migrate old indices if any to data streams


### PR DESCRIPTION
This MR will address ISM in opensearch when the customer already has its own customs policy with.



- The system has a custom policy for index vz-system with the same priority and DefaultDisable is not configured.     --> Created missing policy 

- System has a custom policy for index vz-system with higher priority and DefaultDisable is not configured.  ---> Created both default policies.

- System has a custom policy for index vz-system with same priority and DefaultDisable true.      ---> Nothing happened. Single policy exists.

- System has a custom policy for index vz-system with higher priority and DefaultDisable true.     --->Nothing happened. Single policy exists.

- System doesn’t have any policy and DefaultDisable is false.          ---> Default policies created.

- System doesn’t have any policy and DefaultDisable true.    ---> Nothing happened empty system.
Special Case
- System has same name policy with some different conditions, then vz policy will override the same and create ISM policy as per our configuration.