### PR TITLE
VZ-9210: Add annotation to OS/OSD pods to add hooks to delay application startup until the pod proxy is ready to accept traffic

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -211,3 +211,6 @@ const PodUser = 1000
 
 // TimeStamp used to add timestamp as TimeFieldName in the index pattern
 const TimeStamp = "@timestamp"
+
+// HoldAppUntilProxyStarts used to hold the application until Istio sidecar proxy starts
+const HoldAppUntilProxyStarts = "true"

--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -347,6 +347,7 @@ func NewOpenSearchDashboardsDeployment(vmo *vmcontrollerv1.VerrazzanoMonitoringI
 			deployment.Spec.Template.Annotations = make(map[string]string)
 		}
 		deployment.Spec.Template.Annotations["traffic.sidecar.istio.io/includeOutboundPorts"] = fmt.Sprintf("%d", constants.OSHTTPPort)
+		deployment.Spec.Template.Annotations["proxy.istio.io/config"] = fmt.Sprintf("{ 'holdApplicationUntilProxyStarts': %s }", constants.HoldAppUntilProxyStarts)
 		// Adding command to install OS plugins at pod bootup
 		deployment.Spec.Template.Spec.Containers[0].Command = []string{
 			"sh",

--- a/pkg/resources/deployments/elasticsearch.go
+++ b/pkg/resources/deployments/elasticsearch.go
@@ -136,6 +136,7 @@ func (es ElasticsearchBasic) createElasticsearchIngestDeploymentElements(vmo *vm
 		}
 		ingestDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = fmt.Sprintf("%d", constants.OSTransportPort)
 		ingestDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = fmt.Sprintf("%d", constants.OSTransportPort)
+		ingestDeployment.Spec.Template.Annotations["proxy.istio.io/config"] = fmt.Sprintf("{ 'holdApplicationUntilProxyStarts': %s }", constants.HoldAppUntilProxyStarts)
 		deployments = append(deployments, ingestDeployment)
 	}
 	return deployments
@@ -245,6 +246,7 @@ func (es ElasticsearchBasic) createElasticsearchDataDeploymentElements(vmo *vmco
 			}
 			dataDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = fmt.Sprintf("%d", constants.OSTransportPort)
 			dataDeployment.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = fmt.Sprintf("%d", constants.OSTransportPort)
+			dataDeployment.Spec.Template.Annotations["proxy.istio.io/config"] = fmt.Sprintf("{ 'holdApplicationUntilProxyStarts': %s }", constants.HoldAppUntilProxyStarts)
 			deployments = append(deployments, dataDeployment)
 		}
 	}

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -65,15 +65,21 @@ const (
 	`
 	OSMasterPluginsInstallTmpl = `
      set -euo pipefail
+     # wait for Sidecar proxy to be ready
+     until curl -sS --head localhost:15021/healthz/ready; do echo Waiting for Sidecar; sleep 3 ; done ;
      # Install OS plugins that are not bundled with OS
      %s
     `
 	OSIngestPluginsInstallTmpl = `
      set +euo pipefail
+     # wait for Sidecar proxy to be ready
+     countdown=10;until curl -sS --head localhost:15021/healthz/ready || [ $countdown -eq 0 ]; do echo Waiting for Sidecar; sleep 3 ; ((countdown--)) ; done ;
      # Install OS plugins that are not bundled with OS
      %s
     `
 	OSDataPluginsInstallTmpl = `
+     # wait for Sidecar proxy to be ready
+     countdown=10;until curl -sS --head localhost:15021/healthz/ready || [ $countdown -eq 0 ]; do echo Waiting for Sidecar; sleep 3 ; ((countdown--)) ; done ;
      # Install OS plugins that are not bundled with OS
      %s
     `
@@ -85,6 +91,8 @@ const (
     /usr/share/opensearch/bin/opensearch-plugin install -b %s
 	`
 	OSDashboardPluginsInstallCmd = `
+    # wait for Sidecar proxy to be ready
+    until curl -sS --head localhost:15021/healthz/ready; do echo Waiting for Sidecar; sleep 3 ; done ;
     /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install %s
 	`
 )

--- a/pkg/resources/helper.go
+++ b/pkg/resources/helper.go
@@ -65,21 +65,15 @@ const (
 	`
 	OSMasterPluginsInstallTmpl = `
      set -euo pipefail
-     # wait for Sidecar proxy to be ready
-     until curl -sS --head localhost:15021/healthz/ready; do echo Waiting for Sidecar; sleep 3 ; done ;
      # Install OS plugins that are not bundled with OS
      %s
     `
 	OSIngestPluginsInstallTmpl = `
      set +euo pipefail
-     # wait for Sidecar proxy to be ready
-     countdown=10;until curl -sS --head localhost:15021/healthz/ready || [ $countdown -eq 0 ]; do echo Waiting for Sidecar; sleep 3 ; ((countdown--)) ; done ;
      # Install OS plugins that are not bundled with OS
      %s
     `
 	OSDataPluginsInstallTmpl = `
-     # wait for Sidecar proxy to be ready
-     countdown=10;until curl -sS --head localhost:15021/healthz/ready || [ $countdown -eq 0 ]; do echo Waiting for Sidecar; sleep 3 ; ((countdown--)) ; done ;
      # Install OS plugins that are not bundled with OS
      %s
     `
@@ -91,8 +85,6 @@ const (
     /usr/share/opensearch/bin/opensearch-plugin install -b %s
 	`
 	OSDashboardPluginsInstallCmd = `
-    # wait for Sidecar proxy to be ready
-    until curl -sS --head localhost:15021/healthz/ready; do echo Waiting for Sidecar; sleep 3 ; done ;
     /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin install %s
 	`
 )

--- a/pkg/resources/statefulsets/statefulset.go
+++ b/pkg/resources/statefulsets/statefulset.go
@@ -273,7 +273,7 @@ fi`,
 	}
 	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeInboundPorts"] = fmt.Sprintf("%d", constants.OSTransportPort)
 	statefulSet.Spec.Template.Annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = fmt.Sprintf("%d", constants.OSTransportPort)
-
+	statefulSet.Spec.Template.Annotations["proxy.istio.io/config"] = fmt.Sprintf("{ 'holdApplicationUntilProxyStarts': %s }", constants.HoldAppUntilProxyStarts)
 	// set Node Role labels for role based selectors
 	nodes.SetNodeRoleLabels(&node, statefulSet.Spec.Template.Labels)
 	return statefulSet


### PR DESCRIPTION
Added annotations `proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'` to OS/OSD pods.
This annotation adds hooks to delay application startup until the pod proxy is ready to accept traffic, mitigating some startup race conditions.