### PR TITLE
VZ-9220: Fix OS data node PVC resize through VZ CR

### DIFF
--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -49,7 +49,8 @@ func NewOSClient(statefulSetLister appslistersv1.StatefulSetLister) *OSClient {
 // - 'green' health
 // - all expected nodes are present in the cluster status
 func (o *OSClient) IsDataResizable(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance) error {
-	if vmo.Spec.Opensearch.DataNode.Replicas < MinDataNodesForResize {
+	dataNodes := nodes.DataNodes(vmo)
+	if len(dataNodes) < MinDataNodesForResize {
 		return fmt.Errorf("cannot resize OpenSearch with less than %d data nodes. Scale up your cluster to at least %d data nodes", MinDataNodesForResize, MinDataNodesForResize)
 	}
 	return o.opensearchHealth(vmo, true, true)

--- a/pkg/vmo/pvc_update.go
+++ b/pkg/vmo/pvc_update.go
@@ -154,7 +154,9 @@ func updateVMOStorageForPVC(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, ol
 
 	// Look for the PVC reference and update it
 	updateStorage(&vmo.Spec.Grafana.Storage)
-	updateStorage(vmo.Spec.Opensearch.DataNode.Storage)
+	for _, dataNode := range nodes.DataNodes(vmo) {
+		updateStorage(dataNode.Storage)
+	}
 }
 
 // setPerNodeStorage updates the VMO OpenSearch storage spec to reflect the current API

--- a/pkg/vmo/pvc_update_test.go
+++ b/pkg/vmo/pvc_update_test.go
@@ -189,16 +189,29 @@ func TestUpdateVMOStorageForPVC(t *testing.T) {
 						},
 					},
 				},
+				Nodes: []vmcontrollerv1.ElasticsearchNode{
+					{
+						Roles: []vmcontrollerv1.NodeRole{
+							vmcontrollerv1.DataRole,
+						},
+						Storage: &vmcontrollerv1.Storage{PvcNames: []string{
+							"some other pvc",
+							"oldpvc",
+						}},
+					},
+				},
 			},
 		},
 	}
 
 	updateVMOStorageForPVC(vmo, "oldpvc", "newpvc")
 	assert.Equal(t, "newpvc", vmo.Spec.Opensearch.DataNode.Storage.PvcNames[1])
+	assert.Equal(t, "newpvc", vmo.Spec.Opensearch.Nodes[0].Storage.PvcNames[1])
 }
 
 func TestIsOpenSearchPVC(t *testing.T) {
 	assert.True(t, isOpenSearchPVC(makePVC("vmi-system-es-data-0", "1Gi")))
+	assert.True(t, isOpenSearchPVC(makePVC("vmi-system-es-data-1-03xqy", "1Gi")))
 	assert.False(t, isOpenSearchPVC(makePVC("vmi-system-grafana", "1Gi")))
 }
 


### PR DESCRIPTION
Before we do a resize we are checking if minimum number of data nodes are available, but that check is not correct. We are checking count of  vmo.Spec.Opensearch.DataNode.Replicas which is not populated in the vmi spec so it will not go past this and resize never happens and it keeps failing.

Updated the code to check for all data nodes instead of just vmo.Spec.Opensearch.DataNode

Tested resizing the PVC on a kind cluster. New PVC's were created and assigned one by one to the nodes. The cluster was green at the end. The VMI spec was updated with the new size and pvc names as well.