### PR TITLE
VZ-9459.  Explicitly annotate ingresses with the Verrazzano cluster issuer

### DIFF
--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -18,6 +18,8 @@ import (
 
 var defaultIngressClassName = "verrazzano-nginx"
 
+const verrazzanoClusterIssuerName = "verrazzano-cluster-issuer"
+
 func createIngressRuleElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, componentDetails config.ComponentDetails) netv1.IngressRule {
 	serviceName := resources.GetMetaName(vmo.Name, componentDetails.Name)
 	endpointName := componentDetails.EndpointName
@@ -89,6 +91,7 @@ func createIngressElementNoBasicAuth(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 	}
 
 	ingress.Annotations["cert-manager.io/common-name"] = hostName
+	ingress.Annotations["cert-manager.io/cluster-issuer"] = verrazzanoClusterIssuerName
 	return ingress, nil
 }
 
@@ -290,6 +293,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 	ingress.Annotations["nginx.ingress.kubernetes.io/rewrite-target"] = "/$2"
 	setNginxRoutingAnnotations(ingress)
 	ingress.Annotations["cert-manager.io/common-name"] = ingressHost
+	ingress.Annotations["cert-manager.io/cluster-issuer"] = verrazzanoClusterIssuerName
 	return ingress
 }
 

--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package ingresses


### PR DESCRIPTION
Adds the annotation

```
	ingress.Annotations["cert-manager.io/cluster-issuer"] = "verrazzano-cluster-issuer"
```

to the ingresses managed by the VMO.  This is to allow integration with externally installed Cert-Manager instances where the default ClusterIssuer is not the Verrazzano issuer.