### PR TITLE
VZ-9631 cert manager backport

### DIFF
--- a/pkg/resources/ingresses/ingress.go
+++ b/pkg/resources/ingresses/ingress.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020, 2022, Oracle and/or its affiliates.
+// Copyright (C) 2020, 2023, Oracle and/or its affiliates.
 // Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
 package ingresses
@@ -17,6 +17,8 @@ import (
 )
 
 var defaultIngressClassName = "verrazzano-nginx"
+
+const verrazzanoClusterIssuerName = "verrazzano-cluster-issuer"
 
 func createIngressRuleElement(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, componentDetails config.ComponentDetails) netv1.IngressRule {
 	serviceName := resources.GetMetaName(vmo.Name, componentDetails.Name)
@@ -89,6 +91,7 @@ func createIngressElementNoBasicAuth(vmo *vmcontrollerv1.VerrazzanoMonitoringIns
 	}
 
 	ingress.Annotations["cert-manager.io/common-name"] = hostName
+	ingress.Annotations["cert-manager.io/cluster-issuer"] = verrazzanoClusterIssuerName
 	return ingress, nil
 }
 
@@ -290,6 +293,7 @@ func newOidcProxyIngress(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, compo
 	ingress.Annotations["nginx.ingress.kubernetes.io/rewrite-target"] = "/$2"
 	setNginxRoutingAnnotations(ingress)
 	ingress.Annotations["cert-manager.io/common-name"] = ingressHost
+	ingress.Annotations["cert-manager.io/cluster-issuer"] = verrazzanoClusterIssuerName
 	return ingress
 }
 


### PR DESCRIPTION
* Add the cert-manager.io/cluster-issuer annotation to the OS/OSD/Grafana ingresses

* Fix copyright and add unit tests

(cherry picked from commit b70d5240b054c0999609d2977fb0b9b844c381c5)