### PR TITLE
VZ-10009: Changes to default ISM Policy

### DIFF
--- a/k8s/manifests/opensearch/vz-application-default-ISM-policy.json
+++ b/k8s/manifests/opensearch/vz-application-default-ISM-policy.json
@@ -14,31 +14,8 @@
               "delay":"10m"
             },
             "rollover":{
-              "min_primary_shard_size":"1gb",
-              "min_index_age":"7d"
-            }
-          }
-        ],
-        "transitions":[
-          {
-            "state_name":"cold",
-            "conditions":{
-              "min_index_age":"7d"
-            }
-          }
-        ]
-      },
-      {
-        "name":"cold",
-        "actions":[
-          {
-            "retry":{
-              "count":3,
-              "backoff":"exponential",
-              "delay":"10m"
-            },
-            "close":{
-
+              "min_primary_shard_size":"5gb",
+              "min_index_age":"21d"
             }
           }
         ],
@@ -46,7 +23,7 @@
           {
             "state_name":"delete",
             "conditions":{
-              "min_index_age":"12d"
+              "min_rollover_age":"14d"
             }
           }
         ]

--- a/k8s/manifests/opensearch/vz-system-default-ISM-policy.json
+++ b/k8s/manifests/opensearch/vz-system-default-ISM-policy.json
@@ -21,26 +21,6 @@
         ],
         "transitions":[
           {
-            "state_name":"warm"
-          }
-        ]
-      },
-      {
-        "name":"warm",
-        "actions":[
-          {
-            "retry":{
-              "count":3,
-              "backoff":"exponential",
-              "delay":"10m"
-            },
-            "replica_count":{
-              "number_of_replicas": 0
-            }
-          }
-        ],
-        "transitions":[
-          {
             "state_name":"delete",
             "conditions":{
               "min_rollover_age":"14d"

--- a/k8s/manifests/opensearch/vz-system-default-ISM-policy.json
+++ b/k8s/manifests/opensearch/vz-system-default-ISM-policy.json
@@ -15,21 +15,18 @@
             },
             "rollover":{
               "min_primary_shard_size":"5gb",
-              "min_index_age":"30d"
+              "min_index_age":"21d"
             }
           }
         ],
         "transitions":[
           {
-            "state_name":"cold",
-            "conditions":{
-              "min_index_age":"30d"
-            }
+            "state_name":"warm"
           }
         ]
       },
       {
-        "name":"cold",
+        "name":"warm",
         "actions":[
           {
             "retry":{
@@ -37,8 +34,8 @@
               "backoff":"exponential",
               "delay":"10m"
             },
-            "close":{
-
+            "replica_count":{
+              "number_of_replicas": 0
             }
           }
         ],
@@ -46,7 +43,7 @@
           {
             "state_name":"delete",
             "conditions":{
-              "min_index_age":"35d"
+              "min_rollover_age":"14d"
             }
           }
         ]

--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -300,13 +300,15 @@ func (o *OSClient) createOrUpdateDefaultISMPolicy(log vzlog.VerrazzanoLogger, op
 			if err != nil {
 				return defaultPolicies, err
 			}
-			defaultPolicies = append(defaultPolicies, createdPolicy)
 			// When the default policy is created or updated
 			// Add default policy to the current write index of the data stream
-			err = o.addDefaultPolicyToDataStream(log, openSearchEndpoint, createdPolicy)
-			if err != nil {
-				return defaultPolicies, err
+			if createdPolicy != nil {
+				err = o.addDefaultPolicyToDataStream(log, openSearchEndpoint, createdPolicy)
+				if err != nil {
+					return defaultPolicies, err
+				}
 			}
+			defaultPolicies = append(defaultPolicies, createdPolicy)
 		}
 	}
 	return defaultPolicies, nil

--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -315,6 +315,7 @@ func (o *OSClient) createOrUpdateDefaultISMPolicy(log vzlog.VerrazzanoLogger, op
 	return defaultPolicies, nil
 }
 
+// addDefaultPolicyToDataStream adds the default policy to the current write index of the data stream
 func (o *OSClient) addDefaultPolicyToDataStream(log vzlog.VerrazzanoLogger, openSearchEndpoint, policyName string, policy *ISMPolicy) error {
 	if len(policy.Policy.ISMTemplate) <= 0 {
 		return fmt.Errorf("no index template defined in policy %s", policyName)
@@ -352,6 +353,8 @@ func (o *OSClient) addDefaultPolicyToDataStream(log vzlog.VerrazzanoLogger, open
 	return nil
 }
 
+// isManagedByDefaultPolicy returns true if the policy is being managed by the default policy
+// or if it is not being managed by any policy at all
 func (o *OSClient) isManagedByDefaultPolicy(openSearchEndpoint, index, policyID string) (bool, error) {
 	url := fmt.Sprintf("%s/_plugins/_ism/explain/%s", openSearchEndpoint, index)
 	req, err := http.NewRequest("GET", url, nil)
@@ -382,6 +385,7 @@ func (o *OSClient) isManagedByDefaultPolicy(openSearchEndpoint, index, policyID 
 	return false, nil
 }
 
+// addPolicyForIndex attaches an ISM policy to an index
 func (o *OSClient) addPolicyForIndex(openSearchEndpoint, index, policyID string) error {
 	url := fmt.Sprintf("%s/_plugins/_ism/add/%s", openSearchEndpoint, index)
 	body := strings.NewReader(fmt.Sprintf(`{"policy_id": "%s"}`, policyID))
@@ -401,6 +405,7 @@ func (o *OSClient) addPolicyForIndex(openSearchEndpoint, index, policyID string)
 	return nil
 }
 
+// removePolicyForIndex removes the ISM policy attached to an index
 func (o *OSClient) removePolicyForIndex(openSearchEndpoint, index string) error {
 	url := fmt.Sprintf("%s/_plugins/_ism/remove/%s", openSearchEndpoint, index)
 	req, err := http.NewRequest("POST", url, nil)
@@ -418,6 +423,7 @@ func (o *OSClient) removePolicyForIndex(openSearchEndpoint, index string) error 
 	return nil
 }
 
+// getWriteIndexForDataStream returns the current write indices for a given data stream pattern
 func (o *OSClient) getWriteIndexForDataStream(log vzlog.VerrazzanoLogger, openSearchEndpoint, pattern string) ([]string, error) {
 	url := fmt.Sprintf("%s/_data_stream/%s", openSearchEndpoint, pattern)
 	req, err := http.NewRequest("GET", url, nil)

--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -19,7 +19,7 @@ import (
 
 type (
 	DataStreams struct {
-		DataStream []DataStream `json:"data_streams,omitempty"`
+		DataStreams []DataStream `json:"data_streams,omitempty"`
 	}
 	DataStream struct {
 		Name           string    `json:"name,omitempty"`
@@ -331,9 +331,9 @@ func (o *OSClient) addDefaultPolicyToDataStream(log vzlog.VerrazzanoLogger, open
 		}
 
 		for _, index := range writeIndices {
-			// Check if the index is currently being managed by our default policy
-			// If not then don't add the default policy
-			ok, err := o.isManagedByDefaultPolicy(openSearchEndpoint, index, policyName)
+			// Check if the index is currently being managed by our default policy or no policy at all
+			// If yes then attach the default policy to the index
+			ok, err := o.shouldAddOrRemoveDefaultPolicy(openSearchEndpoint, index, policyName)
 			if err != nil {
 				return err
 			}
@@ -353,9 +353,9 @@ func (o *OSClient) addDefaultPolicyToDataStream(log vzlog.VerrazzanoLogger, open
 	return nil
 }
 
-// isManagedByDefaultPolicy returns true if the policy is being managed by the default policy
+// shouldAddOrRemoveDefaultPolicy returns true if the policy is being managed by the default policy
 // or if it is not being managed by any policy at all
-func (o *OSClient) isManagedByDefaultPolicy(openSearchEndpoint, index, policyID string) (bool, error) {
+func (o *OSClient) shouldAddOrRemoveDefaultPolicy(openSearchEndpoint, index, policyID string) (bool, error) {
 	url := fmt.Sprintf("%s/_plugins/_ism/explain/%s", openSearchEndpoint, index)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -451,7 +451,7 @@ func (o *OSClient) getWriteIndexForDataStream(log vzlog.VerrazzanoLogger, openSe
 	}
 
 	var writeIndex []string
-	for _, dataStream := range dataStreams.DataStream {
+	for _, dataStream := range dataStreams.DataStreams {
 		// Current write index for a data stream is the last index in the indices list
 		indices := dataStream.Indices
 		size := len(indices)

--- a/pkg/opensearch/ism.go
+++ b/pkg/opensearch/ism.go
@@ -34,7 +34,7 @@ type (
 	}
 	Index struct {
 		Name string `json:"index_name,omitempty"`
-		Uuid string `json:"index_uuid,omitempty"`
+		UUID string `json:"index_uuid,omitempty"`
 	}
 	PolicyList struct {
 		Policies      []ISMPolicy `json:"policies"`

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -658,12 +658,12 @@ func TestGetWriteIndexForDataStreams(t *testing.T) {
 	openSearchEndpoint := "localhost:9090"
 	pattern := "verrazzano-system"
 	tests := []struct {
-		DoHttp             func(request *http.Request) (*http.Response, error)
+		DoHTTP             func(request *http.Request) (*http.Response, error)
 		expectErr          bool
 		expectedWriteIndex []string
 	}{
 		{
-			DoHttp: func(request *http.Request) (*http.Response, error) {
+			DoHTTP: func(request *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(dataStreamResponse)),
@@ -673,7 +673,7 @@ func TestGetWriteIndexForDataStreams(t *testing.T) {
 			expectedWriteIndex: []string{".ds-verrazzano-system-000002"},
 		},
 		{
-			DoHttp: func(request *http.Request) (*http.Response, error) {
+			DoHTTP: func(request *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusNotFound,
 					Body:       io.NopCloser(strings.NewReader("{reason: \"no such index [verrazzano-system]\"}")),
@@ -683,7 +683,7 @@ func TestGetWriteIndexForDataStreams(t *testing.T) {
 			expectedWriteIndex: nil,
 		},
 		{
-			DoHttp: func(request *http.Request) (*http.Response, error) {
+			DoHTTP: func(request *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusNotFound,
 					Body:       io.NopCloser(strings.NewReader("")),
@@ -696,7 +696,7 @@ func TestGetWriteIndexForDataStreams(t *testing.T) {
 	for _, tt := range tests {
 		o := &OSClient{
 			httpClient:        nil,
-			DoHTTP:            tt.DoHttp,
+			DoHTTP:            tt.DoHTTP,
 			statefulSetLister: nil,
 		}
 		writeIndex, err := o.getWriteIndexForDataStream(log, openSearchEndpoint, pattern)
@@ -719,12 +719,12 @@ func TestIsManagedByDefaultPolicy(t *testing.T) {
 	defaultPolicyName := "vz-system"
 	otherPolicyName := "other-policy"
 	tests := []struct {
-		DoHttp         func(request *http.Request) (*http.Response, error)
+		DoHTTP         func(request *http.Request) (*http.Response, error)
 		expectErr      bool
 		expectedResult bool
 	}{
 		{
-			DoHttp: func(request *http.Request) (*http.Response, error) {
+			DoHTTP: func(request *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(ismExplainResponse1)),
@@ -734,7 +734,7 @@ func TestIsManagedByDefaultPolicy(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			DoHttp: func(request *http.Request) (*http.Response, error) {
+			DoHTTP: func(request *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(ismExplainResponse2, defaultPolicyName, defaultPolicyName, defaultPolicyName))),
@@ -744,7 +744,7 @@ func TestIsManagedByDefaultPolicy(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			DoHttp: func(request *http.Request) (*http.Response, error) {
+			DoHTTP: func(request *http.Request) (*http.Response, error) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(ismExplainResponse2, otherPolicyName, otherPolicyName, otherPolicyName))),
@@ -757,7 +757,7 @@ func TestIsManagedByDefaultPolicy(t *testing.T) {
 	for _, tt := range tests {
 		o := &OSClient{
 			httpClient:        nil,
-			DoHTTP:            tt.DoHttp,
+			DoHTTP:            tt.DoHTTP,
 			statefulSetLister: nil,
 		}
 		ok, err := o.isManagedByDefaultPolicy(openSearchEndpoint, indexName, defaultPolicyName)

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -709,11 +709,11 @@ func TestGetWriteIndexForDataStreams(t *testing.T) {
 	}
 }
 
-// TestIsManagedByDefaultPolicy tests whether the index is being managed by the default policy or not
+// TestShouldAddOrRemoveDefaultPolicy tests whether we should add or remove policy from the index or not
 // GIVEN an index and policy name and OS client
-// WHEN I call isManagedByDefaultPolicy with an index and policy name
-// THEN a boolean is returned indicating whether the index is being managed by the default policy or not
-func TestIsManagedByDefaultPolicy(t *testing.T) {
+// WHEN I call shouldAddOrRemoveDefaultPolicy with an index and policy name
+// THEN a boolean is returned indicating whether we should add or remove policy from the index or not
+func TestShouldAddOrRemoveDefaultPolicy(t *testing.T) {
 	openSearchEndpoint := "localhost:9090"
 	indexName := ".ds-verrazzano-system-000001"
 	defaultPolicyName := "vz-system"
@@ -760,7 +760,7 @@ func TestIsManagedByDefaultPolicy(t *testing.T) {
 			DoHTTP:            tt.DoHTTP,
 			statefulSetLister: nil,
 		}
-		ok, err := o.isManagedByDefaultPolicy(openSearchEndpoint, indexName, defaultPolicyName)
+		ok, err := o.shouldAddOrRemoveDefaultPolicy(openSearchEndpoint, indexName, defaultPolicyName)
 		if tt.expectErr {
 			assert.Error(t, err)
 		} else {

--- a/pkg/opensearch/ism_test.go
+++ b/pkg/opensearch/ism_test.go
@@ -19,6 +19,7 @@ import (
 	v1 "k8s.io/client-go/listers/apps/v1"
 
 	vmcontrollerv1 "github.com/verrazzano/verrazzano-monitoring-operator/pkg/apis/vmcontroller/v1"
+	"github.com/verrazzano/verrazzano-monitoring-operator/pkg/util/logs/vzlog"
 )
 
 const (
@@ -76,6 +77,48 @@ const (
     }
 }
 `
+	dataStreamResponse = `{
+  "data_streams" : [
+    {
+      "name" : "verrazzano-system",
+      "timestamp_field" : {
+        "name" : "@timestamp"
+      },
+      "indices" : [
+        {
+          "index_name" : ".ds-verrazzano-system-000001",
+          "index_uuid" : "mcoToYr-TMKbcpHpuIhnCA"
+        },
+        {
+          "index_name" : ".ds-verrazzano-system-000002",
+          "index_uuid" : "N9CWCrVtTTWI7FgwqyrUVw"
+        }
+      ],
+      "generation" : 2,
+      "status" : "GREEN",
+      "template" : "verrazzano-data-stream"
+    }
+  ]
+}`
+	ismExplainResponse1 = `{
+  ".ds-verrazzano-system-000001" : {
+    "index.plugins.index_state_management.policy_id" : null,
+    "index.opendistro.index_state_management.policy_id" : null,
+    "enabled" : null
+  },
+  "total_managed_indices" : 0
+}`
+	ismExplainResponse2 = `{
+  ".ds-verrazzano-system-000001" : {
+    "index.plugins.index_state_management.policy_id" : "%s",
+    "index.opendistro.index_state_management.policy_id" : "%s",
+    "index" : ".ds-verrazzano-system-000001",
+    "index_uuid" : "ct0nKMwESQSaEV2eyIgAbA",
+    "policy_id" : "%s",
+    "enabled" : true
+  },
+  "total_managed_indices" : 1
+}`
 )
 
 var testPolicyList = fmt.Sprintf(`{
@@ -603,5 +646,126 @@ func TestUpdateISMPolicyFromFile(t *testing.T) {
 				t.Errorf("updateISMPolicyFromFile() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestGetWriteIndexForDataStreams tests whether the correct write index for a data stream is being returned or not
+// GIVEN a pattern and OS client
+// WHEN I call getWriteIndexForDataStream with pattern
+// THEN the correct write index should be returned
+func TestGetWriteIndexForDataStreams(t *testing.T) {
+	log := vzlog.DefaultLogger()
+	openSearchEndpoint := "localhost:9090"
+	pattern := "verrazzano-system"
+	tests := []struct {
+		DoHttp             func(request *http.Request) (*http.Response, error)
+		expectErr          bool
+		expectedWriteIndex []string
+	}{
+		{
+			DoHttp: func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(dataStreamResponse)),
+				}, nil
+			},
+			expectErr:          false,
+			expectedWriteIndex: []string{".ds-verrazzano-system-000002"},
+		},
+		{
+			DoHttp: func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader("{reason: \"no such index [verrazzano-system]\"}")),
+				}, nil
+			},
+			expectErr:          false,
+			expectedWriteIndex: nil,
+		},
+		{
+			DoHttp: func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader("")),
+				}, fmt.Errorf("no healthy upstream")
+			},
+			expectErr:          true,
+			expectedWriteIndex: nil,
+		},
+	}
+	for _, tt := range tests {
+		o := &OSClient{
+			httpClient:        nil,
+			DoHTTP:            tt.DoHttp,
+			statefulSetLister: nil,
+		}
+		writeIndex, err := o.getWriteIndexForDataStream(log, openSearchEndpoint, pattern)
+		if tt.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, writeIndex, tt.expectedWriteIndex)
+	}
+}
+
+// TestIsManagedByDefaultPolicy tests whether the index is being managed by the default policy or not
+// GIVEN an index and policy name and OS client
+// WHEN I call isManagedByDefaultPolicy with an index and policy name
+// THEN a boolean is returned indicating whether the index is being managed by the default policy or not
+func TestIsManagedByDefaultPolicy(t *testing.T) {
+	openSearchEndpoint := "localhost:9090"
+	indexName := ".ds-verrazzano-system-000001"
+	defaultPolicyName := "vz-system"
+	otherPolicyName := "other-policy"
+	tests := []struct {
+		DoHttp         func(request *http.Request) (*http.Response, error)
+		expectErr      bool
+		expectedResult bool
+	}{
+		{
+			DoHttp: func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(ismExplainResponse1)),
+				}, nil
+			},
+			expectErr:      false,
+			expectedResult: true,
+		},
+		{
+			DoHttp: func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(ismExplainResponse2, defaultPolicyName, defaultPolicyName, defaultPolicyName))),
+				}, nil
+			},
+			expectErr:      false,
+			expectedResult: true,
+		},
+		{
+			DoHttp: func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(ismExplainResponse2, otherPolicyName, otherPolicyName, otherPolicyName))),
+				}, nil
+			},
+			expectErr:      false,
+			expectedResult: false,
+		},
+	}
+	for _, tt := range tests {
+		o := &OSClient{
+			httpClient:        nil,
+			DoHTTP:            tt.DoHttp,
+			statefulSetLister: nil,
+		}
+		ok, err := o.isManagedByDefaultPolicy(openSearchEndpoint, indexName, defaultPolicyName)
+		if tt.expectErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, ok, tt.expectedResult)
 	}
 }

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -134,6 +134,9 @@ func (o *OSClient) DeleteDefaultISMPolicy(log vzlog.VerrazzanoLogger, vmi *vmcon
 				ch <- err
 			}
 			for _, index := range indices {
+				if !o.isManagedByDefaultPolicy(openSearchEndpoint, index, policyName) {
+					continue
+				}
 				err = o.removePolicyForIndex(openSearchEndpoint, index)
 				if err != nil {
 					ch <- err

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -134,12 +134,15 @@ func (o *OSClient) DeleteDefaultISMPolicy(log vzlog.VerrazzanoLogger, vmi *vmcon
 				ch <- err
 			}
 			for _, index := range indices {
-				if !o.isManagedByDefaultPolicy(openSearchEndpoint, index, policyName) {
-					continue
-				}
-				err = o.removePolicyForIndex(openSearchEndpoint, index)
+				ok, err := o.isManagedByDefaultPolicy(openSearchEndpoint, index, policyName)
 				if err != nil {
 					ch <- err
+				}
+				if ok {
+					err = o.removePolicyForIndex(openSearchEndpoint, index)
+					if err != nil {
+						ch <- err
+					}
 				}
 			}
 		}

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -134,7 +134,7 @@ func (o *OSClient) DeleteDefaultISMPolicy(log vzlog.VerrazzanoLogger, vmi *vmcon
 				ch <- err
 			}
 			for _, index := range indices {
-				ok, err := o.isManagedByDefaultPolicy(openSearchEndpoint, index, policyName)
+				ok, err := o.shouldAddOrRemoveDefaultPolicy(openSearchEndpoint, index, policyName)
 				if err != nil {
 					ch <- err
 				}

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -101,7 +101,7 @@ func (o *OSClient) ConfigureISM(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance
 }
 
 // DeleteDefaultISMPolicy deletes the default ISM policy if they exists
-func (o *OSClient) DeleteDefaultISMPolicy(vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) chan error {
+func (o *OSClient) DeleteDefaultISMPolicy(log vzlog.VerrazzanoLogger, vmi *vmcontrollerv1.VerrazzanoMonitoringInstance) chan error {
 	ch := make(chan error)
 	go func() {
 		// if Elasticsearch.DisableDefaultPolicy is set to false, skip the deletion.
@@ -121,6 +121,17 @@ func (o *OSClient) DeleteDefaultISMPolicy(vmi *vmcontrollerv1.VerrazzanoMonitori
 			// If policy doesn't exist, ignore the error, otherwise pass the error to channel.
 			if (err != nil && resp == nil) || (err != nil && resp != nil && resp.StatusCode != http.StatusNotFound) {
 				ch <- err
+			}
+			// Remove the policy from the current write indices of system and application data streams
+			var pattern string
+			if policyName == "vz-system" {
+				pattern = "verrazzano-system"
+			} else {
+				pattern = "verrazzano-application-*"
+			}
+			indices, err := o.getWriteIndexForDataStream(log, openSearchEndpoint, pattern)
+			for _, index := range indices {
+				err = o.removePolicyForIndex(openSearchEndpoint, index)
 			}
 		}
 		ch <- nil

--- a/pkg/opensearch/opensearch.go
+++ b/pkg/opensearch/opensearch.go
@@ -130,8 +130,14 @@ func (o *OSClient) DeleteDefaultISMPolicy(log vzlog.VerrazzanoLogger, vmi *vmcon
 				pattern = "verrazzano-application-*"
 			}
 			indices, err := o.getWriteIndexForDataStream(log, openSearchEndpoint, pattern)
+			if err != nil {
+				ch <- err
+			}
 			for _, index := range indices {
 				err = o.removePolicyForIndex(openSearchEndpoint, index)
+				if err != nil {
+					ch <- err
+				}
 			}
 		}
 		ch <- nil

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -571,7 +571,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	**********************/
 	specDiffs := diff.Diff(originalVMO, vmo)
 	if specDiffs != "" {
-		deleteISMChannel := c.osClient.DeleteDefaultISMPolicy(vmo)
+		deleteISMChannel := c.osClient.DeleteDefaultISMPolicy(c.log, vmo)
 		c.log.Debugf("Acquired lock in namespace: %s", vmo.Namespace)
 		c.log.Debugf("VMO %s : Spec differences %s", vmo.Name, specDiffs)
 		c.log.Oncef("Updating VMO")


### PR DESCRIPTION
Changes to default ISM policy:

- Removed cold state from ISM policies
- Transition to delete state, 14 days after rollover
- System and application ISM policy are now same

Other changes:

- When default ISM policy is enabled/created/updated, attach the policy to active write index of system and application data streams if it was previously being managed by our default policy or no policy at all
- When default ISM policy is disabled, remove the policy from active write index of data streams.