### PR TITLE
Fix multiple race conditions in unit tests

### DIFF
--- a/pkg/metricsexporter/metricsexporter_utils.go
+++ b/pkg/metricsexporter/metricsexporter_utils.go
@@ -47,8 +47,8 @@ func RequiredInitialization() {
 
 // RegisterMetrics begins the registration process, Required Initialization must be called first. This function does not start the metrics server
 func RegisterMetrics() {
-	MetricsExp.internalMetricsDelegate.InitializeAllMetricsArray()  // populate allMetrics array with all map values
-	go MetricsExp.internalMetricsDelegate.RegisterMetricsHandlers() // begin the retry process
+	MetricsExp.internalMetricsDelegate.InitializeAllMetricsArray()      // populate allMetrics array with all map values
+	go MetricsExp.internalMetricsDelegate.RegisterMetricsHandlers(true) // begin the retry process
 }
 
 func StartMetricsServer() {
@@ -89,11 +89,15 @@ func (md *metricsDelegate) InitializeAllMetricsArray() {
 }
 
 // RegisterMetricsHandlers loops through the failedMetrics map until all metrics are registered successfully
-func (md *metricsDelegate) RegisterMetricsHandlers() {
+func (md *metricsDelegate) RegisterMetricsHandlers(forever bool) {
 	md.initializeFailedMetricsArray() // Get list of metrics to register initially
 	// loop until there is no error in registering
 	for err := md.registerMetricsHandlersHelper(); err != nil; err = md.registerMetricsHandlersHelper() {
 		zap.S().Errorf("Failed to register metrics for VMO %v \n", err)
+		// forever may be false for unit testing
+		if !forever {
+			break
+		}
 		time.Sleep(time.Second)
 	}
 }

--- a/pkg/vmo/metricsexporter_test.go
+++ b/pkg/vmo/metricsexporter_test.go
@@ -33,8 +33,6 @@ import (
 
 type registerTest struct {
 	name               string
-	isConcurrent       bool
-	waitTime           time.Duration
 	allMetricsLength   int
 	failedMetricLength int
 	allMetrics         []prometheus.Collector
@@ -65,57 +63,46 @@ func TestRegistrationSystem(t *testing.T) {
 	testCases := []registerTest{
 		{
 			name:               "TestNoMetrics",
-			isConcurrent:       false,
 			allMetrics:         []prometheus.Collector{},
 			allMetricsLength:   0,
 			failedMetricLength: 0,
-			waitTime:           0 * time.Second,
 		},
 		{
-			name:         "TestOneValidMetric",
-			isConcurrent: false,
+			name: "TestOneValidMetric",
 			allMetrics: []prometheus.Collector{
 				prometheus.NewCounter(prometheus.CounterOpts{Name: "testOneValidMetric_A", Help: "This is the first valid metric"}),
 			},
 			allMetricsLength:   1,
 			failedMetricLength: 0,
-			waitTime:           0 * time.Second,
 		},
 		{
-			name:         "TestOneInvalidMetric",
-			isConcurrent: true,
+			name: "TestOneInvalidMetric",
 			allMetrics: []prometheus.Collector{
 				prometheus.NewCounter(prometheus.CounterOpts{Help: "This is the first invalid metric"}),
 			},
 			allMetricsLength:   1,
 			failedMetricLength: 1,
-			waitTime:           1 * time.Second,
 		},
 		{
-			name:         "TestTwoValidMetrics",
-			isConcurrent: false,
+			name: "TestTwoValidMetrics",
 			allMetrics: []prometheus.Collector{
 				prometheus.NewCounter(prometheus.CounterOpts{Name: "TestTwoValidMetrics_A", Help: "This is the first valid metric"}),
 				prometheus.NewCounter(prometheus.CounterOpts{Name: "TestTwoValidMetrics_B", Help: "This is the second valid metric"}),
 			},
 			allMetricsLength:   2,
 			failedMetricLength: 0,
-			waitTime:           0 * time.Second,
 		},
 		{
-			name:         "TestTwoInvalidMetrics",
-			isConcurrent: true,
+			name: "TestTwoInvalidMetrics",
 			allMetrics: []prometheus.Collector{
 				prometheus.NewCounter(prometheus.CounterOpts{Help: "This is the first invalid metric"}),
 				prometheus.NewCounter(prometheus.CounterOpts{Help: "This is the second invalid metric"}),
 			},
 			allMetricsLength:   2,
 			failedMetricLength: 2,
-			waitTime:           1 * time.Second,
 		},
 		{
-			name:         "TestThreeValidMetrics",
-			isConcurrent: false,
+			name: "TestThreeValidMetrics",
 			allMetrics: []prometheus.Collector{
 				prometheus.NewCounter(prometheus.CounterOpts{Name: "TestThreeValidMetrics_A", Help: "This is the first valid metric"}),
 				prometheus.NewCounter(prometheus.CounterOpts{Name: "TestThreeValidMetrics_B", Help: "This is the second valid metric"}),
@@ -123,11 +110,9 @@ func TestRegistrationSystem(t *testing.T) {
 			},
 			allMetricsLength:   3,
 			failedMetricLength: 0,
-			waitTime:           0 * time.Second,
 		},
 		{
-			name:         "TestThreeInvalidMetrics",
-			isConcurrent: true,
+			name: "TestThreeInvalidMetrics",
 			allMetrics: []prometheus.Collector{
 				prometheus.NewCounter(prometheus.CounterOpts{Help: "This is the first invalid metric"}),
 				prometheus.NewCounter(prometheus.CounterOpts{Help: "This is the second invalid metric"}),
@@ -135,7 +120,6 @@ func TestRegistrationSystem(t *testing.T) {
 			},
 			allMetricsLength:   3,
 			failedMetricLength: 3,
-			waitTime:           1 * time.Second,
 		},
 	}
 
@@ -144,14 +128,9 @@ func TestRegistrationSystem(t *testing.T) {
 			clearMetrics()
 			assert := assert.New(t)
 			*allMetrics = testCase.allMetrics
-			if !testCase.isConcurrent {
-				metricsexporter.TestDelegate.RegisterMetricsHandlers()
-			} else {
-				go metricsexporter.TestDelegate.RegisterMetricsHandlers()
-				time.Sleep(testCase.waitTime)
-			}
+			metricsexporter.TestDelegate.RegisterMetricsHandlers(false)
 			assert.Equal(testCase.allMetricsLength, len(*allMetrics), "allMetrics array length is not correct")
-			assert.Equal(testCase.failedMetricLength, len(delegate.GetFailedMetricsMap()), "failedMetrics map lenght is not correct")
+			assert.Equal(testCase.failedMetricLength, len(delegate.GetFailedMetricsMap()), "failedMetrics map length is not correct")
 		})
 	}
 }


### PR DESCRIPTION
There are at least two race conditions in the metricsexporter unit tests, due to running the metrics handler in a go routine. I started by using channels to coordinate access to the metrics map but it quickly became complicated, so I added a flag to allow the handler to exit after one iteration. That removes the need for a go routine in the unit tests and removes all of the race conditions.