### PR TITLE
Add checks for OpenSearch enabled

### DIFF
--- a/pkg/opensearch/health.go
+++ b/pkg/opensearch/health.go
@@ -37,7 +37,7 @@ func (o *OSClient) opensearchHealth(vmo *vmcontrollerv1.VerrazzanoMonitoringInst
 	// If OpenSearch is not enabled in the VMI Spec
 	// Return no error meaning OS is healthy
 	// This is to allow uninstalling the OS cluster
-	if vmo.Spec.Opensearch.Enabled != true {
+	if !vmo.Spec.Opensearch.Enabled {
 		return nil
 	}
 	// Verify that the cluster is Green

--- a/pkg/opensearch/health.go
+++ b/pkg/opensearch/health.go
@@ -34,6 +34,12 @@ const (
 )
 
 func (o *OSClient) opensearchHealth(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, checkNodeCount bool, waitForVersion bool) error {
+	// If OpenSearch is not enabled in the VMI Spec
+	// Return no error meaning OS is healthy
+	// This is to allow uninstalling the OS cluster
+	if vmo.Spec.Opensearch.Enabled != true {
+		return nil
+	}
 	// Verify that the cluster is Green
 	clusterHealth, err := o.getOpenSearchClusterHealth(vmo)
 	if err != nil {

--- a/pkg/opensearch/health_test.go
+++ b/pkg/opensearch/health_test.go
@@ -121,6 +121,7 @@ var testvmo = vmcontrollerv1.VerrazzanoMonitoringInstance{
 	},
 	Spec: vmcontrollerv1.VerrazzanoMonitoringInstanceSpec{
 		Opensearch: vmcontrollerv1.Opensearch{
+			Enabled: true,
 			DataNode: vmcontrollerv1.ElasticsearchNode{
 				Replicas: 3,
 			},

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -21,7 +21,7 @@ type Monitor struct {
 
 func (m *Monitor) MigrateOldIndices(log vzlog.VerrazzanoLogger, vmi *vmcontrollerv1.VerrazzanoMonitoringInstance,
 	o *opensearch.OSClient, od *dashboards.OSDashboardsClient) error {
-	if !o.IsOpenSearchReady(vmi) {
+	if vmi.Spec.Opensearch.Enabled || !o.IsOpenSearchReady(vmi) {
 		return nil
 	}
 

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -21,7 +21,7 @@ type Monitor struct {
 
 func (m *Monitor) MigrateOldIndices(log vzlog.VerrazzanoLogger, vmi *vmcontrollerv1.VerrazzanoMonitoringInstance,
 	o *opensearch.OSClient, od *dashboards.OSDashboardsClient) error {
-	if vmi.Spec.Opensearch.Enabled || !o.IsOpenSearchReady(vmi) {
+	if !vmi.Spec.Opensearch.Enabled || !o.IsOpenSearchReady(vmi) {
 		return nil
 	}
 

--- a/pkg/vmo/controller.go
+++ b/pkg/vmo/controller.go
@@ -612,7 +612,7 @@ func (c *Controller) syncHandlerStandardMode(vmo *vmcontrollerv1.VerrazzanoMonit
 	/*********************
 	* Add default index patterns
 	**********************/
-	if vmo.Spec.OpensearchDashboards.Enabled {
+	if vmo.Spec.OpensearchDashboards.Enabled && vmo.Spec.Opensearch.Enabled {
 		err = c.osDashboardsClient.CreateDefaultIndexPatterns(c.log, resources.GetOpenSearchDashboardsHTTPEndpoint(vmo))
 		if err != nil {
 			c.log.ErrorfThrottled("Failed to add default index patterns : %v", err)


### PR DESCRIPTION
Added a few checks on whether opensearch is enabled or not in the VMI. This is to allow deleting the OS when set as disabled in the VMI.