### PR TITLE
VZ-10300 1.6 backport of make the default grafana user role Viewer (#367)

### DIFF
--- a/pkg/resources/deployments/deployment.go
+++ b/pkg/resources/deployments/deployment.go
@@ -106,7 +106,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, kubeclientset kuberne
 				{Name: "GF_AUTH_BASIC_ENABLED", Value: "true"},
 				{Name: "GF_USERS_ALLOW_SIGN_UP", Value: "false"},
 				{Name: "GF_USERS_AUTO_ASSIGN_ORG", Value: "true"},
-				{Name: "GF_USERS_AUTO_ASSIGN_ORG_ROLE", Value: "Editor"},
+				{Name: "GF_USERS_AUTO_ASSIGN_ORG_ROLE", Value: "Viewer"},
 				{Name: "GF_AUTH_DISABLE_LOGIN_FORM", Value: "false"},
 				{Name: "GF_AUTH_DISABLE_SIGNOUT_MENU", Value: "false"},
 			}...)
@@ -138,7 +138,7 @@ func New(vmo *vmcontrollerv1.VerrazzanoMonitoringInstance, kubeclientset kuberne
 				{Name: "GF_AUTH_BASIC_ENABLED", Value: "false"},
 				{Name: "GF_USERS_ALLOW_SIGN_UP", Value: "false"},
 				{Name: "GF_USERS_AUTO_ASSIGN_ORG", Value: "true"},
-				{Name: "GF_USERS_AUTO_ASSIGN_ORG_ROLE", Value: "Editor"},
+				{Name: "GF_USERS_AUTO_ASSIGN_ORG_ROLE", Value: "Viewer"},
 				{Name: "GF_AUTH_DISABLE_LOGIN_FORM", Value: "true"},
 				{Name: "GF_AUTH_DISABLE_SIGNOUT_MENU", Value: "true"},
 				{Name: "GF_AUTH_PROXY_ENABLED", Value: "true"},

--- a/pkg/resources/deployments/deployment_test.go
+++ b/pkg/resources/deployments/deployment_test.go
@@ -364,15 +364,16 @@ func TestGrafanaSMTPConfig(t *testing.T) {
 	}
 
 	expectedEnvVars := map[string]string{
-		"GF_SMTP_ENABLED":         fmt.Sprintf("%v", trueValue),
-		"GF_SMTP_HOST":            vmi.Spec.Grafana.SMTP.Host,
-		"GF_SMTP_CERT_FILE":       fmt.Sprintf("%s/%s", constants.GrafanaSMTPConfigVolumePath, vmi.Spec.Grafana.SMTP.CertFileKey),
-		"GF_SMTP_KEY_FILE":        fmt.Sprintf("%s/%s", constants.GrafanaSMTPConfigVolumePath, vmi.Spec.Grafana.SMTP.KeyFileKey),
-		"GF_SMTP_SKIP_VERIFY":     fmt.Sprintf("%v", trueValue),
-		"GF_SMTP_FROM_ADDRESS":    vmi.Spec.Grafana.SMTP.FromAddress,
-		"GF_SMTP_FROM_NAME":       vmi.Spec.Grafana.SMTP.FromName,
-		"GF_SMTP_EHLO_IDENTITY":   vmi.Spec.Grafana.SMTP.EHLOIdentity,
-		"GF_SMTP_STARTTLS_POLICY": string(vmi.Spec.Grafana.SMTP.StartTLSPolicy),
+		"GF_SMTP_ENABLED":               fmt.Sprintf("%v", trueValue),
+		"GF_SMTP_HOST":                  vmi.Spec.Grafana.SMTP.Host,
+		"GF_SMTP_CERT_FILE":             fmt.Sprintf("%s/%s", constants.GrafanaSMTPConfigVolumePath, vmi.Spec.Grafana.SMTP.CertFileKey),
+		"GF_SMTP_KEY_FILE":              fmt.Sprintf("%s/%s", constants.GrafanaSMTPConfigVolumePath, vmi.Spec.Grafana.SMTP.KeyFileKey),
+		"GF_SMTP_SKIP_VERIFY":           fmt.Sprintf("%v", trueValue),
+		"GF_SMTP_FROM_ADDRESS":          vmi.Spec.Grafana.SMTP.FromAddress,
+		"GF_SMTP_FROM_NAME":             vmi.Spec.Grafana.SMTP.FromName,
+		"GF_SMTP_EHLO_IDENTITY":         vmi.Spec.Grafana.SMTP.EHLOIdentity,
+		"GF_SMTP_STARTTLS_POLICY":       string(vmi.Spec.Grafana.SMTP.StartTLSPolicy),
+		"GF_USERS_AUTO_ASSIGN_ORG_ROLE": "Viewer",
 	}
 	for _, deployment := range expected.Deployments {
 		if deployment.Name == resources.GetMetaName(vmi.Name, config.Grafana.Name) {
@@ -391,6 +392,7 @@ func TestGrafanaSMTPConfig(t *testing.T) {
 					assert.NotNil(t, env.ValueFrom)
 					assert.Equal(t, vmi.Spec.Grafana.SMTP.PasswordKey, env.ValueFrom.SecretKeyRef.Key)
 				}
+
 			}
 			assert.Len(t, expectedEnvVars, 0, fmt.Sprintf("Could not find %v env variables set in Grafana deployment", expectedEnvVars))
 


### PR DESCRIPTION
(cherry picked from commit c39455fddafff25a2c12ef4bf9d6508385029d0e)