### PR TITLE
VZ-10471: Modify the logic to fetch storageclass for resize

### DIFF
--- a/pkg/vmo/pvc.go
+++ b/pkg/vmo/pvc.go
@@ -69,7 +69,12 @@ func CreatePersistentVolumeClaims(controller *Controller, vmo *vmcontrollerv1.Ve
 		// If the PVC already exists, we check if it needs resizing
 		if existingPvc != nil {
 			if pvcNeedsResize(existingPvc, expectedPVC) {
-				if newPVCName, err := resizePVC(controller, vmo, existingPvc, expectedPVC, storageClass); err != nil {
+				// Fetch the storage class from the pvc
+				existingStorageClass, err := determineStorageClass(controller, existingPvc.Spec.StorageClassName)
+				if err != nil {
+					return nil, err
+				}
+				if newPVCName, err := resizePVC(controller, vmo, existingPvc, expectedPVC, existingStorageClass); err != nil {
 					return nil, err
 				} else if newPVCName != nil {
 					// we need to wait until the PVC is bound


### PR DESCRIPTION
VMO is using the default storage class unless specified with spec.StorageClass. We don't expose this in VZ, so changing the default storage class results in this unexpected behavior when resizing data nodes - since the default storage class is no longer aligned with the storage class used in the existing PVC.
This PR fixes the logic so the PVC storage class is used when determining the resize strategy