### PR TITLE
VZ-11454: Use ol8-static as the final base image

### DIFF
--- a/docker-images/verrazzano-monitoring-operator/Dockerfile
+++ b/docker-images/verrazzano-monitoring-operator/Dockerfile
@@ -1,5 +1,7 @@
 # Copyright (C) 2020, 2023, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+ARG FINAL_IMAGE=ghcr.io/verrazzano/ol8-static:v0.0.1-20231102152128-e7afc807
+
 FROM ghcr.io/oracle/oraclelinux:7-slim AS build_base
 
 RUN yum update -y \
@@ -25,14 +27,14 @@ RUN go build \
     -o /usr/bin/verrazzano-monitoring-operator ./cmd/verrazzano-monitoring-ctrl \
     && chmod 500 /usr/bin/verrazzano-monitoring-operator
 
+RUN groupadd -r verrazzano-monitoring-operator && \
+    useradd --no-log-init -r -g verrazzano-monitoring-operator -u 1000 verrazzano-monitoring-operator
 
-FROM ghcr.io/oracle/oraclelinux:8-slim AS final
+FROM $FINAL_IMAGE AS final
 
-RUN microdnf update -y \
-    && microdnf clean all \
-    && rm -rf /var/cache/yum /var/lib/rpm/__db.* \
-    && groupadd -r verrazzano-monitoring-operator \
-    && useradd --no-log-init -r -g verrazzano-monitoring-operator -u 1000 verrazzano-monitoring-operator
+# copy users/groups added in build_base stage
+COPY --from=build_base /etc/passwd /etc/passwd
+COPY --from=build_base /etc/group /etc/group
 
 COPY --from=build_base --chown=verrazzano-monitoring-operator:verrazzano-monitoring-operator /usr/bin/verrazzano-monitoring-operator /usr/local/bin/verrazzano-monitoring-operator
 USER 1000


### PR DESCRIPTION
This PR converts the VMO Dockerfile to use the ol8-static distroless image as the final image.